### PR TITLE
In Diff/Commit view display »Stage« Button consistently at the left

### DIFF
--- a/html/views/commit/commit.css
+++ b/html/views/commit/commit.css
@@ -63,12 +63,14 @@ table.diff {
 
 .diff .hunkbutton {
 	min-width: 5em;
-	padding: 3px 0;
+	padding: 2px 0;
+	border: 1px solid #9abbea;
     top: 4px;
 	margin-bottom: 4px;
 	margin-right: 3px;
 	float: right;
 	position: relative;
+	box-sizing: border-box;
 	z-index: 1;
 
 	background-color: #cce5ff;

--- a/html/views/commit/commit.css
+++ b/html/views/commit/commit.css
@@ -94,7 +94,7 @@ table.diff {
     background-color: #7795c7;
 }
 
-#selected #stagelines {
+#selected .hunkbutton {
     background-color: #FFF;
 }
 

--- a/html/views/commit/commit.js
+++ b/html/views/commit/commit.js
@@ -189,8 +189,8 @@ var displayDiff = function(diff, cached)
 		if (cached)
 			header.innerHTML = "<a href='#' class='hunkbutton' onclick='addHunk(this, true); return false'>Unstage</a>" + header.innerHTML;
 		else {
-			header.innerHTML = "<a href='#' class='hunkbutton' onclick='addHunk(this, false); return false'>Stage</a>" + header.innerHTML;
 			header.innerHTML = "<a href='#' class='hunkbutton' onclick='discardHunk(this, event); return false'>Discard</a>" + header.innerHTML;
+			header.innerHTML = "<a href='#' class='hunkbutton' onclick='addHunk(this, false); return false'>Stage</a>" + header.innerHTML;
 		}
 	}
 	setSelectHandlers();
@@ -456,11 +456,13 @@ var showSelection = function(file, from, to, trust)
 				   (originalCached?"Uns":"S")+"tage"));
 	button.setAttribute("class","hunkbutton");
 	button.setAttribute("id","stagelines");
+	
 	var copy_button = document.createElement('a');
 	copy_button.setAttribute("href","#");
 	copy_button.appendChild(document.createTextNode("Copy"));
 	copy_button.setAttribute("class","hunkbutton");
 	copy_button.setAttribute("id","copylines");
+	
 	var buttons_div = document.createElement('div');
 	buttons_div.appendChild(button);
 	buttons_div.appendChild(copy_button);


### PR DESCRIPTION
This should fix #9.

Also display both action buttons for the selected
lines in the same colour (white) as they also have
the same colour for each hunk.