### PR TITLE
Work around Interface Builder ignoring smart quote and dash settings

### DIFF
--- a/Classes/Views/PBCommitMessageView.m
+++ b/Classes/Views/PBCommitMessageView.m
@@ -31,6 +31,10 @@
                forKeyPath:@"PBCommitMessageViewVerticalBodyLineLength"
                   options:NSKeyValueObservingOptionNew
                   context:NULL];
+
+	// IB seems to ignore these properties when set there since 10.9
+	self.automaticDashSubstitutionEnabled = NO;
+	self.automaticQuoteSubstitutionEnabled = NO;
 }
 
 -(void) observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context


### PR DESCRIPTION
These are currently disabled in the XIB, but [Interface Builder apparently doesn't respect the settings since 10.9](https://stackoverflow.com/questions/19801601/nstextview-with-smart-quotes-disabled-still-replaces-quotes).