### PR TITLE
Add an .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{c,css,h,js,m}]
+indent_style = tab
+indent_size = tab
+tab_width = 4
+
+[*.py]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
In addition to being useful for [editors supporting .editorconfig](http://editorconfig.org/#download), GitHub [supports this too](https://taylorhakes.com/posts/Github-Tab-Formatting/) (but [no official docs...?](https://help.github.com/search/?utf8=%E2%9C%93&q=editorconfig)) and will render matching files with the specified tabstop of 4.