### PR TITLE
Fix display of renames (#46)

### DIFF
--- a/Resources/html/views/history/history.js
+++ b/Resources/html/views/history/history.js
@@ -312,8 +312,8 @@ var loadCommitDiff = function(jsonData)
 			fileElem.targetFileId = "file_index_"+i;
 			
 			var displayName, representedFile;
-			if (fileInfo.changeType == "renamed") {
-				displayName = fileInfo.filename;
+			if (fileInfo.changeType === "renamed") {
+				displayName = formatRenameDiff(renameDiff(fileInfo.oldFilename, fileInfo.newFilename));
 				representedFile = fileInfo.newFilename;
 			}
 			else {


### PR DESCRIPTION
The option to show file moves in a single line
rather than a separate remove and add is not one
to set when creating the diff. It has to be used
to manipulate that diff in an additional step.

As all the parameters used here as NSString /
NSNumber-typed the compiler couldn’t detect
the option being passed to the wrong method :/

Also adapted the JS to display the file moving
again.

This behaviour was introduced in 7af30a7. It
should fix the issue described in #46.