### PR TITLE
Show application as gitx/gitx in About page

### DIFF
--- a/Classes/Controllers/ApplicationController.m
+++ b/Classes/Controllers/ApplicationController.m
@@ -142,10 +142,10 @@ static OpenRecentController* recentsDialog = nil;
 		[dict addEntriesFromDictionary:[[NSDictionary alloc] initWithObjectsAndKeys:gitversion, @"Version", nil]];
 
 	#ifdef DEBUG_BUILD
-		[dict addEntriesFromDictionary:[[NSDictionary alloc] initWithObjectsAndKeys:@"GitX-dev (DEBUG)", @"ApplicationName", nil]];
+		[dict addEntriesFromDictionary:[[NSDictionary alloc] initWithObjectsAndKeys:@"gitx/GitX (DEBUG)", @"ApplicationName", nil]];
 	#endif
 
-	[dict addEntriesFromDictionary:[[NSDictionary alloc] initWithObjectsAndKeys:@"GitX-dev (rowanj fork)", @"ApplicationName", nil]];
+	[dict addEntriesFromDictionary:[[NSDictionary alloc] initWithObjectsAndKeys:@"gitx/GitX", @"ApplicationName", nil]];
 
 	[NSApp orderFrontStandardAboutPanelWithOptions:dict];
 }

--- a/Resources/Credits.html
+++ b/Resources/Credits.html
@@ -7,5 +7,5 @@ p {
 </style>
 <p>By developers, for developers.</p>
 <p style="margin: 0px; padding: 0px">
-  <a href="https://rowanj.github.io/gitx/">https://rowanj.github.io/gitx/</a>
+  <a href="https://github.com/gitx/gitx">https://github.com/gitx/gitx</a>
 </p>


### PR DESCRIPTION
OK, I wrote in #4 that I wouldn't contribute to the code... but just one quick thing again to help know what's what when building and running this fork: update the "About" page to name the project "gitx/GitX" and point to https://github.com/gitx/gitx.

With that, I can tell that I'm successfully running this project rather than the rowanj version I previously had installed.

Again feeling presumptuous to choose the naming for a project I don't expect to be contributing to -- feel free of course to put something else in there!

Cheers



