### PR TITLE
Move the copy methods to the relevant controller

### DIFF
--- a/Classes/Controllers/PBGitHistoryController.h
+++ b/Classes/Controllers/PBGitHistoryController.h
@@ -91,11 +91,6 @@
 - (IBAction)selectNext:(id)sender;
 - (IBAction)selectPrevious:(id)sender;
 
-- (void) copyCommitInfo;
-- (void) copyCommitSHA;
-- (void) copyCommitShortName;
-- (void) copyCommitPatch;
-
 
 - (BOOL) hasNonlinearPath;
 

--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -338,7 +338,7 @@
 		[menuItem setState:(self.selectedCommitDetailsIndex == kHistoryDetailViewIndex) ? NSOnState : NSOffState];
     } else if (action == @selector(setTreeView:)) {
 		[menuItem setState:(self.selectedCommitDetailsIndex == kHistoryTreeViewIndex) ? NSOnState : NSOffState];
-	} 
+	}
 	
 	if ([self respondsToSelector:action]) {
 		if (action == @selector(createBranch:) || action == @selector(createTag:)) {
@@ -346,6 +346,13 @@
 		}
 		
         return YES;
+	}
+
+	if (action == @selector(copy:)
+		|| action == @selector(copySHA:)
+		|| action == @selector(copyShortName:)
+		|| action == @selector(copyPatch:)) {
+		return self.commitController.selectedObjects.count > 0;
 	}
 	
     return [[self nextResponder] validateMenuItem:menuItem];
@@ -403,27 +410,25 @@
 	[searchController selectPreviousResult];
 }
 
-- (void) copyCommitInfo
+- (IBAction) copy:(id)sender
 {
 	[GitXCommitCopier putStringToPasteboard:[GitXCommitCopier toSHAAndHeadingString:commitController.selectedObjects]];
 }
 
-- (void) copyCommitSHA
+- (IBAction) copySHA:(id)sender
 {
 	[GitXCommitCopier putStringToPasteboard:[GitXCommitCopier toFullSHA:commitController.selectedObjects]];
 }
 
-- (void) copyCommitShortName
+- (IBAction) copyShortName:(id)sender
 {
 	[GitXCommitCopier putStringToPasteboard:[GitXCommitCopier toShortName:commitController.selectedObjects]];
 }
 
-- (void) copyCommitPatch
+- (IBAction) copyPatch:(id)sender
 {
 	[GitXCommitCopier putStringToPasteboard:[GitXCommitCopier toPatch:commitController.selectedObjects]];
 }
-
-
 
 - (IBAction) toggleQLPreviewPanel:(id)sender
 {

--- a/Classes/PBCommitList.h
+++ b/Classes/PBCommitList.h
@@ -29,9 +29,4 @@ typedef void(^PBFindPanelActionBlock)(id sender);
 @property (assign) BOOL useAdjustScroll;
 @property (copy) PBFindPanelActionBlock findPanelActionBlock;
 
-- (IBAction) copy:(id)sender;
-- (IBAction) copySHA:(id)sender;
-- (IBAction) copyShortName:(id)sender;
-- (IBAction) copyPatch:(id)sender;
-
 @end

--- a/Classes/PBCommitList.m
+++ b/Classes/PBCommitList.m
@@ -47,40 +47,6 @@
 		[super keyDown: event];
 }
 
-
-
-- (BOOL) validateUserInterfaceItem:(id<NSValidatedUserInterfaceItem>)item {
-	if (item.action == @selector(copy:)
-		|| item.action == @selector(copySHA:)
-		|| item.action == @selector(copyShortName:)
-		|| item.action == @selector(copyPatch:)) {
-		return controller.commitController.selectedObjects.count > 0;
-	}
-	
-	return [super validateUserInterfaceItem:item];
-}
-
-- (IBAction) copy:(id)sender
-{
-	[controller copyCommitInfo];
-}
-
-- (IBAction) copySHA:(id)sender
-{
-	[controller copyCommitSHA];
-}
-
-- (IBAction) copyShortName:(id)sender
-{
-	[controller copyCommitShortName];
-}
-
-- (IBAction) copyPatch:(id)sender
-{
-	[controller copyCommitPatch];
-}
-
-
 // !!! Andre Berg 20100330: Used from -scrollSelectionToTopOfViewFrom: of PBGitHistoryController
 // so that when the history controller udpates the branch filter the origin of the superview gets
 // shifted into multiples of the row height. Otherwise the top selected row will always be off by


### PR DESCRIPTION
This was a tentative fix for the weird behavior of the `Edit > Copy patch` (eg. ⌃⌥⌘C) menu item when you whack modifiers around, but this isn't it. I've checked the various `-validateMenuItem:` method we have, to no avail.