### PR TITLE
PBCreateBranchSheet was deallocating itself mid-message

### DIFF
--- a/Classes/Views/PBCreateBranchSheet.m
+++ b/Classes/Views/PBCreateBranchSheet.m
@@ -95,14 +95,15 @@
 		return;
 	}
 
-	[self closeCreateBranchSheet:self];
+	PBCreateBranchSheet *ownRef = self; // ensures self exists after close
+	[ownRef closeCreateBranchSheet:ownRef];
 
-	[self.repository createBranch:name atRefish:self.startRefish];
+	[self.repository createBranch:name atRefish:ownRef.startRefish];
 	
-	[PBGitDefaults setShouldCheckoutBranch:self.shouldCheckoutBranch];
+	[PBGitDefaults setShouldCheckoutBranch:ownRef.shouldCheckoutBranch];
 
-	if (self.shouldCheckoutBranch)
-		[self.repository checkoutRefish:ref];
+	if (ownRef.shouldCheckoutBranch)
+		[ownRef.repository checkoutRefish:ref];
 }
 
 


### PR DESCRIPTION
This is the same class of bug that was fixed in https://github.com/rowanj/gitx/issues/24 (https://github.com/rowanj/gitx/commit/af59c91ea82fd08cdff8af10b5cf1ff190eac42b).

The ownership model here is still rather fragile. I don't think sheets are intended to have action targets with the same lifetime as their window. Perhaps the sheet window should hold a strong reference to its window controller? (Inverting the usual relation.)

Fixes #31 and supersedes #33.