### PR TITLE
Improve git version detection

### DIFF
--- a/Classes/Util/PBEasyPipe.m
+++ b/Classes/Util/PBEasyPipe.m
@@ -62,7 +62,10 @@ NSString *const PBEasyPipeUnderlyingExceptionKey = @"PBEasyPipeUnderlyingExcepti
 
     // Prepare ourselves a nicer environment
     NSMutableDictionary *env = [[[NSProcessInfo processInfo] environment] mutableCopy];
-    [env removeObjectsForKeys:@[@"MallocStackLogging", @"MallocStackLoggingNoCompact", @"NSZombieEnabled"]];
+    [env removeObjectsForKeys:@[@"MallocStackLogging",
+								@"MallocStackLoggingNoCompact",
+								@"DYLD_INSERT_LIBRARIES", // to avoid GuardMalloc logging
+								@"NSZombieEnabled"]];
     [task setEnvironment:env];
 
 	if (directory)

--- a/Classes/git/PBGitBinary.m
+++ b/Classes/git/PBGitBinary.m
@@ -22,9 +22,22 @@ static NSString* gitPath = nil;
 		return nil;
 
 	NSString *version = [PBEasyPipe outputForCommand:path withArgs:[NSArray arrayWithObject:@"--version"]];
-	if ([version hasPrefix:@"git version "])
-		return [version substringFromIndex:12];
 
+	return [self extractGitVersion:version];
+}
+
++ (NSString *) extractGitVersion:(NSString *)versionString
+{
+	NSError * error;
+	NSRegularExpression * regex = [NSRegularExpression regularExpressionWithPattern:@"git version ([0-9.]+)"
+																			options:0
+																			  error:&error];
+	NSTextCheckingResult * result = [regex firstMatchInString:versionString
+													  options:0
+														range:NSMakeRange(0, versionString.length)];
+	if (result != nil && result.numberOfRanges == 2) {
+		return [versionString substringWithRange:[result rangeAtIndex:1]];
+	}
 	return nil;
 }
 
@@ -37,7 +50,7 @@ static NSString* gitPath = nil;
 	if (!version)
 		return NO;
 
-	int c = [version compare:@"" MIN_GIT_VERSION];
+	int c = [version compare:@"" MIN_GIT_VERSION options:NSNumericSearch];
 	if (c == NSOrderedSame || c == NSOrderedDescending) {
 		gitPath = path;
 		return YES;


### PR DESCRIPTION
Use a regex to extract the version number. (E.g. when configuring
Xcode to use GuardMalloc, the text we capture contains some
GuardMalloc-related text as well. This change makes extracting
the version number more stable against that. It does seem, however,
that other parsing tasks in GitX will not cope well with that
situation, either).

Do a numerical compare for the version number. (Seeing that git
does allow two digit sub-versions in the current 2.11, doing a
pure string comparison isn’t sufficient.)