### PR TITLE
Fix unstaging new files

### DIFF
--- a/Classes/git/PBGitIndex.m
+++ b/Classes/git/PBGitIndex.m
@@ -404,7 +404,7 @@ NS_ENUM(NSUInteger, PBGitIndexOperation) {
 				NSString *indexInfo;
 				if (file.status == NEW) {
 					// Index info lies because the file is NEW
-					indexInfo = [NSString stringWithFormat:@"0 0000000000000000000000000000000000000000\t\"%@\"", file.path];
+					indexInfo = [NSString stringWithFormat:@"0 0000000000000000000000000000000000000000\t%@\0", file.path];
 				} else {
 					indexInfo = [file indexInfo];
 				}


### PR DESCRIPTION
`update-index -z` is set, so paths must be NUL delimited and not quoted.

See https://github.com/git/git/blob/v2.11.0/builtin/update-index.c#L525-L531