### PR TITLE
Display size changes for binary files

### DIFF
--- a/Classes/Controllers/PBWebHistoryController.m
+++ b/Classes/Controllers/PBWebHistoryController.m
@@ -90,6 +90,18 @@ static NSString *deltaTypeName(GTDiffDeltaType t) {
 
 static NSDictionary *loadCommitSummary(GTRepository *repo, GTCommit *commit, BOOL (^isCanceled)());
 
+// A GTDiffDelta's GTDiffFile does not always set the file size. See `git_diff_get_delta`.
+static NSUInteger reallyGetFileSize(GTRepository *repo, GTDiffFile *file) {
+	GTObjectDatabase *odb = [repo objectDatabaseWithError:nil];
+	if (!odb) return 0;
+	size_t size = 0;
+	git_otype otype;
+	if (git_odb_read_header(&size, &otype, odb.git_odb, file.OID.git_oid) != 0) {
+		return 0;
+	}
+	return size;
+}
+
 - (void) changeContentToCommit:(PBGitCommit *)commit
 {
 	// The sha is the same, but refs may have changed. reload it lazy
@@ -196,14 +208,28 @@ static NSDictionary *loadCommitSummary(GTRepository *repo, GTCommit *commit, BOO
 					[fullDiff appendString:patchString];
 				}
 			}
+			// Use the patch's delta as it may have loaded more file sizes.
+			delta = patch.delta;
 		} else {
 			NSLog(@"generatePatch error: %@", err);
 		}
+		GTDiffFile *oldFile = delta.oldFile;
+		GTDiffFile *newFile = delta.newFile;
+		NSUInteger oldFileSize = oldFile.size;
+		NSUInteger newFileSize = newFile.size;
+		if (oldFileSize == 0 && (oldFile.flags & GIT_DIFF_FLAG_EXISTS)) {
+			oldFileSize = reallyGetFileSize(repo, newFile);
+		}
+		if (newFileSize == 0 && (newFile.flags & GIT_DIFF_FLAG_EXISTS)) {
+			newFileSize = reallyGetFileSize(repo, newFile);
+		}
 		[fileDeltas addObject:@{
-			@"filename" : delta.newFile.path,
-			@"oldFilename" : delta.oldFile.path,
-			@"newFilename" : delta.newFile.path,
+			@"filename" : newFile.path,
+			@"oldFilename" : oldFile.path,
+			@"newFilename" : newFile.path,
 			@"changeType" : deltaTypeName(delta.type),
+			@"oldFileSize" : @(oldFileSize),
+			@"newFileSize" : @(newFileSize),
 			@"numLinesAdded" : @(numLinesAdded),
 			@"numLinesRemoved" : @(numLinesRemoved),
 			@"binary" :

--- a/html/views/history/history.css
+++ b/html/views/history/history.css
@@ -256,8 +256,6 @@ a {
 #files .diffstat-numbers.binary {
 	display: inline-block;
 	right: 30px;
-	-webkit-border-radius: 12px;
-	background-color: #a7681f;
 }
 
 /*

--- a/html/views/history/history.js
+++ b/html/views/history/history.js
@@ -347,6 +347,8 @@ var loadCommitDiff = function(jsonData)
 			if (fileInfo.binary) {
 				// remove the diffstat-info element
 				diffstatElem.parentNode.removeChild(diffstatElem);
+				binaryElem.innerText =
+				    fileInfo.oldFileSize + " \u2192 " + fileInfo.newFileSize + " bytes";
 			}
 			else {
 				// remove the binary element


### PR DESCRIPTION
Before:
![screen shot 2016-12-10 at 7 34 20 pm](https://cloud.githubusercontent.com/assets/34699/21077401/e1fa191c-bf0f-11e6-9e0a-f81f1f2d2acc.png)

After:
![screen shot 2016-12-10 at 7 33 46 pm](https://cloud.githubusercontent.com/assets/34699/21077402/f2eb3882-bf0f-11e6-9f23-0aa62b7221a2.png)

It would be nice to show a bar graphic like text diffs, but that can be in another PR.