### PR TITLE
Connect diff copying to the standard copy: menu item

### DIFF
--- a/Classes/Controllers/PBWebChangesController.m
+++ b/Classes/Controllers/PBWebChangesController.m
@@ -140,9 +140,7 @@
 -(void)copy: (NSString *)text{
 	NSArray *lines = [text componentsSeparatedByString:@"\n"];
 	NSMutableArray *processedLines = [NSMutableArray arrayWithCapacity:lines.count -1];
-	// FIXME Don't unconditionally skip the first line, expecting it to contain the
-	//       CopyStage button text. The buttons are only added if changed text is selected.
-	for (int i = 1; i < lines.count; i++) {
+	for (int i = 0; i < lines.count; i++) {
 		NSString *line = [lines objectAtIndex:i];
 		if (line.length>0) {
 			[processedLines addObject:[line substringFromIndex:1]];

--- a/Classes/Controllers/PBWebController.m
+++ b/Classes/Controllers/PBWebController.m
@@ -219,4 +219,9 @@ dragDestinationActionMaskForDraggingInfo:(id<NSDraggingInfo>)draggingInfo
 	[self preferencesChanged];
 }
 
+- (void)makeWebViewFirstResponder
+{
+	[self.view.window makeFirstResponder:self.view];
+}
+
 @end

--- a/html/views/commit/commit.js
+++ b/html/views/commit/commit.js
@@ -489,7 +489,15 @@ var copy = function()
 {
 	var selection = document.getElementById("selected");
 	if(!selection) return false;
-	Controller.copy_(selection.innerText);
+	var selectedText = "";
+	for (var i = 0, n = selection.childNodes.length; i < n; ++i) {
+		var line = selection.childNodes[i];
+		if (line.getAttribute("index") !== null) {
+			selectedText += line.innerText;
+			selectedText += "\n";
+		}
+	}
+	Controller.copy_(selectedText);
 }
 
 

--- a/html/views/commit/commit.js
+++ b/html/views/commit/commit.js
@@ -479,6 +479,10 @@ var showSelection = function(file, from, to, trust)
 	file.insertBefore(selection, from);
 	for (i = 0; i < elementList.length; i++)
 		selection.appendChild(elementList[i]);
+
+	// Drag-selecting does not select the WebView, so make sure
+	// it's selected so that menu items work.
+	Controller.makeWebViewFirstResponder();
 }
 
 var copy = function()


### PR DESCRIPTION
Implements the second item of #9, although it doesn't remove the inline copy button.

I also fixed a bug where the first line selected sometimes doesn't get copied.