### PR TITLE
Remember text substitution preferences

### DIFF
--- a/Classes/Views/GitXTextView.h
+++ b/Classes/Views/GitXTextView.h
@@ -1,0 +1,12 @@
+//
+//  GitXTextView.h
+//  GitX
+//
+//  Created by NanoTech on 2016-12-14.
+//
+
+#import <Cocoa/Cocoa.h>
+
+/** A text view that remembers text substitution preferences. */
+@interface GitXTextView : NSTextView
+@end

--- a/Classes/Views/GitXTextView.m
+++ b/Classes/Views/GitXTextView.m
@@ -1,0 +1,92 @@
+//
+//  GitXTextView.m
+//  GitX
+//
+//  Created by NanoTech on 2016-12-14.
+//
+
+#import "GitXTextView.h"
+
+static NSString *AutomaticDashSubstitutionEnabledKey = @"GitXTextViewAutomaticDashSubstitutionEnabled";
+static NSString *AutomaticDataDetectionEnabledKey = @"GitXTextViewAutomaticDataDetectionEnabled";
+static NSString *AutomaticLinkDetectionEnabledKey = @"GitXTextViewAutomaticLinkDetectionEnabled";
+static NSString *AutomaticQuoteSubstitutionEnabled = @"GitXTextViewAutomaticQuoteSubstitutionEnabled";
+static NSString *AutomaticSpellingCorrectionEnabledKey = @"GitXTextViewAutomaticSpellingCorrectionEnabled";
+static NSString *AutomaticTextReplacementEnabledKey = @"GitXTextViewAutomaticTextReplacementEnabled";
+static NSString *SmartInsertDeleteEnabledKey = @"GitXTextViewSmartInsertDeleteEnabled"; // "Smart Copy/Paste"
+
+@implementation GitXTextView
+
++ (void)initialize
+{
+	if (self != [GitXTextView class]) return;
+
+	// Matches the commit message text view properties in PBGitCommitView.xib
+	[[NSUserDefaults standardUserDefaults] registerDefaults:@{
+		AutomaticDashSubstitutionEnabledKey : @(NO),
+		AutomaticDataDetectionEnabledKey : @(NO),
+		AutomaticLinkDetectionEnabledKey : @(YES),
+		AutomaticQuoteSubstitutionEnabled : @(NO),
+		AutomaticSpellingCorrectionEnabledKey : @(NO),
+		AutomaticTextReplacementEnabledKey : @(NO),
+		SmartInsertDeleteEnabledKey : @(YES),
+	}];
+}
+
+- (void)awakeFromNib
+{
+	[super awakeFromNib];
+
+	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+	super.automaticDashSubstitutionEnabled = [defaults boolForKey:AutomaticDashSubstitutionEnabledKey];
+	super.automaticDataDetectionEnabled = [defaults boolForKey:AutomaticDataDetectionEnabledKey];
+	super.automaticLinkDetectionEnabled = [defaults boolForKey:AutomaticLinkDetectionEnabledKey];
+	super.automaticQuoteSubstitutionEnabled = [defaults boolForKey:AutomaticQuoteSubstitutionEnabled];
+	super.automaticSpellingCorrectionEnabled = [defaults boolForKey:AutomaticSpellingCorrectionEnabledKey];
+	super.automaticTextReplacementEnabled = [defaults boolForKey:AutomaticTextReplacementEnabledKey];
+	super.smartInsertDeleteEnabled = [defaults boolForKey:SmartInsertDeleteEnabledKey];
+}
+
+- (void)setAutomaticDashSubstitutionEnabled:(BOOL)enabled
+{
+	[[NSUserDefaults standardUserDefaults] setBool:enabled forKey:AutomaticDashSubstitutionEnabledKey];
+	[super setAutomaticDashSubstitutionEnabled:enabled];
+}
+
+- (void)setAutomaticDataDetectionEnabled:(BOOL)enabled
+{
+	[[NSUserDefaults standardUserDefaults] setBool:enabled forKey:AutomaticDataDetectionEnabledKey];
+	[super setAutomaticDataDetectionEnabled:enabled];
+}
+
+- (void)setAutomaticLinkDetectionEnabled:(BOOL)enabled
+{
+	[[NSUserDefaults standardUserDefaults] setBool:enabled forKey:AutomaticLinkDetectionEnabledKey];
+	[super setAutomaticLinkDetectionEnabled:enabled];
+}
+
+- (void)setAutomaticQuoteSubstitutionEnabled:(BOOL)enabled
+{
+	[[NSUserDefaults standardUserDefaults] setBool:enabled forKey:AutomaticQuoteSubstitutionEnabled];
+	[super setAutomaticQuoteSubstitutionEnabled:enabled];
+}
+
+- (void)setAutomaticSpellingCorrectionEnabled:(BOOL)enabled
+{
+	[[NSUserDefaults standardUserDefaults] setBool:enabled forKey:AutomaticSpellingCorrectionEnabledKey];
+	[super setAutomaticSpellingCorrectionEnabled:enabled];
+}
+
+- (void)setAutomaticTextReplacementEnabled:(BOOL)enabled
+{
+	[[NSUserDefaults standardUserDefaults] setBool:enabled forKey:AutomaticTextReplacementEnabledKey];
+	[super setAutomaticTextReplacementEnabled:enabled];
+}
+
+- (void)setSmartInsertDeleteEnabled:(BOOL)enabled
+{
+	[[NSUserDefaults standardUserDefaults] setBool:enabled forKey:SmartInsertDeleteEnabledKey];
+	[super setSmartInsertDeleteEnabled:enabled];
+}
+
+@end

--- a/Classes/Views/PBCommitMessageView.h
+++ b/Classes/Views/PBCommitMessageView.h
@@ -6,11 +6,11 @@
 //  Copyright 2008 Jeff Mesnil (http://jmesnil.net/). All rights reserved.
 //
 
-#import <Cocoa/Cocoa.h>
+#import "GitXTextView.h"
 
 @class PBGitRepository;
 
-@interface PBCommitMessageView : NSTextView
+@interface PBCommitMessageView : GitXTextView
 
 @property (nonatomic, strong) PBGitRepository *repository;
 

--- a/Classes/Views/PBCommitMessageView.m
+++ b/Classes/Views/PBCommitMessageView.m
@@ -15,6 +15,8 @@
 
 - (void) awakeFromNib
 {
+    [super awakeFromNib];
+
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
     [defaults addObserver:self

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		97CF01FB18A6C5BB00E30F2B /* new_file.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 97CF01F818A6C5BB00E30F2B /* new_file.pdf */; };
 		A2F8D0DF17AAB32500580B84 /* PBGitStash.m in Sources */ = {isa = PBXBuildFile; fileRef = A2F8D0DE17AAB32500580B84 /* PBGitStash.m */; };
 		A2F8D0EB17AAB95E00580B84 /* PBGitSVStashItem.m in Sources */ = {isa = PBXBuildFile; fileRef = A2F8D0EA17AAB95E00580B84 /* PBGitSVStashItem.m */; };
+		BF42F1331E025403004769FF /* GitXTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = BF42F1321E025403004769FF /* GitXTextView.m */; };
 		D87127011229A21C00012334 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D87127001229A21C00012334 /* QuartzCore.framework */; };
 		D89E9B141218BA260097A90B /* ScriptingBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D89E9AB21218A9DA0097A90B /* ScriptingBridge.framework */; };
 		D8E3B2B810DC9FB2001096A3 /* ScriptingBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8E3B2B710DC9FB2001096A3 /* ScriptingBridge.framework */; };
@@ -614,6 +615,8 @@
 		A2F8D0DE17AAB32500580B84 /* PBGitStash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBGitStash.m; sourceTree = "<group>"; };
 		A2F8D0E917AAB95E00580B84 /* PBGitSVStashItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBGitSVStashItem.h; sourceTree = "<group>"; };
 		A2F8D0EA17AAB95E00580B84 /* PBGitSVStashItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBGitSVStashItem.m; sourceTree = "<group>"; };
+		BF42F1321E025403004769FF /* GitXTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXTextView.m; sourceTree = "<group>"; };
+		BF42F1431E025411004769FF /* GitXTextView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GitXTextView.h; sourceTree = "<group>"; };
 		D87127001229A21C00012334 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		D89E9AB21218A9DA0097A90B /* ScriptingBridge.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ScriptingBridge.framework; path = System/Library/Frameworks/ScriptingBridge.framework; sourceTree = SDKROOT; };
 		D8E3B2B710DC9FB2001096A3 /* ScriptingBridge.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ScriptingBridge.framework; path = /System/Library/Frameworks/ScriptingBridge.framework; sourceTree = "<absolute>"; };
@@ -1002,6 +1005,8 @@
 			children = (
 				4A5D76B414A9A9CC00DF6C68 /* GitXTextFieldCell.h */,
 				4A5D76B514A9A9CC00DF6C68 /* GitXTextFieldCell.m */,
+				BF42F1431E025411004769FF /* GitXTextView.h */,
+				BF42F1321E025403004769FF /* GitXTextView.m */,
 				4A5D76B614A9A9CC00DF6C68 /* GLFileView.h */,
 				4A5D76B714A9A9CC00DF6C68 /* GLFileView.m */,
 				4A5D76B814A9A9CC00DF6C68 /* PBAddRemoteSheet.h */,
@@ -1476,6 +1481,7 @@
 				4A5D773914A9A9CC00DF6C68 /* PBSourceViewItem.m in Sources */,
 				4A5D777314A9AEB000DF6C68 /* PBSourceViewAction.m in Sources */,
 				4A5D777414A9AEB000DF6C68 /* PBSourceViewBadge.m in Sources */,
+				BF42F1331E025403004769FF /* GitXTextView.m in Sources */,
 				4A5D777514A9AEB000DF6C68 /* PBSourceViewRemote.m in Sources */,
 				4AB71FF814B7EDD400F1DFFC /* RJModalRepoSheet.m in Sources */,
 				643952771603EF9B00BB7AFF /* PBGitSVSubmoduleItem.m in Sources */,


### PR DESCRIPTION
Supersedes #3.

- This only affects the commit message text view, and not the search field.
- Spelling and grammar check (underlining only) settings appear to be already persisted automatically.
- The smart quotes quote type selected in the Show Substitutions window is not persisted as I don't see an API to access it. This probably doesn't matter.
- `PBGitDefaults` exists for handling preferences, but I think this is cleaner self-contained. Properties can be moved over later if needed.
- Lots of boilerplate, but I think everything matches up. An X macro might be nice here, but then we're using an X macro.