### PR TITLE
Make ref contextual menus localisable

### DIFF
--- a/Classes/Controllers/PBRefController.h
+++ b/Classes/Controllers/PBRefController.h
@@ -21,23 +21,24 @@
 	__weak IBOutlet PBCommitList *commitList;
 }
 
-- (void) fetchRemote:(PBRefMenuItem *)sender;
-- (void) pullRemote:(PBRefMenuItem *)sender;
-- (void) pushUpdatesToRemote:(PBRefMenuItem *)sender;
-- (void) pushDefaultRemoteForRef:(PBRefMenuItem *)sender;
-- (void) pushToRemote:(PBRefMenuItem *)sender;
-- (void) showConfirmPushRefSheet:(PBGitRef *)ref remote:(PBGitRef *)remoteRef;
+- (IBAction) fetchRemote:(PBRefMenuItem *)sender;
+- (IBAction) pullRemote:(PBRefMenuItem *)sender;
+- (IBAction) pushUpdatesToRemote:(PBRefMenuItem *)sender;
+- (IBAction) pushDefaultRemoteForRef:(PBRefMenuItem *)sender;
+- (IBAction) pushToRemote:(PBRefMenuItem *)sender;
+- (IBAction) showConfirmPushRefSheet:(PBGitRef *)ref remote:(PBGitRef *)remoteRef;
+- (IBAction)showDeleteRefSheet:(PBRefMenuItem *)sender;
 
-- (void) checkout:(PBRefMenuItem *)sender;
-- (void) merge:(PBRefMenuItem *)sender;
-- (void) cherryPick:(PBRefMenuItem *)sender;
-- (void) rebaseHeadBranch:(PBRefMenuItem *)sender;
-- (void) createBranch:(PBRefMenuItem *)sender;
-- (void) copySHA:(PBRefMenuItem *)sender;
-- (void) copyShortSHA:(PBRefMenuItem *)sender;
-- (void) copyPatch:(PBRefMenuItem *)sender;
-- (void) diffWithHEAD:(PBRefMenuItem *)sender;
-- (void) createTag:(PBRefMenuItem *)sender;
-- (void) showTagInfoSheet:(PBRefMenuItem *)sender;
+- (IBAction) checkout:(PBRefMenuItem *)sender;
+- (IBAction) merge:(PBRefMenuItem *)sender;
+- (IBAction) cherryPick:(PBRefMenuItem *)sender;
+- (IBAction) rebaseHeadBranch:(PBRefMenuItem *)sender;
+- (IBAction) createBranch:(PBRefMenuItem *)sender;
+- (IBAction) copySHA:(PBRefMenuItem *)sender;
+- (IBAction) copyShortSHA:(PBRefMenuItem *)sender;
+- (IBAction) copyPatch:(PBRefMenuItem *)sender;
+- (IBAction) diffWithHEAD:(PBRefMenuItem *)sender;
+- (IBAction) createTag:(PBRefMenuItem *)sender;
+- (IBAction) showTagInfoSheet:(PBRefMenuItem *)sender;
 
 @end

--- a/Classes/Controllers/PBRefController.m
+++ b/Classes/Controllers/PBRefController.m
@@ -290,7 +290,7 @@
 
 #pragma mark Remove a branch, remote or tag
 
-- (void)showDeleteRefSheet:(PBRefMenuItem *)sender
+- (IBAction)showDeleteRefSheet:(PBRefMenuItem *)sender
 {
 	id<PBGitRefish> refish = sender.refishs.firstObject;
 	if ([refish refishType] == kGitXCommitType)

--- a/Classes/Views/PBRefMenuItem.m
+++ b/Classes/Views/PBRefMenuItem.m
@@ -38,11 +38,11 @@
     BOOL isCleanWorkingCopy = YES;
     
     // pop
-    NSString *stashPopTitle = [NSString stringWithFormat:@"Pop %@", targetRefName];
+    NSString *stashPopTitle = [NSString stringWithFormat:NSLocalizedString(@"Pop %@", @"Contextual Menu Item to pop the selected stash ref"), targetRefName];
     [items addObject:[PBRefMenuItem itemWithTitle:stashPopTitle action:@selector(stashPop:) enabled:isCleanWorkingCopy]];
     
     // apply
-    NSString *stashApplyTitle = @"Apply";
+    NSString *stashApplyTitle = [NSString stringWithFormat:NSLocalizedString(@"Apply %@", @"Contextual Menu Item to apply the selected stash ref"), targetRefName];
     [items addObject:[PBRefMenuItem itemWithTitle:stashApplyTitle action:@selector(stashApply:) enabled:YES]];
     
     // view diff
@@ -52,7 +52,7 @@
     [items addObject:[PBRefMenuItem separatorItem]];
 
     // drop
-    NSString *stashDropTitle = @"Drop";
+    NSString *stashDropTitle = [NSString stringWithFormat:NSLocalizedString(@"Drop %@", @"Contextual Menu Item to drop the selected stash ref"), targetRefName];
     [items addObject:[PBRefMenuItem itemWithTitle:stashDropTitle action:@selector(stashDrop:) enabled:YES]];
     
 	for (PBRefMenuItem *item in items) {
@@ -70,89 +70,101 @@
 		return nil;
 	}
 	
-    if ([ref isStash]) {
+    if (ref.isStash) {
         return [self defaultMenuItemsForStashRef:ref inRepository:repo target:target];
     }
 
-	NSString *refName = [ref shortName];
+	NSString *refName = ref.shortName;
 
-	PBGitRef *headRef = [[repo headRef] ref];
-	NSString *headRefName = [headRef shortName];
+	PBGitRef *headRef = repo.headRef.ref;
+	NSString *headRefName = headRef.shortName;
+
 	BOOL isHead = [ref isEqualToRef:headRef];
 	BOOL isOnHeadBranch = isHead ? YES : [repo isRefOnHeadBranch:ref];
 	BOOL isDetachedHead = (isHead && [headRefName isEqualToString:@"HEAD"]);
 
-	NSString *remoteName = [ref remoteName];
-	if (!remoteName && [ref isBranch]) {
+	NSString *remoteName = ref.remoteName;
+	if (!remoteName && ref.isBranch) {
 		remoteName = [[repo remoteRefForBranch:ref error:NULL] remoteName];
 	}
 	BOOL hasRemote = (remoteName ? YES : NO);
-	BOOL isRemote = ([ref isRemote] && ![ref isRemoteBranch]);
+	BOOL isRemote = (ref.isRemote && !ref.isRemoteBranch);
 
 	NSMutableArray *items = [NSMutableArray array];
 	if (!isRemote) {
 		// checkout ref
-		NSString *checkoutTitle = [@"Checkout " stringByAppendingString:refName];
+		NSString *checkoutTitle = [NSString stringWithFormat:NSLocalizedString(@"Checkout “%@”", @"Contextual Menu Item to check out the selected ref"), refName];
 		[items addObject:[PBRefMenuItem itemWithTitle:checkoutTitle action:@selector(checkout:) enabled:!isHead]];
 		[items addObject:[PBRefMenuItem separatorItem]];
 
 		// create branch
-		NSString *createBranchTitle = [ref isRemoteBranch] ? [NSString stringWithFormat:@"Create Branch tracking %@…", refName] : @"Create Branch…";
+		NSString *createBranchTitle = ref.isRemoteBranch
+			? [NSString stringWithFormat:NSLocalizedString(@"Create Branch tracking “%@”…", @"Contextual Menu Item to create a branch tracking the selected remote branch"), refName]
+			: NSLocalizedString(@"Create Branch…", @"Contextual Menu Item to create a new branch at the selected ref");
 		[items addObject:[PBRefMenuItem itemWithTitle:createBranchTitle action:@selector(createBranch:) enabled:YES]];
 
 		// create tag
-		[items addObject:[PBRefMenuItem itemWithTitle:@"Create Tag…" action:@selector(createTag:) enabled:YES]];
+		[items addObject:[PBRefMenuItem itemWithTitle:NSLocalizedString(@"Create Tag…", @"Contextual Menu Item to create a tag at the selected ref") action:@selector(createTag:) enabled:YES]];
 
 		// view tag info
-		if ([ref isTag])
-			[items addObject:[PBRefMenuItem itemWithTitle:@"View Tag Info…" action:@selector(showTagInfoSheet:) enabled:YES]];
+		if (ref.isTag) {
+			[items addObject:[PBRefMenuItem itemWithTitle:NSLocalizedString(@"View Tag Info…", @"Contextual Menu Item to view Information about the selected tag") action:@selector(showTagInfoSheet:) enabled:YES]];
+		}
 
 		// Diff
-		NSString *diffTitle = [NSString stringWithFormat:@"Diff with %@", headRefName];
+		NSString *diffTitle = [NSString stringWithFormat:NSLocalizedString(@"Diff with “%@”", @"Contextual Menu Item to view a diff between the selected ref and HEAD"), headRefName];
 		[items addObject:[PBRefMenuItem itemWithTitle:diffTitle action:@selector(diffWithHEAD:) enabled:!isHead]];
 		[items addObject:[PBRefMenuItem separatorItem]];
 
 		// merge ref
-		NSString *mergeTitle = isOnHeadBranch ? @"Merge" : [NSString stringWithFormat:@"Merge %@ into %@", refName, headRefName];
+		NSString *mergeTitle = isOnHeadBranch
+			? NSLocalizedString(@"Merge", @"Inactive Contextual Menu Item for merging")
+			: [NSString stringWithFormat:@"Merge %@ into %@", refName, headRefName];
 		[items addObject:[PBRefMenuItem itemWithTitle:mergeTitle action:@selector(merge:) enabled:!isOnHeadBranch]];
 
 		// rebase
-		NSString *rebaseTitle = isOnHeadBranch ? @"Rebase" : [NSString stringWithFormat:@"Rebase %@ on %@", headRefName, refName];
+		NSString *rebaseTitle = isOnHeadBranch
+			? NSLocalizedString(@"Rebase", @"Inactive Contextual Menu Item for rebasing")
+			: [NSString stringWithFormat:NSLocalizedString(@"Rebase ”%@“ onto “%@”", @"Contextual Menu Item to rebase HEAD onto the selected ref"), headRefName, refName];
 		[items addObject:[PBRefMenuItem itemWithTitle:rebaseTitle action:@selector(rebaseHeadBranch:) enabled:!isOnHeadBranch]];
 
 		[items addObject:[PBRefMenuItem separatorItem]];
 	}
 
 	// fetch
-	NSString *fetchTitle = hasRemote ? [NSString stringWithFormat:@"Fetch %@", remoteName] : @"Fetch";
+	NSString *fetchTitle = hasRemote
+		? [NSString stringWithFormat:NSLocalizedString(@"Fetch “%@”", @"Contextual Menu Item to fetch the selected remote"), remoteName]
+		: NSLocalizedString(@"Fetch", @"Inactive Contextual Menu Item for fetching");
 	[items addObject:[PBRefMenuItem itemWithTitle:fetchTitle action:@selector(fetchRemote:) enabled:hasRemote]];
 
 	// pull
-	NSString *pullTitle = hasRemote ? [NSString stringWithFormat:@"Pull %@ and Update %@", remoteName, headRefName] : @"Pull";
+	NSString *pullTitle = hasRemote
+		? [NSString stringWithFormat:NSLocalizedString(@"Pull “%@” and Update “%@”", @"Contextual Menu Item to pull the remote and update the selected branch"), remoteName, headRefName]
+		: NSLocalizedString(@"Pull", @"Inactive Contextual Menu Item for pulling");
 	[items addObject:[PBRefMenuItem itemWithTitle:pullTitle action:@selector(pullRemote:) enabled:hasRemote]];
 
 	// push
-	if (isRemote || [ref isRemoteBranch]) {
+	if (isRemote || ref.isRemoteBranch) {
 		// push updates to remote
-		NSString *pushTitle = [NSString stringWithFormat:@"Push Updates to %@", remoteName];
+		NSString *pushTitle = [NSString stringWithFormat:NSLocalizedString(@"Push Updates to “%@”", @"Contextual Menu Item to push updates of the selected ref to he named remote"), remoteName];
 		[items addObject:[PBRefMenuItem itemWithTitle:pushTitle action:@selector(pushUpdatesToRemote:) enabled:YES]];
 	}
 	else if (isDetachedHead) {
-		[items addObject:[PBRefMenuItem itemWithTitle:@"Push" action:nil enabled:NO]];
+		[items addObject:[PBRefMenuItem itemWithTitle:NSLocalizedString(@"Push", @"Inactive Contextual Menu Item for pushing") action:nil enabled:NO]];
 	}
 	else {
 		// push to default remote
 		BOOL hasDefaultRemote = NO;
-		if (![ref isTag] && hasRemote) {
+		if (!ref.isTag && hasRemote) {
 			hasDefaultRemote = YES;
-			NSString *pushTitle = [NSString stringWithFormat:@"Push %@ to %@", refName, remoteName];
+			NSString *pushTitle = [NSString stringWithFormat:NSLocalizedString(@"Push “%@” to “%@”", @"Contextual Menu Item to push a ref to a specific remote"), refName, remoteName];
 			[items addObject:[PBRefMenuItem itemWithTitle:pushTitle action:@selector(pushDefaultRemoteForRef:) enabled:YES]];
 		}
 
 		// push to remotes submenu
 		NSArray *remoteNames = [repo remotes];
 		if ([remoteNames count] && !(hasDefaultRemote && ([remoteNames count] == 1))) {
-			NSString *pushToTitle = [NSString stringWithFormat:@"Push %@ to", refName];
+			NSString *pushToTitle = [NSString stringWithFormat:NSLocalizedString(@"Push “%@” to", @"Contextual Menu Submenu Item containing the remotes the selected ref can be pushed to"), refName];
 			PBRefMenuItem *pushToItem = [PBRefMenuItem itemWithTitle:pushToTitle action:nil enabled:YES];
 			NSMenu *remotesMenu = [[NSMenu alloc] initWithTitle:NSLocalizedString(@"Remotes Menu", @"Menu listing the repository’s remotes")];
 			for (NSString *remote in remoteNames) {
@@ -169,14 +181,14 @@
 
 	// delete ref
 	[items addObject:[PBRefMenuItem separatorItem]];
-	{
-		BOOL isStash = [[ref ref] hasPrefix:@"refs/stash"];
-		NSString *deleteTitle = [NSString stringWithFormat:@"Delete %@…", refName];
-		if ([ref isRemote]) {
-			deleteTitle = [NSString stringWithFormat:@"Remove %@…", refName];
-		}
-		BOOL deleteEnabled = !(isDetachedHead || isHead || isStash);
-		PBRefMenuItem *deleteItem = [PBRefMenuItem itemWithTitle:deleteTitle action:@selector(showDeleteRefSheet:) enabled:deleteEnabled];
+	BOOL isStash = [[ref ref] hasPrefix:@"refs/stash"];
+	BOOL isDeleteEnabled = !(isDetachedHead || isHead || isStash);
+	if (isDeleteEnabled) {
+		NSString *deleteFormat = ref.isRemote
+			? NSLocalizedString(@"Delete “%@”…", @"Contextual Menu Item to delete a local ref (e.g. branch)")
+			: NSLocalizedString(@"Remove “%@”…", @"Contextual Menu Item to remove a remote");
+		NSString *deleteItemTitle = [NSString stringWithFormat:deleteFormat, refName];
+		PBRefMenuItem *deleteItem = [PBRefMenuItem itemWithTitle:deleteItemTitle action:@selector(showDeleteRefSheet:) enabled:YES];
 		[items addObject:deleteItem];
 	}
 
@@ -196,38 +208,44 @@
 	BOOL isSingleCommitSelection = commits.count == 1;
 	PBGitCommit *firstCommit = commits.firstObject;
 	
-	NSString *headBranchName = [[[firstCommit.repository headRef] ref] shortName];
-	BOOL isOnHeadBranch = [firstCommit isOnHeadBranch];
+	NSString *headBranchName = firstCommit.repository.headRef.ref.shortName;
+	BOOL isOnHeadBranch = firstCommit.isOnHeadBranch;
 	BOOL isHead = [firstCommit.OID isEqual:firstCommit.repository.headOID];
 
 	if (isSingleCommitSelection) {
-		[items addObject:[PBRefMenuItem itemWithTitle:@"Checkout Commit" action:@selector(checkout:) enabled:YES]];
+		[items addObject:[PBRefMenuItem itemWithTitle:NSLocalizedString(@"Checkout Commit", @"Contextual Menu Item to check out the selected commit") action:@selector(checkout:) enabled:YES]];
 		[items addObject:[PBRefMenuItem separatorItem]];
 
-		[items addObject:[PBRefMenuItem itemWithTitle:@"Create Branch…" action:@selector(createBranch:) enabled:YES]];
-		[items addObject:[PBRefMenuItem itemWithTitle:@"Create Tag…" action:@selector(createTag:) enabled:YES]];
+		[items addObject:[PBRefMenuItem itemWithTitle:NSLocalizedString(@"Create Branch…", @"Contextual Menu Item to create a branch at the selected commit") action:@selector(createBranch:) enabled:YES]];
+		[items addObject:[PBRefMenuItem itemWithTitle:NSLocalizedString(@"Create Tag…", @"Contextual Menu Item to create a tag at the selected commit") action:@selector(createTag:) enabled:YES]];
 		[items addObject:[PBRefMenuItem separatorItem]];
 	}
 	
-	[items addObject:[PBRefMenuItem itemWithTitle:@"Copy SHA" action:@selector(copySHA:) enabled:YES]];
-	[items addObject:[PBRefMenuItem itemWithTitle:@"Copy short SHA" action:@selector(copyShortSHA:) enabled:YES]];
-	[items addObject:[PBRefMenuItem itemWithTitle:@"Copy Patch" action:@selector(copyPatch:) enabled:YES]];
+	[items addObject:[PBRefMenuItem itemWithTitle:NSLocalizedString(@"Copy SHA", @"Contextual Menu Item to copy the selected commits’ full SHA(s)") action:@selector(copySHA:) enabled:YES]];
+	[items addObject:[PBRefMenuItem itemWithTitle:NSLocalizedString(@"Copy short SHA", @"Contextual Menu Item to copy the selected commits’ short SHA(s)") action:@selector(copyShortSHA:) enabled:YES]];
+	[items addObject:[PBRefMenuItem itemWithTitle:NSLocalizedString(@"Copy Patch", @"Contextual Menu Item to copy the selected commits as patch(es)") action:@selector(copyPatch:) enabled:YES]];
 
 	if (isSingleCommitSelection) {
-		NSString *diffTitle = [NSString stringWithFormat:@"Diff with %@", headBranchName];
+		NSString *diffTitle = [NSString stringWithFormat:NSLocalizedString(@"Diff with “%@”", @"Contextual Menu Item to view a diff between the selected commit and HEAD"), headBranchName];
 		[items addObject:[PBRefMenuItem itemWithTitle:diffTitle action:@selector(diffWithHEAD:) enabled:!isHead]];
 		[items addObject:[PBRefMenuItem separatorItem]];
 
 		// merge commit
-		NSString *mergeTitle = isOnHeadBranch ? @"Merge Commit" : [NSString stringWithFormat:@"Merge Commit into %@", headBranchName];
+		NSString *mergeTitle = isOnHeadBranch
+			? NSLocalizedString(@"Merge Commit", @"Inactive Contextual Menu Item for merging commits")
+			: [NSString stringWithFormat:NSLocalizedString(@"Merge Commit into “%@”", @"Contextual Menu Item to merge the selected commit into HEAD"), headBranchName];
 		[items addObject:[PBRefMenuItem itemWithTitle:mergeTitle action:@selector(merge:) enabled:!isOnHeadBranch]];
 
 		// cherry pick
-		NSString *cherryPickTitle = isOnHeadBranch ? @"Cherry Pick Commit" : [NSString stringWithFormat:@"Cherry Pick Commit to %@", headBranchName];
+		NSString *cherryPickTitle = isOnHeadBranch
+			? NSLocalizedString(@"Cherry Pick Commit", @"Inactive Contextual Menu Item for cherry-picking commits")
+			: [NSString stringWithFormat:NSLocalizedString(@"Cherry Pick Commit to “%@”", @"Contextual Menu Item to cherry-pick the selected commit on top of HEAD"), headBranchName];
 		[items addObject:[PBRefMenuItem itemWithTitle:cherryPickTitle action:@selector(cherryPick:) enabled:!isOnHeadBranch]];
 
 		// rebase
-		NSString *rebaseTitle = isOnHeadBranch ? @"Rebase Commit" : [NSString stringWithFormat:@"Rebase %@ on Commit", headBranchName];
+		NSString *rebaseTitle = isOnHeadBranch
+			? NSLocalizedString(@"Rebase Commit", @"Inactive Contextual Menu Item for rebasing onto commits")
+			: [NSString stringWithFormat:NSLocalizedString(@"Rebase “%@” onto Commit", @"Contextual Menu Item to rebase the HEAD branch onto the selected commit"), headBranchName];
 		[items addObject:[PBRefMenuItem itemWithTitle:rebaseTitle action:@selector(rebaseHeadBranch:) enabled:!isOnHeadBranch]];
 	}
 	


### PR DESCRIPTION
Looking at these I started wondering whether it’d be a good idea
to remove the inactive items in there.

I can see the point of them
making things more consistent across menus – but the idea of a
contextual menu started off focusing on the commands that are actually
usable in the current context.

Besides, the menus are already quite long.