### PR TITLE
Fix open panel only accepting files

### DIFF
--- a/Classes/Controllers/ApplicationController.m
+++ b/Classes/Controllers/ApplicationController.m
@@ -144,10 +144,6 @@ static OpenRecentController* recentsDialog = nil;
 				if (!document) {
 					NSLog(@"Error opening repository \"%@\": %@", panel.URL.path, error);
 					[controller presentError:error];
-					[sender replyToOpenOrPrint:NSApplicationDelegateReplyFailure];
-				}
-				else {
-					[sender replyToOpenOrPrint:NSApplicationDelegateReplySuccess];
 				}
 			}];
 		}

--- a/Classes/Controllers/ApplicationController.m
+++ b/Classes/Controllers/ApplicationController.m
@@ -130,6 +130,30 @@ static OpenRecentController* recentsDialog = nil;
 	[firstResponder terminate: sender];
 }
 
+//Override the default behavior
+- (IBAction)openDocument:(id)sender {
+	NSOpenPanel* panel = [[NSOpenPanel alloc] init];
+	
+	[panel setCanChooseFiles:false];
+	[panel setCanChooseDirectories:true];
+	
+	[panel beginWithCompletionHandler:^(NSInteger result) {
+		if (result == NSFileHandlingPanelOKButton) {
+			PBRepositoryDocumentController* controller = [PBRepositoryDocumentController sharedDocumentController];
+			[controller openDocumentWithContentsOfURL:panel.URL display:true completionHandler:^(NSDocument * _Nullable document, BOOL documentWasAlreadyOpen, NSError * _Nullable error) {
+				if (!document) {
+					NSLog(@"Error opening repository \"%@\": %@", panel.URL.path, error);
+					[controller presentError:error];
+					[sender replyToOpenOrPrint:NSApplicationDelegateReplyFailure];
+				}
+				else {
+					[sender replyToOpenOrPrint:NSApplicationDelegateReplySuccess];
+				}
+			}];
+		}
+	}];
+}
+
 - (IBAction)openPreferencesWindow:(id)sender
 {
 	[[PBPrefsWindowController sharedPrefsWindowController] showWindow:nil];


### PR DESCRIPTION
This pull request refers to #74, where only files can be selected in the open panel. It should be exactly the other way around where only folders can be opened. 

