### PR TITLE
Setup clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,94 @@
+---
+# Custom options in the special build of clang-format (these are not standard options)
+# IndentNestedBlocks: false
+# AllowNewlineBeforeBlockParameter: false
+
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+ConstructorInitializerIndentWidth: 4
+SortIncludes: false
+
+AlignAfterOpenBracket: true
+AlignEscapedNewlinesLeft: true
+AlignOperands: false
+AlignTrailingComments: true
+
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+
+AlwaysBreakAfterDefinitionReturnType: false
+AlwaysBreakTemplateDeclarations: false
+AlwaysBreakBeforeMultilineStrings: false
+
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+
+BinPackArguments: true
+BinPackParameters: true
+ColumnLimit: 0
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+DerivePointerAlignment: false
+ExperimentalAutoDetectBinPacking: false
+IndentCaseLabels: true
+IndentWrappedFunctionNames: false
+IndentFunctionDeclarationAfterType: false
+MaxEmptyLinesToKeep: 2
+KeepEmptyLinesAtTheStartOfBlocks: false
+NamespaceIndentation: Inner
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 10000
+PenaltyBreakComment: 300
+PenaltyBreakString: 1000
+PenaltyBreakFirstLessLess: 120
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Right
+SpacesBeforeTrailingComments: 1
+Cpp11BracedListStyle: true
+Standard:        Auto
+IndentWidth:     4
+TabWidth:        4
+UseTab:          Always
+BreakBeforeBraces: Custom
+BraceWrapping: 
+    AfterClass: true
+    AfterControlStatement: false
+    AfterEnum: false
+    AfterFunction: true
+    AfterNamespace: false
+    AfterObjCDeclaration: false
+    AfterStruct: false
+    AfterUnion: false
+    BeforeCatch: false
+    BeforeElse: false
+    IndentBraces: false
+
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterCStyleCast: false
+SpacesInContainerLiterals: true
+SpaceBeforeAssignmentOperators: true
+
+ContinuationIndentWidth: 4
+CommentPragmas:  '^ IWYU pragma:'
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+SpaceBeforeParens: ControlStatements
+DisableFormat:   false
+
+---
+Language: ObjC
+---
+Language: Cpp
+...
+

--- a/Classes/Controllers/ApplicationController.h
+++ b/Classes/Controllers/ApplicationController.h
@@ -11,8 +11,7 @@
 
 @class PBCloneRepositoryPanel;
 
-@interface ApplicationController : NSObject<NSApplicationDelegate>
-{
+@interface ApplicationController : NSObject <NSApplicationDelegate> {
 	IBOutlet NSWindow *window;
 	IBOutlet id firstResponder;
 

--- a/Classes/Controllers/ApplicationController.m
+++ b/Classes/Controllers/ApplicationController.m
@@ -22,33 +22,33 @@
 #import <Sparkle/SUUpdater.h>
 #import <Sparkle/SUUpdaterDelegate.h>
 
-static OpenRecentController* recentsDialog = nil;
+static OpenRecentController *recentsDialog = nil;
 
 @interface ApplicationController () <SUUpdaterDelegate>
 @end
 
 @implementation ApplicationController
 
-- (ApplicationController*)init
+- (ApplicationController *)init
 {
 #ifdef DEBUG_BUILD
 	[NSApp activateIgnoringOtherApps:YES];
 #endif
 
-	if(!(self = [super init]))
+	if (!(self = [super init]))
 		return nil;
 
-	if(![[NSBundle bundleWithPath:@"/System/Library/Frameworks/Quartz.framework/Frameworks/QuickLookUI.framework"] load])
-		if(![[NSBundle bundleWithPath:@"/System/Library/PrivateFrameworks/QuickLookUI.framework"] load])
+	if (![[NSBundle bundleWithPath:@"/System/Library/Frameworks/Quartz.framework/Frameworks/QuickLookUI.framework"] load])
+		if (![[NSBundle bundleWithPath:@"/System/Library/PrivateFrameworks/QuickLookUI.framework"] load])
 			NSLog(@"Could not load QuickLook");
 
 	/* Value Transformers */
 	NSValueTransformer *transformer = [[PBNSURLPathUserDefaultsTransfomer alloc] init];
 	[NSValueTransformer setValueTransformer:transformer forName:@"PBNSURLPathUserDefaultsTransfomer"];
-	
+
 	// Make sure the PBGitDefaults is initialized, by calling a random method
 	[PBGitDefaults class];
-	
+
 	started = NO;
 	return self;
 }
@@ -64,27 +64,27 @@ static OpenRecentController* recentsDialog = nil;
 
 	// Force update the services menu if we have a new services version
 	NSInteger serviceVersion = [[NSUserDefaults standardUserDefaults] integerForKey:@"Services Version"];
-	if (serviceVersion < 2)
-	{
+	if (serviceVersion < 2) {
 		NSLog(@"Updating services menu…");
 		NSUpdateDynamicServices();
 		[[NSUserDefaults standardUserDefaults] setInteger:2 forKey:@"Services Version"];
 	}
 }
 
-- (void)application:(NSApplication *)sender openFiles:(NSArray <NSString *> *)filenames {
-	PBRepositoryDocumentController * controller = [PBRepositoryDocumentController sharedDocumentController];
-	
-	for (NSString * filename in filenames) {
-		NSURL * repository = [NSURL fileURLWithPath:filename];
-		[controller openDocumentWithContentsOfURL:repository display:YES
-								completionHandler:^void (NSDocument *document, BOOL documentWasAlreadyOpen, NSError *error) {
+- (void)application:(NSApplication *)sender openFiles:(NSArray<NSString *> *)filenames
+{
+	PBRepositoryDocumentController *controller = [PBRepositoryDocumentController sharedDocumentController];
+
+	for (NSString *filename in filenames) {
+		NSURL *repository = [NSURL fileURLWithPath:filename];
+		[controller openDocumentWithContentsOfURL:repository
+										  display:YES
+								completionHandler:^void(NSDocument *document, BOOL documentWasAlreadyOpen, NSError *error) {
 									if (!document) {
 										NSLog(@"Error opening repository \"%@\": %@", repository.path, error);
 										[controller presentError:error];
 										[sender replyToOpenOrPrint:NSApplicationDelegateReplyFailure];
-									}
-									else {
+									} else {
 										[sender replyToOpenOrPrint:NSApplicationDelegateReplySuccess];
 									}
 								}];
@@ -93,7 +93,7 @@ static OpenRecentController* recentsDialog = nil;
 
 - (BOOL)applicationShouldOpenUntitledFile:(NSApplication *)sender
 {
-	if(!started || [[[NSDocumentController sharedDocumentController] documents] count])
+	if (!started || [[[NSDocumentController sharedDocumentController] documents] count])
 		return NO;
 	return YES;
 }
@@ -101,52 +101,52 @@ static OpenRecentController* recentsDialog = nil;
 - (BOOL)applicationOpenUntitledFile:(NSApplication *)theApplication
 {
 	recentsDialog = [[OpenRecentController alloc] init];
-	if ([recentsDialog.possibleResults count] > 0)
-	{
+	if ([recentsDialog.possibleResults count] > 0) {
 		[recentsDialog show];
 		return YES;
-	}
-	else
-	{
+	} else {
 		return NO;
 	}
 }
 
-- (void)applicationDidFinishLaunching:(NSNotification*)notification
+- (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
 	[[SUUpdater sharedUpdater] setSendsSystemProfile:YES];
-    [[SUUpdater sharedUpdater] setDelegate:self];
+	[[SUUpdater sharedUpdater] setDelegate:self];
 
 	// Make sure Git's SSH password requests get forwarded to our little UI tool:
-	setenv( "SSH_ASKPASS", [[[NSBundle mainBundle] pathForResource: @"gitx_askpasswd" ofType: @""] UTF8String], 1 );
-	setenv( "DISPLAY", "localhost:0", 1 );
+	setenv("SSH_ASKPASS", [[[NSBundle mainBundle] pathForResource:@"gitx_askpasswd" ofType:@""] UTF8String], 1);
+	setenv("DISPLAY", "localhost:0", 1);
 
 	[NSApp registerObserverForAppearanceChanges:self];
 	[self registerServices];
 	started = YES;
 }
 
-- (void) windowWillClose: sender
+- (void)windowWillClose:sender
 {
-	[firstResponder terminate: sender];
+	[firstResponder terminate:sender];
 }
 
 //Override the default behavior
-- (IBAction)openDocument:(id)sender {
-	NSOpenPanel* panel = [[NSOpenPanel alloc] init];
-	
+- (IBAction)openDocument:(id)sender
+{
+	NSOpenPanel *panel = [[NSOpenPanel alloc] init];
+
 	[panel setCanChooseFiles:false];
 	[panel setCanChooseDirectories:true];
-	
+
 	[panel beginWithCompletionHandler:^(NSInteger result) {
 		if (result == NSFileHandlingPanelOKButton) {
-			PBRepositoryDocumentController* controller = [PBRepositoryDocumentController sharedDocumentController];
-			[controller openDocumentWithContentsOfURL:panel.URL display:true completionHandler:^(NSDocument * _Nullable document, BOOL documentWasAlreadyOpen, NSError * _Nullable error) {
-				if (!document) {
-					NSLog(@"Error opening repository \"%@\": %@", panel.URL.path, error);
-					[controller presentError:error];
-				}
-			}];
+			PBRepositoryDocumentController *controller = [PBRepositoryDocumentController sharedDocumentController];
+			[controller openDocumentWithContentsOfURL:panel.URL
+											  display:true
+									completionHandler:^(NSDocument *_Nullable document, BOOL documentWasAlreadyOpen, NSError *_Nullable error) {
+										if (!document) {
+											NSLog(@"Error opening repository \"%@\": %@", panel.URL.path, error);
+											[controller presentError:error];
+										}
+									}];
 		}
 	}];
 }
@@ -163,16 +163,16 @@ static OpenRecentController* recentsDialog = nil;
 	if (gitversion)
 		[dict addEntriesFromDictionary:[[NSDictionary alloc] initWithObjectsAndKeys:gitversion, @"Version", nil]];
 
-	#ifdef DEBUG_BUILD
-		[dict addEntriesFromDictionary:[[NSDictionary alloc] initWithObjectsAndKeys:@"GitX-dev (DEBUG)", @"ApplicationName", nil]];
-	#endif
+#ifdef DEBUG_BUILD
+	[dict addEntriesFromDictionary:[[NSDictionary alloc] initWithObjectsAndKeys:@"GitX-dev (DEBUG)", @"ApplicationName", nil]];
+#endif
 
 	[dict addEntriesFromDictionary:[[NSDictionary alloc] initWithObjectsAndKeys:@"GitX-dev (rowanj fork)", @"ApplicationName", nil]];
 
 	[NSApp orderFrontStandardAboutPanelWithOptions:dict];
 }
 
-- (IBAction) showCloneRepository:(id)sender
+- (IBAction)showCloneRepository:(id)sender
 {
 	if (!cloneRepositoryPanel)
 		cloneRepositoryPanel = [PBCloneRepositoryPanel panel];
@@ -182,19 +182,19 @@ static OpenRecentController* recentsDialog = nil;
 
 - (IBAction)installCliTool:(id)sender;
 {
-	BOOL success               = NO;
-	NSString* installationPath = @"/usr/local/bin/";
-	NSString* installationName = @"gitx";
-	NSString* toolPath         = [[NSBundle mainBundle] pathForResource:@"gitx" ofType:@""];
+	BOOL success = NO;
+	NSString *installationPath = @"/usr/local/bin/";
+	NSString *installationName = @"gitx";
+	NSString *toolPath = [[NSBundle mainBundle] pathForResource:@"gitx" ofType:@""];
 	if (toolPath) {
 		AuthorizationRef auth;
 		if (AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment, kAuthorizationFlagDefaults, &auth) == errAuthorizationSuccess) {
-			char const* mkdir_arg[] = { "-p", [installationPath UTF8String], NULL};
-			char const* mkdir	= "/bin/mkdir";
-			AuthorizationExecuteWithPrivileges(auth, mkdir, kAuthorizationFlagDefaults, (char**)mkdir_arg, NULL);
-			char const* arguments[] = { "-f", "-s", [toolPath UTF8String], [[installationPath stringByAppendingString: installationName] UTF8String],  NULL };
-			char const* helperTool  = "/bin/ln";
-			if (AuthorizationExecuteWithPrivileges(auth, helperTool, kAuthorizationFlagDefaults, (char**)arguments, NULL) == errAuthorizationSuccess) {
+			char const *mkdir_arg[] = {"-p", [installationPath UTF8String], NULL};
+			char const *mkdir = "/bin/mkdir";
+			AuthorizationExecuteWithPrivileges(auth, mkdir, kAuthorizationFlagDefaults, (char **)mkdir_arg, NULL);
+			char const *arguments[] = {"-f", "-s", [toolPath UTF8String], [[installationPath stringByAppendingString:installationName] UTF8String], NULL};
+			char const *helperTool = "/bin/ln";
+			if (AuthorizationExecuteWithPrivileges(auth, helperTool, kAuthorizationFlagDefaults, (char **)arguments, NULL) == errAuthorizationSuccess) {
 				int status;
 				int pid = wait(&status);
 				if (pid != -1 && WIFEXITED(status) && WEXITSTATUS(status) == 0)
@@ -207,7 +207,7 @@ static OpenRecentController* recentsDialog = nil;
 		}
 	}
 
-	NSAlert * alert = [[NSAlert alloc] init];
+	NSAlert *alert = [[NSAlert alloc] init];
 	if (success) {
 		alert.messageText = NSLocalizedString(@"Installation Complete", @"Headline for successfully completed installation of the command line tool");
 		alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"The gitx tool has been installed to %@.", @"Informative text for successfully completed installation of the command line tool at the location %@"), installationPath];
@@ -225,20 +225,20 @@ static OpenRecentController* recentsDialog = nil;
 	NSArray *keys = [NSArray arrayWithObjects:@"key", @"displayKey", @"value", @"displayValue", nil];
 	NSMutableArray *feedParameters = [NSMutableArray array];
 
-    // only add parameters if the profile is being sent this time
-    if (sendingProfile) {
-        NSString *CFBundleGitVersion = [[[NSBundle mainBundle] infoDictionary] valueForKey:@"CFBundleGitVersion"];
+	// only add parameters if the profile is being sent this time
+	if (sendingProfile) {
+		NSString *CFBundleGitVersion = [[[NSBundle mainBundle] infoDictionary] valueForKey:@"CFBundleGitVersion"];
 		if (CFBundleGitVersion)
-			[feedParameters addObject:[NSDictionary dictionaryWithObjects:[NSArray arrayWithObjects:@"CFBundleGitVersion", @"Full Version", CFBundleGitVersion, CFBundleGitVersion, nil] 
+			[feedParameters addObject:[NSDictionary dictionaryWithObjects:[NSArray arrayWithObjects:@"CFBundleGitVersion", @"Full Version", CFBundleGitVersion, CFBundleGitVersion, nil]
 																  forKeys:keys]];
 
-        NSString *gitVersion = [PBGitBinary version];
+		NSString *gitVersion = [PBGitBinary version];
 		if (gitVersion)
-			[feedParameters addObject:[NSDictionary dictionaryWithObjects:[NSArray arrayWithObjects:@"gitVersion", @"git Version", gitVersion, gitVersion, nil] 
+			[feedParameters addObject:[NSDictionary dictionaryWithObjects:[NSArray arrayWithObjects:@"gitVersion", @"git Version", gitVersion, gitVersion, nil]
 																  forKeys:keys]];
 	}
 
-    return feedParameters;
+	return feedParameters;
 }
 
 
@@ -251,14 +251,13 @@ static OpenRecentController* recentsDialog = nil;
 
 - (IBAction)reportAProblem:(id)sender
 {
-    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://github.com/gitx/gitx/issues"]];
+	[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://github.com/gitx/gitx/issues"]];
 }
 
 - (IBAction)showChangeLog:(id)sender
 {
 	[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://github.com/gitx/gitx/releases"]];
 }
-
 
 
 @end

--- a/Classes/Controllers/DBPrefsWindowController.h
+++ b/Classes/Controllers/DBPrefsWindowController.h
@@ -42,14 +42,14 @@
 #import <Cocoa/Cocoa.h>
 
 
-@interface DBPrefsWindowController : NSWindowController<NSAnimationDelegate, NSToolbarDelegate> {
+@interface DBPrefsWindowController : NSWindowController <NSAnimationDelegate, NSToolbarDelegate> {
 	NSMutableArray *toolbarIdentifiers;
 	NSMutableDictionary *toolbarViews;
 	NSMutableDictionary *toolbarItems;
-	
+
 	BOOL _crossFade;
 	BOOL _shiftSlowsAnimation;
-	
+
 	NSView *contentSubview;
 	NSViewAnimation *viewAnimation;
 }

--- a/Classes/Controllers/DBPrefsWindowController.m
+++ b/Classes/Controllers/DBPrefsWindowController.m
@@ -11,8 +11,6 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 @implementation DBPrefsWindowController
 
 
-
-
 #pragma mark -
 #pragma mark Class Methods
 
@@ -26,15 +24,11 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 }
 
 
-
-
 + (NSString *)nibName
-	// Subclasses can override this to use a nib with a different name.
+// Subclasses can override this to use a nib with a different name.
 {
-   return @"Preferences";
+	return @"Preferences";
 }
-
-
 
 
 #pragma mark -
@@ -42,17 +36,17 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 
 
 - (id)initWithWindow:(NSWindow *)window
-  // -initWithWindow: is the designated initializer for NSWindowController.
+// -initWithWindow: is the designated initializer for NSWindowController.
 {
 	self = [super initWithWindow:nil];
 	if (self != nil) {
-			// Set up an array and some dictionaries to keep track
-			// of the views we'll be displaying.
+		// Set up an array and some dictionaries to keep track
+		// of the views we'll be displaying.
 		toolbarIdentifiers = [[NSMutableArray alloc] init];
 		toolbarViews = [[NSMutableDictionary alloc] init];
 		toolbarItems = [[NSMutableDictionary alloc] init];
 
-			// Set up an NSViewAnimation to animate the transitions.
+		// Set up an NSViewAnimation to animate the transitions.
 		viewAnimation = [[NSViewAnimation alloc] init];
 		[viewAnimation setAnimationBlockingMode:NSAnimationNonblocking];
 		[viewAnimation setAnimationCurve:NSAnimationEaseInOut];
@@ -65,31 +59,23 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 }
 
 
-
-
 - (void)windowDidLoad
 {
-		// Create a new window to display the preference views.
-		// If the developer attached a window to this controller
-		// in Interface Builder, it gets replaced with this one.
-	NSPanel *panel = [[NSPanel alloc] initWithContentRect:NSMakeRect(0,0,1000,1000)
-												    styleMask:(NSTitledWindowMask |
-															   NSClosableWindowMask |
-															   NSMiniaturizableWindowMask)
-													  backing:NSBackingStoreBuffered
-													    defer:YES];
+	// Create a new window to display the preference views.
+	// If the developer attached a window to this controller
+	// in Interface Builder, it gets replaced with this one.
+	NSPanel *panel = [[NSPanel alloc] initWithContentRect:NSMakeRect(0, 0, 1000, 1000)
+												styleMask:(NSTitledWindowMask |
+														   NSClosableWindowMask |
+														   NSMiniaturizableWindowMask)
+												  backing:NSBackingStoreBuffered
+													defer:YES];
 	[self setWindow:panel];
 	contentSubview = [[NSView alloc] initWithFrame:[[[self window] contentView] frame]];
 	[contentSubview setAutoresizingMask:(NSViewMinYMargin | NSViewWidthSizable)];
 	[[[self window] contentView] addSubview:contentSubview];
 	[[self window] setShowsToolbarButton:NO];
 }
-
-
-
-
-
-
 
 
 #pragma mark -
@@ -103,8 +89,6 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 }
 
 
-
-
 - (void)addView:(NSView *)view label:(NSString *)label
 {
 	[self addView:view
@@ -113,12 +97,10 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 }
 
 
-
-
 - (void)addView:(NSView *)view label:(NSString *)label image:(NSImage *)image
 {
-	NSAssert (view != nil,
-			  @"Attempted to add a nil view when calling -addView:label:image:.");
+	NSAssert(view != nil,
+			 @"Attempted to add a nil view when calling -addView:label:image:.");
 
 	NSString *identifier = [label copy];
 
@@ -135,42 +117,32 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 }
 
 
-
-
 #pragma mark -
 #pragma mark Accessor Methods
 
 
 - (BOOL)crossFade
 {
-    return _crossFade;
+	return _crossFade;
 }
-
-
 
 
 - (void)setCrossFade:(BOOL)fade
 {
-    _crossFade = fade;
+	_crossFade = fade;
 }
-
-
 
 
 - (BOOL)shiftSlowsAnimation
 {
-    return _shiftSlowsAnimation;
+	return _shiftSlowsAnimation;
 }
-
-
 
 
 - (void)setShiftSlowsAnimation:(BOOL)slows
 {
-    _shiftSlowsAnimation = slows;
+	_shiftSlowsAnimation = slows;
 }
-
-
 
 
 #pragma mark -
@@ -179,17 +151,17 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 
 - (IBAction)showWindow:(id)sender
 {
-		// This forces the resources in the nib to load.
+	// This forces the resources in the nib to load.
 	(void)[self window];
 
-		// Clear the last setup and get a fresh one.
+	// Clear the last setup and get a fresh one.
 	[toolbarIdentifiers removeAllObjects];
 	[toolbarViews removeAllObjects];
 	[toolbarItems removeAllObjects];
 	[self setupToolbar];
 
-	NSAssert (([toolbarIdentifiers count] > 0),
-			  @"No items were added to the toolbar in -setupToolbar.");
+	NSAssert(([toolbarIdentifiers count] > 0),
+			 @"No items were added to the toolbar in -setupToolbar.");
 
 	if ([[self window] toolbar] == nil) {
 		NSToolbar *toolbar = [[NSToolbar alloc] initWithIdentifier:@"DBPreferencesToolbar"];
@@ -211,25 +183,19 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 }
 
 
-
-
 #pragma mark -
 #pragma mark Toolbar
 
-- (NSArray *)toolbarDefaultItemIdentifiers:(NSToolbar*)toolbar
+- (NSArray *)toolbarDefaultItemIdentifiers:(NSToolbar *)toolbar
 {
 	return toolbarIdentifiers;
 }
 
 
-
-
-- (NSArray *)toolbarAllowedItemIdentifiers:(NSToolbar*)toolbar
+- (NSArray *)toolbarAllowedItemIdentifiers:(NSToolbar *)toolbar
 {
 	return toolbarIdentifiers;
 }
-
-
 
 
 - (NSArray *)toolbarSelectableItemIdentifiers:(NSToolbar *)toolbar
@@ -238,14 +204,10 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 }
 
 
-
-
 - (NSToolbarItem *)toolbar:(NSToolbar *)toolbar itemForItemIdentifier:(NSString *)identifier willBeInsertedIntoToolbar:(BOOL)willBeInserted
 {
 	return [toolbarItems objectForKey:identifier];
 }
-
-
 
 
 - (void)toggleActivePreferenceView:(NSToolbarItem *)toolbarItem
@@ -254,25 +216,23 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 }
 
 
-
-
 - (void)displayViewForIdentifier:(NSString *)identifier animate:(BOOL)animate
 {
-		// Find the view we want to display.
+	// Find the view we want to display.
 	NSView *newView = [toolbarViews objectForKey:identifier];
 
-		// See if there are any visible views.
+	// See if there are any visible views.
 	NSView *oldView = nil;
 	if ([[contentSubview subviews] count] > 0) {
-			// Get a list of all of the views in the window. Usually at this
-			// point there is just one visible view. But if the last fade
-			// hasn't finished, we need to get rid of it now before we move on.
+		// Get a list of all of the views in the window. Usually at this
+		// point there is just one visible view. But if the last fade
+		// hasn't finished, we need to get rid of it now before we move on.
 		NSEnumerator *subviewsEnum = [[contentSubview subviews] reverseObjectEnumerator];
 
-			// The first one (last one added) is our visible view.
+		// The first one (last one added) is our visible view.
 		oldView = [subviewsEnum nextObject];
 
-			// Remove any others.
+		// Remove any others.
 		NSView *reallyOldView = nil;
 		while ((reallyOldView = [subviewsEnum nextObject]) != nil) {
 			[reallyOldView removeFromSuperviewWithoutNeedingDisplay];
@@ -299,8 +259,6 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 }
 
 
-
-
 #pragma mark -
 #pragma mark Cross-Fading Methods
 
@@ -309,70 +267,66 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 {
 	[viewAnimation stopAnimation];
 
-    if ([self shiftSlowsAnimation] && [[[self window] currentEvent] modifierFlags] & NSShiftKeyMask)
+	if ([self shiftSlowsAnimation] && [[[self window] currentEvent] modifierFlags] & NSShiftKeyMask)
 		[viewAnimation setDuration:1.25];
-    else
+	else
 		[viewAnimation setDuration:0.25];
 
 	NSDictionary *fadeOutDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
-		oldView, NSViewAnimationTargetKey,
-		NSViewAnimationFadeOutEffect, NSViewAnimationEffectKey,
-		nil];
+														oldView, NSViewAnimationTargetKey,
+														NSViewAnimationFadeOutEffect, NSViewAnimationEffectKey,
+														nil];
 
 	NSDictionary *fadeInDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
-		newView, NSViewAnimationTargetKey,
-		NSViewAnimationFadeInEffect, NSViewAnimationEffectKey,
-		nil];
+													   newView, NSViewAnimationTargetKey,
+													   NSViewAnimationFadeInEffect, NSViewAnimationEffectKey,
+													   nil];
 
 	NSDictionary *resizeDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
-		[self window], NSViewAnimationTargetKey,
-		[NSValue valueWithRect:[[self window] frame]], NSViewAnimationStartFrameKey,
-		[NSValue valueWithRect:[self frameForView:newView]], NSViewAnimationEndFrameKey,
-		nil];
+													   [self window], NSViewAnimationTargetKey,
+													   [NSValue valueWithRect:[[self window] frame]], NSViewAnimationStartFrameKey,
+													   [NSValue valueWithRect:[self frameForView:newView]], NSViewAnimationEndFrameKey,
+													   nil];
 
 	NSArray *animationArray = [NSArray arrayWithObjects:
-		fadeOutDictionary,
-		fadeInDictionary,
-		resizeDictionary,
-		nil];
+										   fadeOutDictionary,
+										   fadeInDictionary,
+										   resizeDictionary,
+										   nil];
 
 	[viewAnimation setViewAnimations:animationArray];
 	[viewAnimation startAnimation];
 }
 
 
-
-
 - (void)animationDidEnd:(NSAnimation *)animation
 {
 	NSView *subview;
 
-		// Get a list of all of the views in the window. Hopefully
-		// at this point there are two. One is visible and one is hidden.
+	// Get a list of all of the views in the window. Hopefully
+	// at this point there are two. One is visible and one is hidden.
 	NSEnumerator *subviewsEnum = [[contentSubview subviews] reverseObjectEnumerator];
 
-		// This is our visible view. Just get past it.
+	// This is our visible view. Just get past it.
 	[subviewsEnum nextObject];
 
-		// Remove everything else. There should be just one, but
-		// if the user does a lot of fast clicking, we might have
-		// more than one to remove.
+	// Remove everything else. There should be just one, but
+	// if the user does a lot of fast clicking, we might have
+	// more than one to remove.
 	while ((subview = [subviewsEnum nextObject]) != nil) {
 		[subview removeFromSuperviewWithoutNeedingDisplay];
 	}
 
-		// This is a work-around that prevents the first
-		// toolbar icon from becoming highlighted.
+	// This is a work-around that prevents the first
+	// toolbar icon from becoming highlighted.
 	[[self window] makeFirstResponder:nil];
 
 	(void)animation;
 }
 
 
-
-
 - (NSRect)frameForView:(NSView *)view
-	// Calculate the window size for the new view.
+// Calculate the window size for the new view.
 {
 	NSRect windowFrame = [[self window] frame];
 	NSRect contentRect = [[self window] contentRectForFrameRect:windowFrame];
@@ -386,8 +340,6 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 }
 
 
-
-
 #pragma mark -
 #pragma mark Default View
 
@@ -396,8 +348,6 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 {
 	return [toolbarIdentifiers objectAtIndex:0];
 }
-
-
 
 
 @end

--- a/Classes/Controllers/OpenRecentController.h
+++ b/Classes/Controllers/OpenRecentController.h
@@ -9,20 +9,20 @@
 #import <Cocoa/Cocoa.h>
 
 
-@interface OpenRecentController : NSWindowController<NSTableViewDataSource, NSTableViewDelegate> {
-	IBOutlet NSSearchField* searchField;
-	NSURL* selectedResult;
-	IBOutlet NSTableView* resultViewer;	
+@interface OpenRecentController : NSWindowController <NSTableViewDataSource, NSTableViewDelegate> {
+	IBOutlet NSSearchField *searchField;
+	NSURL *selectedResult;
+	IBOutlet NSTableView *resultViewer;
 }
 
-@property (strong) NSMutableArray* currentResults;
-@property (strong) NSMutableArray* possibleResults;
+@property (strong) NSMutableArray *currentResults;
+@property (strong) NSMutableArray *possibleResults;
 
-- (void) hide;
-- (void) show;
+- (void)hide;
+- (void)show;
 
-- (IBAction)doSearch:(id) sender;
-- (IBAction)changeSelection:(id) sender;
+- (IBAction)doSearch:(id)sender;
+- (IBAction)changeSelection:(id)sender;
 - (IBAction)tableDoubleClick:(id)sender;
 
 

--- a/Classes/Controllers/OpenRecentController.m
+++ b/Classes/Controllers/OpenRecentController.m
@@ -19,90 +19,93 @@
 	self = [super initWithWindowNibName:@"OpenRecentPopup"];
 	if (!self)
 		return nil;
-	
+
 	currentResults = [NSMutableArray array];
-	
+
 	possibleResults = [NSMutableArray array];
 	for (NSURL *url in [[NSDocumentController sharedDocumentController] recentDocumentURLs]) {
 		if ([url checkResourceIsReachableAndReturnError:NULL]) {
-			[possibleResults addObject: url];
+			[possibleResults addObject:url];
 		}
 	}
-	
-	
+
+
 	return self;
 }
 
-- (void) show
+- (void)show
 {
 	[self doSearch:self];
 	[self.window makeKeyAndOrderFront:self];
 }
 
-- (void) hide
+- (void)hide
 {
 	[[self window] orderOut:self];
 }
 
-- (IBAction)doSearch:(id) sender
+- (IBAction)doSearch:(id)sender
 {
 	NSString *searchString = [searchField stringValue];
-	
-	while( [currentResults count] > 0 ) [currentResults removeLastObject];
-	
-    for(NSURL* url in possibleResults){
-		NSString* label = [url lastPathComponent];
-		if([searchString length] > 0) {
-			NSRange aRange = [label rangeOfString: searchString options: NSCaseInsensitiveSearch];
+
+	while ([currentResults count] > 0) [currentResults removeLastObject];
+
+	for (NSURL *url in possibleResults) {
+		NSString *label = [url lastPathComponent];
+		if ([searchString length] > 0) {
+			NSRange aRange = [label rangeOfString:searchString options:NSCaseInsensitiveSearch];
 			if (aRange.location == NSNotFound) continue;
 		}
-		[currentResults addObject: url];
-    }   
-	
-	if( [currentResults count] > 0 )
+		[currentResults addObject:url];
+	}
+
+	if ([currentResults count] > 0)
 		selectedResult = [currentResults objectAtIndex:0];
 	else
 		selectedResult = nil;
-	
+
 	[resultViewer reloadData];
 }
 
 - (void)awakeFromNib
 {
 	[super awakeFromNib];
-    [resultViewer setTarget:self];
-    [resultViewer setDoubleAction:@selector(tableDoubleClick:)];
+	[resultViewer setTarget:self];
+	[resultViewer setDoubleAction:@selector(tableDoubleClick:)];
 }
 
-- (IBAction) tableDoubleClick:(id)sender 
+- (IBAction)tableDoubleClick:(id)sender
 {
 	[self changeSelection:self];
-	if(selectedResult != nil) {
-		[[NSDocumentController sharedDocumentController] openDocumentWithContentsOfURL:selectedResult display:YES completionHandler:^(NSDocument * _Nullable document, BOOL documentWasAlreadyOpen, NSError * _Nullable error) {
+	if (selectedResult != nil) {
+		[[NSDocumentController sharedDocumentController] openDocumentWithContentsOfURL:selectedResult
+																			   display:YES
+																	 completionHandler:^(NSDocument *_Nullable document, BOOL documentWasAlreadyOpen, NSError *_Nullable error){
 
-		}];
+																	 }];
 	}
 	[self hide];
 }
 
-- (BOOL)control:(NSControl*)control textView:(NSTextView*)textView doCommandBySelector:(SEL)commandSelector {
-    BOOL result = NO;
-    if (commandSelector == @selector(insertNewline:)) {
-		if(selectedResult != nil) {
-			[[NSDocumentController sharedDocumentController] openDocumentWithContentsOfURL:selectedResult display:YES completionHandler:^(NSDocument * _Nullable document, BOOL documentWasAlreadyOpen, NSError * _Nullable error) {
+- (BOOL)control:(NSControl *)control textView:(NSTextView *)textView doCommandBySelector:(SEL)commandSelector
+{
+	BOOL result = NO;
+	if (commandSelector == @selector(insertNewline:)) {
+		if (selectedResult != nil) {
+			[[NSDocumentController sharedDocumentController] openDocumentWithContentsOfURL:selectedResult
+																				   display:YES
+																		 completionHandler:^(NSDocument *_Nullable document, BOOL documentWasAlreadyOpen, NSError *_Nullable error){
 
-			}];
+																		 }];
 		}
 		[self hide];
-//		[searchWindow makeKeyAndOrderFront: nil];
+		//		[searchWindow makeKeyAndOrderFront: nil];
 		result = YES;
-    }
-	else if(commandSelector == @selector(cancelOperation:)) {
+	} else if (commandSelector == @selector(cancelOperation:)) {
 		[self hide];
 		result = YES;
-	}
-	else if(commandSelector == @selector(moveUp:)) {
-		if(selectedResult != nil) {
+	} else if (commandSelector == @selector(moveUp:)) {
+		if (selectedResult != nil) {
 			NSUInteger index = [currentResults indexOfObject:selectedResult] - 1;
 			if (index > 0) {
 				index -= 1;
@@ -112,48 +115,47 @@
 			[resultViewer scrollRowToVisible:index];
 		}
 		result = YES;
-	}
-	else if(commandSelector == @selector(moveDown:)) {
-		if(selectedResult != nil) {
+	} else if (commandSelector == @selector(moveDown:)) {
+		if (selectedResult != nil) {
 			NSUInteger index = [currentResults indexOfObject:selectedResult] + 1;
-			if(index >= [currentResults count]) index = [currentResults count] - 1;
+			if (index >= [currentResults count]) index = [currentResults count] - 1;
 			selectedResult = [currentResults objectAtIndex:index];
 			[resultViewer selectRowIndexes:[NSIndexSet indexSetWithIndex:index] byExtendingSelection:FALSE];
 			[resultViewer scrollRowToVisible:index];
 		}
 		result = YES;
 	}
-    return result;
+	return result;
 }
 
 - (id)tableView:(NSTableView *)aTableView objectValueForTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex
-{	
-    id theValue = nil;
-    NSParameterAssert(rowIndex >= 0 && rowIndex < [currentResults count]);
-	
-    NSURL* row = [currentResults objectAtIndex:rowIndex];
-	if( [[aTableColumn identifier] isEqualToString: @"icon"] ) {
+{
+	id theValue = nil;
+	NSParameterAssert(rowIndex >= 0 && rowIndex < [currentResults count]);
+
+	NSURL *row = [currentResults objectAtIndex:rowIndex];
+	if ([[aTableColumn identifier] isEqualToString:@"icon"]) {
 		id icon;
-		NSError* error;
+		NSError *error;
 		[row getResourceValue:&icon forKey:NSURLEffectiveIconKey error:&error];
 		return icon;
-	} else if( [[aTableColumn identifier] isEqualToString: @"label"] ) {
+	} else if ([[aTableColumn identifier] isEqualToString:@"label"]) {
 		return [row lastPathComponent];
 	}
-    return theValue;
-	
+	return theValue;
 }
 
 - (NSInteger)numberOfRowsInTableView:(NSTableView *)aTableView
 {
-    return [currentResults count];
+	return [currentResults count];
 }
 
-- (IBAction)changeSelection:(id) sender {
+- (IBAction)changeSelection:(id)sender
+{
 	NSInteger i = resultViewer.selectedRow;
-	if(i >= 0 && i < currentResults.count)
-		selectedResult = [currentResults objectAtIndex: i];
-	else 
+	if (i >= 0 && i < currentResults.count)
+		selectedResult = [currentResults objectAtIndex:i];
+	else
 		selectedResult = nil;
 }
 

--- a/Classes/Controllers/PBDiffWindowController.m
+++ b/Classes/Controllers/PBDiffWindowController.m
@@ -30,11 +30,11 @@
 
 - (id)initWithDiff:(NSString *)aDiff
 {
-    self = [super initWithWindowNibName:@"PBDiffWindow"];
-    if (!self) return nil;
+	self = [super initWithWindowNibName:@"PBDiffWindow"];
+	if (!self) return nil;
 
 	_diff = aDiff;
-    
+
 	return self;
 }
 

--- a/Classes/Controllers/PBGitCommitController.h
+++ b/Classes/Controllers/PBGitCommitController.h
@@ -13,11 +13,11 @@
 
 @interface PBGitCommitController : PBViewController
 
-- (IBAction) refresh:(id) sender;
-- (IBAction) commit:(id) sender;
-- (IBAction) forceCommit:(id) sender;
-- (IBAction) signOff:(id)sender;
+- (IBAction)refresh:(id)sender;
+- (IBAction)commit:(id)sender;
+- (IBAction)forceCommit:(id)sender;
+- (IBAction)signOff:(id)sender;
 
-- (PBGitIndex *) index;
+- (PBGitIndex *)index;
 
 @end

--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -45,8 +45,8 @@
 
 @implementation PBGitCommitController
 
-@synthesize stagedTable=stagedTable;
-@synthesize unstagedTable=unstagedTable;
+@synthesize stagedTable = stagedTable;
+@synthesize unstagedTable = unstagedTable;
 
 - (id)initWithRepository:(PBGitRepository *)theRepository superController:(PBGitWindowController *)controller
 {
@@ -85,16 +85,20 @@
 
 	[unstagedFilesController setFilterPredicate:[NSPredicate predicateWithFormat:@"hasUnstagedChanges == 1"]];
 	[stagedFilesController setFilterPredicate:[NSPredicate predicateWithFormat:@"hasStagedChanges == 1"]];
-    [trackedFilesController setFilterPredicate:[NSPredicate predicateWithFormat:@"status > 0"]];
-	
-	[unstagedFilesController setSortDescriptors:[NSArray arrayWithObjects:
-		[[NSSortDescriptor alloc] initWithKey:@"status" ascending:false],
-		[[NSSortDescriptor alloc] initWithKey:@"path" ascending:true], nil]];
-	[stagedFilesController setSortDescriptors:[NSArray arrayWithObject:
-		[[NSSortDescriptor alloc] initWithKey:@"path" ascending:true]]];
+	[trackedFilesController setFilterPredicate:[NSPredicate predicateWithFormat:@"status > 0"]];
 
-    // listen for updates
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_repositoryUpdatedNotification:) name:PBGitRepositoryEventNotification object:repository];
+	[unstagedFilesController setSortDescriptors:[NSArray arrayWithObjects:
+															 [[NSSortDescriptor alloc] initWithKey:@"status"
+																						 ascending:false],
+															 [[NSSortDescriptor alloc] initWithKey:@"path"
+																						 ascending:true],
+															 nil]];
+	[stagedFilesController setSortDescriptors:[NSArray arrayWithObject:
+														   [[NSSortDescriptor alloc] initWithKey:@"path"
+																					   ascending:true]]];
+
+	// listen for updates
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_repositoryUpdatedNotification:) name:PBGitRepositoryEventNotification object:repository];
 
 	[stagedFilesController setAutomaticallyRearrangesObjects:NO];
 	[unstagedFilesController setAutomaticallyRearrangesObjects:NO];
@@ -105,30 +109,31 @@
 	[unstagedTable setTarget:self];
 	[stagedTable setTarget:self];
 
-	[unstagedTable registerForDraggedTypes: [NSArray arrayWithObject:FileChangesTableViewType]];
-	[stagedTable registerForDraggedTypes: [NSArray arrayWithObject:FileChangesTableViewType]];
+	[unstagedTable registerForDraggedTypes:[NSArray arrayWithObject:FileChangesTableViewType]];
+	[stagedTable registerForDraggedTypes:[NSArray arrayWithObject:FileChangesTableViewType]];
 
 	// Copy the menu over so we have two discrete menu objects
 	// which allows us to tell them apart in our delegate methods
 	stagedTable.menu = [unstagedTable.menu copy];
 }
 
-- (void) _repositoryUpdatedNotification:(NSNotification *)notification {
-    PBGitRepositoryWatcherEventType eventType = [(NSNumber *)[[notification userInfo] objectForKey:kPBGitRepositoryEventTypeUserInfoKey] unsignedIntValue];
-    if(eventType & (PBGitRepositoryWatcherEventTypeWorkingDirectory | PBGitRepositoryWatcherEventTypeIndex)){
-      // refresh if the working directory or index is modified
-      [self refresh:self];
-    }
+- (void)_repositoryUpdatedNotification:(NSNotification *)notification
+{
+	PBGitRepositoryWatcherEventType eventType = [(NSNumber *)[[notification userInfo] objectForKey:kPBGitRepositoryEventTypeUserInfoKey] unsignedIntValue];
+	if (eventType & (PBGitRepositoryWatcherEventTypeWorkingDirectory | PBGitRepositoryWatcherEventTypeIndex)) {
+		// refresh if the working directory or index is modified
+		[self refresh:self];
+	}
 }
 
-- (void) updateView
+- (void)updateView
 {
 	[self refresh:nil];
 }
 
 - (void)closeView
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	[webController closeView];
 }
 
@@ -137,27 +142,28 @@
 	return commitMessageView;
 }
 
-- (PBGitIndex *) index {
+- (PBGitIndex *)index
+{
 	return repository.index;
 }
 
-- (void) commitWithVerification:(BOOL) doVerify
+- (void)commitWithVerification:(BOOL)doVerify
 {
 	if ([[NSFileManager defaultManager] fileExistsAtPath:[repository.gitURL.path stringByAppendingPathComponent:@"MERGE_HEAD"]]) {
-		NSString * message = NSLocalizedString(@"Cannot commit merges",
-											   @"Title for sheet that GitX cannot create merge commits");
-		NSString * info = NSLocalizedString(@"GitX cannot commit merges yet. Please commit your changes from the command line.",
-											@"Information text for sheet that GitX cannot create merge commits");
+		NSString *message = NSLocalizedString(@"Cannot commit merges",
+											  @"Title for sheet that GitX cannot create merge commits");
+		NSString *info = NSLocalizedString(@"GitX cannot commit merges yet. Please commit your changes from the command line.",
+										   @"Information text for sheet that GitX cannot create merge commits");
 
 		[self.windowController showMessageSheet:message infoText:info];
 		return;
 	}
 
 	if ([[stagedFilesController arrangedObjects] count] == 0) {
-		NSString * message = NSLocalizedString(@"No changes to commit",
-											   @"Title for sheet that you need to stage changes before creating a commit");
-		NSString * info = NSLocalizedString(@"You need to stage some changed files before committing by moving them to the list of Staged Changes.",
-											@"Information text for sheet that you need to stage changes before creating a commit");
+		NSString *message = NSLocalizedString(@"No changes to commit",
+											  @"Title for sheet that you need to stage changes before creating a commit");
+		NSString *info = NSLocalizedString(@"You need to stage some changed files before committing by moving them to the list of Staged Changes.",
+										   @"Information text for sheet that you need to stage changes before creating a commit");
 
 		[self.windowController showMessageSheet:message infoText:info];
 		return;
@@ -165,13 +171,13 @@
 
 	NSString *commitMessage = [commitMessageView string];
 	if (commitMessage.length < kMinimalCommitMessageLength) {
-		NSString * message = NSLocalizedString(@"Missing commit message",
-											   @"Title for sheet that you need to enter a commit message before creating a commit");
-		NSString * info = [NSString stringWithFormat:
-						   NSLocalizedString(@"Please enter a commit message at least %i characters long before commiting.",
-											 @"Format for sheet that you need to enter a commit message before creating a commit giving the minimum length of the commit message required"),
-						   kMinimalCommitMessageLength ];
-		[self.windowController showMessageSheet:message infoText:info ];
+		NSString *message = NSLocalizedString(@"Missing commit message",
+											  @"Title for sheet that you need to enter a commit message before creating a commit");
+		NSString *info = [NSString stringWithFormat:
+									   NSLocalizedString(@"Please enter a commit message at least %i characters long before commiting.",
+														 @"Format for sheet that you need to enter a commit message before creating a commit giving the minimum length of the commit message required"),
+									   kMinimalCommitMessageLength];
+		[self.windowController showMessageSheet:message infoText:info];
 		return;
 	}
 
@@ -186,7 +192,7 @@
 
 - (void)discardChangesForFiles:(NSArray *)files force:(BOOL)force
 {
-	void (^performDiscard)(void) = ^ {
+	void (^performDiscard)(void) = ^{
 		[self.repository.index discardChangesForFiles:files];
 	};
 
@@ -222,17 +228,17 @@
 
 	NSString *SOBline = [NSString stringWithFormat:NSLocalizedString(@"Signed-off-by: %@ <%@>",
 																	 @"Signed off message format. Most likely this should not be localised."),
-						 userName,
-						 userEmail];
+												   userName,
+												   userEmail];
 
-	if([commitMessageView.string rangeOfString:SOBline].location == NSNotFound) {
+	if ([commitMessageView.string rangeOfString:SOBline].location == NSNotFound) {
 		NSArray *selectedRanges = [commitMessageView selectedRanges];
 		commitMessageView.string = [NSString stringWithFormat:@"%@\n\n%@", commitMessageView.string, SOBline];
 		[commitMessageView setSelectedRanges:selectedRanges];
 	}
 }
 
-- (IBAction) refresh:(id) sender
+- (IBAction)refresh:(id)sender
 {
 	self.isBusy = YES;
 	self.status = NSLocalizedString(@"Refreshing index…", @"Message in status bar while the index is refreshing");
@@ -242,14 +248,14 @@
 	[repository reloadRefs];
 }
 
-- (IBAction) commit:(id) sender
+- (IBAction)commit:(id)sender
 {
-    [self commitWithVerification:YES];
+	[self commitWithVerification:YES];
 }
 
-- (IBAction) forceCommit:(id) sender
+- (IBAction)forceCommit:(id)sender
 {
-    [self commitWithVerification:NO];
+	[self commitWithVerification:NO];
 }
 
 - (IBAction)toggleAmendCommit:(id)sender
@@ -257,7 +263,7 @@
 	[[[self repository] index] setAmend:![[[self repository] index] isAmend]];
 }
 
-- (NSArray <PBChangedFile *> *)selectedFilesForSender:(id)sender
+- (NSArray<PBChangedFile *> *)selectedFilesForSender:(id)sender
 {
 	NSParameterAssert(sender != nil);
 
@@ -270,9 +276,9 @@
 
 - (IBAction)openFiles:(id)sender
 {
-	NSArray <PBChangedFile *> *selectedFiles = [self selectedFilesForSender:sender];
+	NSArray<PBChangedFile *> *selectedFiles = [self selectedFilesForSender:sender];
 
-	NSMutableArray <NSURL *> *fileURLs = [NSMutableArray array];
+	NSMutableArray<NSURL *> *fileURLs = [NSMutableArray array];
 	NSURL *workingDirectoryURL = self.repository.workingDirectoryURL;
 	for (PBChangedFile *file in selectedFiles) {
 		[fileURLs addObject:[workingDirectoryURL URLByAppendingPathComponent:file.path]];
@@ -282,9 +288,9 @@
 
 - (IBAction)revealInFinder:(id)sender
 {
-	NSArray <PBChangedFile *> *selectedFiles = [self selectedFilesForSender:sender];
+	NSArray<PBChangedFile *> *selectedFiles = [self selectedFilesForSender:sender];
 
-	NSMutableArray <NSURL *> *fileURLs = [NSMutableArray array];
+	NSMutableArray<NSURL *> *fileURLs = [NSMutableArray array];
 	NSURL *workingDirectoryURL = self.repository.workingDirectoryURL;
 	for (PBChangedFile *file in selectedFiles) {
 		[fileURLs addObject:[workingDirectoryURL URLByAppendingPathComponent:file.path]];
@@ -294,7 +300,7 @@
 
 - (IBAction)moveToTrash:(id)sender
 {
-	NSArray <PBChangedFile *> *selectedFiles = [self selectedFilesForSender:sender];
+	NSArray<PBChangedFile *> *selectedFiles = [self selectedFilesForSender:sender];
 
 	NSURL *workingDirectoryURL = self.repository.workingDirectoryURL;
 
@@ -305,31 +311,30 @@
 	[confirmTrash addButtonWithTitle:NSLocalizedString(@"OK", @"Move to trash alert - OK button")];
 	[confirmTrash addButtonWithTitle:NSLocalizedString(@"Cancel", @"Move to trash alert - Cancel button")];
 
-	[self.windowController confirmDialog:confirmTrash suppressionIdentifier:nil forAction:^{
-		BOOL anyTrashed = NO;
-		for (PBChangedFile *file in selectedFiles)
-		{
-			NSURL* fileURL = [workingDirectoryURL URLByAppendingPathComponent:[file path]];
+	[self.windowController confirmDialog:confirmTrash
+				   suppressionIdentifier:nil
+							   forAction:^{
+								   BOOL anyTrashed = NO;
+								   for (PBChangedFile *file in selectedFiles) {
+									   NSURL *fileURL = [workingDirectoryURL URLByAppendingPathComponent:[file path]];
 
-			NSError* error = nil;
-			NSURL* resultURL = nil;
-			if ([[NSFileManager defaultManager] trashItemAtURL:fileURL
-											  resultingItemURL:&resultURL
-														 error:&error])
-			{
-				anyTrashed = YES;
-			}
-		}
-		if (anyTrashed)
-		{
-			[self.repository.index refresh];
-		}
-	}];
+									   NSError *error = nil;
+									   NSURL *resultURL = nil;
+									   if ([[NSFileManager defaultManager] trashItemAtURL:fileURL
+																		 resultingItemURL:&resultURL
+																					error:&error]) {
+										   anyTrashed = YES;
+									   }
+								   }
+								   if (anyTrashed) {
+									   [self.repository.index refresh];
+								   }
+							   }];
 }
 
-- (IBAction)ignoreFiles:(id) sender
+- (IBAction)ignoreFiles:(id)sender
 {
-	NSArray <PBChangedFile *> *selectedFiles = [self selectedFilesForSender:sender];
+	NSArray<PBChangedFile *> *selectedFiles = [self selectedFilesForSender:sender];
 	if ([selectedFiles count] == 0)
 		return;
 
@@ -358,12 +363,14 @@ static void reselectNextFile(NSArrayController *controller)
 	});
 }
 
-- (IBAction)stageFiles:(id)sender {
+- (IBAction)stageFiles:(id)sender
+{
 	[self.repository.index stageFiles:unstagedFilesController.selectedObjects];
 	reselectNextFile(unstagedFilesController);
 }
 
-- (IBAction)unstageFiles:(id)sender {
+- (IBAction)unstageFiles:(id)sender
+{
 	[self.repository.index unstageFiles:stagedFilesController.selectedObjects];
 	reselectNextFile(stagedFilesController);
 }
@@ -382,7 +389,7 @@ static void reselectNextFile(NSArrayController *controller)
 		[self discardChangesForFiles:selectedFiles force:TRUE];
 }
 
-# pragma mark PBGitIndex Notification handling
+#pragma mark PBGitIndex Notification handling
 
 - (void)refreshFinished:(NSNotification *)notification
 {
@@ -400,7 +407,7 @@ static void reselectNextFile(NSArrayController *controller)
 	commitMessageView.editable = YES;
 	commitMessageView.string = @"";
 	[webController setStateMessage:notification.userInfo[kNotificationDictionaryDescriptionKey]];
-}	
+}
 
 - (void)commitFailed:(NSNotification *)notification
 {
@@ -409,11 +416,11 @@ static void reselectNextFile(NSArrayController *controller)
 
 	NSString *reason = notification.userInfo[kNotificationDictionaryDescriptionKey];
 	self.status = [NSString stringWithFormat:
-				   NSLocalizedString(@"Commit failed: %@",
-									 @"Message in status bar when creating a commit has failed, including the reason for the failure"),
-				   reason];
+								NSLocalizedString(@"Commit failed: %@",
+												  @"Message in status bar when creating a commit has failed, including the reason for the failure"),
+								reason];
 	[self.windowController showMessageSheet:NSLocalizedString(@"Commit failed", @"Title for sheet that creating a commit has failed")
-										 infoText:reason];
+								   infoText:reason];
 }
 
 - (void)commitHookFailed:(NSNotification *)notification
@@ -423,12 +430,12 @@ static void reselectNextFile(NSArrayController *controller)
 
 	NSString *reason = notification.userInfo[kNotificationDictionaryDescriptionKey];
 	self.status = [NSString stringWithFormat:
-				   NSLocalizedString(@"Commit hook failed: %@",
-									 @"Message in status bar when running a commit hook failed, including the reason for the failure"),
-				   reason];
+								NSLocalizedString(@"Commit hook failed: %@",
+												  @"Message in status bar when running a commit hook failed, including the reason for the failure"),
+								reason];
 	[self.windowController showCommitHookFailedSheet:NSLocalizedString(@"Commit hook failed", @"Title for sheet that running a commit hook has failed")
-												  infoText:reason
-										  commitController:self];
+											infoText:reason
+									commitController:self];
 }
 
 - (void)amendCommit:(NSNotification *)notification
@@ -438,7 +445,7 @@ static void reselectNextFile(NSArrayController *controller)
 	if ([[commitMessageView string] length] > kMinimalCommitMessageLength) {
 		return;
 	}
-	
+
 	NSString *message = notification.userInfo[kNotificationDictionaryMessageKey];
 	commitMessageView.string = message;
 }
@@ -447,38 +454,38 @@ static void reselectNextFile(NSArrayController *controller)
 {
 	[stagedFilesController rearrangeObjects];
 	[unstagedFilesController rearrangeObjects];
-    
-    commitButton.enabled = ([[stagedFilesController arrangedObjects] count] > 0);
+
+	commitButton.enabled = ([[stagedFilesController arrangedObjects] count] > 0);
 }
 
 - (void)indexOperationFailed:(NSNotification *)notification
 {
 	[self.windowController showMessageSheet:NSLocalizedString(@"Index operation failed", @"Title for sheet that running an index operation has failed")
-										 infoText:notification.userInfo[kNotificationDictionaryDescriptionKey]];
+								   infoText:notification.userInfo[kNotificationDictionaryDescriptionKey]];
 }
 
 #pragma mark NSTextView delegate methods
 
 - (void)focusTable:(NSTableView *)table
 {
-    if ([table numberOfRows] > 0) {
-        if ([table numberOfSelectedRows] == 0) {
-            [table selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
-        }
-        [[table window] makeFirstResponder:table];
-    }
+	if ([table numberOfRows] > 0) {
+		if ([table numberOfSelectedRows] == 0) {
+			[table selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
+		}
+		[[table window] makeFirstResponder:table];
+	}
 }
 
 - (BOOL)textView:(NSTextView *)textView doCommandBySelector:(SEL)commandSelector;
 {
-    if (commandSelector == @selector(insertTab:)) {
-        [self focusTable:stagedTable];
-        return YES;
-    } else if (commandSelector == @selector(insertBacktab:)) {
-        [self focusTable:unstagedTable];
-        return YES;
+	if (commandSelector == @selector(insertTab:)) {
+		[self focusTable:stagedTable];
+		return YES;
+	} else if (commandSelector == @selector(insertBacktab:)) {
+		[self focusTable:unstagedTable];
+		return YES;
 	}
-    return NO;
+	return NO;
 }
 
 #pragma mark NSMenu delegate
@@ -487,8 +494,7 @@ NSString *PBLocalizedStringForArray(NSArray<PBChangedFile *> *array, NSString *s
 {
 	if (array.count == 0) {
 		return defaultString;
-	}
-	else if (array.count == 1) {
+	} else if (array.count == 1) {
 		return [NSString stringWithFormat:singleFormat, array.firstObject.path.lastPathComponent];
 	}
 	return [NSString stringWithFormat:multipleFormat, array.count];
@@ -496,29 +502,26 @@ NSString *PBLocalizedStringForArray(NSArray<PBChangedFile *> *array, NSString *s
 
 BOOL canDiscardAnyFileIn(NSArray<PBChangedFile *> *files)
 {
-	for (PBChangedFile *file in files)
-	{
-		if (file.hasUnstagedChanges)
-		{
+	for (PBChangedFile *file in files) {
+		if (file.hasUnstagedChanges) {
 			return YES;
 		}
 	}
 	return NO;
 }
 
-BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray <PBChangedFile *> *files)
+BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray<PBChangedFile *> *files)
 {
-	for (PBChangedFile *file in files)
-	{
-		if (file.status != NEW)
-		{
+	for (PBChangedFile *file in files) {
+		if (file.status != NEW) {
 			return NO;
 		}
 	}
 	return YES;
 }
 
-- (void)menuNeedsUpdate:(NSMenu *)menu {
+- (void)menuNeedsUpdate:(NSMenu *)menu
+{
 	for (NSMenuItem *item in menu.itemArray) {
 		[self validateMenuItem:item];
 	}
@@ -527,9 +530,9 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray <PBChangedFile *> *files)
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem
 {
 	NSTableView *table = (menuItem.menu == stagedTable.menu ? stagedTable : unstagedTable);
-	NSArray <PBChangedFile *> *filesForStaging = unstagedFilesController.selectedObjects;
-	NSArray <PBChangedFile *> *filesForUnstaging = stagedFilesController.selectedObjects;
-	NSArray <PBChangedFile *> *selectedFiles = (table.tag == 0 ? filesForStaging : filesForUnstaging);
+	NSArray<PBChangedFile *> *filesForStaging = unstagedFilesController.selectedObjects;
+	NSArray<PBChangedFile *> *filesForUnstaging = stagedFilesController.selectedObjects;
+	NSArray<PBChangedFile *> *selectedFiles = (table.tag == 0 ? filesForStaging : filesForUnstaging);
 	BOOL isInContextualMenu = (menuItem.parentItem == nil);
 
 	if (menuItem.action == @selector(stageFiles:)) {
@@ -542,8 +545,7 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray <PBChangedFile *> *files)
 			menuItem.hidden = (filesForStaging.count == 0);
 		}
 		return filesForStaging.count > 0;
-	}
-	else if (menuItem.action == @selector(unstageFiles:)) {
+	} else if (menuItem.action == @selector(unstageFiles:)) {
 		if (isInContextualMenu) {
 			menuItem.title = PBLocalizedStringForArray(filesForUnstaging,
 													   NSLocalizedString(@"Unstage “%@”", @"Unstage file menu item (single file with name)"),
@@ -553,8 +555,7 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray <PBChangedFile *> *files)
 			menuItem.hidden = (filesForUnstaging.count == 0);
 		}
 		return filesForUnstaging.count > 0;
-	}
-	else if (menuItem.action == @selector(discardFiles:)) {
+	} else if (menuItem.action == @selector(discardFiles:)) {
 		if (isInContextualMenu) {
 			menuItem.title = PBLocalizedStringForArray(filesForStaging,
 													   NSLocalizedString(@"Discard changes to “%@”…", @"Discard changes menu item (single file with name)"),
@@ -564,8 +565,7 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray <PBChangedFile *> *files)
 			menuItem.hidden = shouldTrashInsteadOfDiscardAnyFileIn(filesForStaging);
 		}
 		return filesForStaging.count > 0 && canDiscardAnyFileIn(filesForStaging);
-	}
-	else if (menuItem.action == @selector(discardFilesForcibly:)) {
+	} else if (menuItem.action == @selector(discardFilesForcibly:)) {
 		if (isInContextualMenu) {
 			menuItem.title = PBLocalizedStringForArray(filesForStaging,
 													   NSLocalizedString(@"Discard changes to “%@”", @"Force Discard changes menu item (single file with name)"),
@@ -577,8 +577,7 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray <PBChangedFile *> *files)
 			menuItem.alternate = !shouldHide;
 		}
 		return filesForStaging.count > 0 && canDiscardAnyFileIn(filesForStaging);
-	}
-	else if (menuItem.action == @selector(moveToTrash:)) {
+	} else if (menuItem.action == @selector(moveToTrash:)) {
 		if (isInContextualMenu) {
 			menuItem.title = PBLocalizedStringForArray(filesForStaging,
 													   NSLocalizedString(@"Move “%@” to Trash", @"Move to Trash menu item (single file with name)"),
@@ -588,15 +587,14 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray <PBChangedFile *> *files)
 			menuItem.hidden = !isVisible;
 		}
 		return filesForStaging.count > 0 && canDiscardAnyFileIn(filesForStaging);
-	}
-	else if (menuItem.action == @selector(openFiles:)) {
+	} else if (menuItem.action == @selector(openFiles:)) {
 		if (selectedFiles.count == 0) return NO;
 
 		NSString *filePath = selectedFiles.firstObject.path;
 		if (isInContextualMenu) {
 			if (selectedFiles.count == 1 && [self.repository submoduleAtPath:filePath error:NULL] != nil) {
 				menuItem.title = [NSString stringWithFormat:NSLocalizedString(@"Open Submodule “%@” in GitX", @"Open Submodule Repository in GitX menu item (single file with name)"),
-								  filePath.stringByStandardizingPath];
+															filePath.stringByStandardizingPath];
 			} else {
 				menuItem.title = PBLocalizedStringForArray(selectedFiles,
 														   NSLocalizedString(@"Open “%@”", @"Open File menu item (single file with name)"),
@@ -605,8 +603,7 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray <PBChangedFile *> *files)
 			}
 		}
 		return YES;
-	}
-	else if (menuItem.action == @selector(ignoreFiles:)) {
+	} else if (menuItem.action == @selector(ignoreFiles:)) {
 		BOOL isActive = selectedFiles.count > 0 && table.tag == 0;
 		if (isInContextualMenu) {
 			menuItem.title = PBLocalizedStringForArray(selectedFiles,
@@ -616,21 +613,19 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray <PBChangedFile *> *files)
 			menuItem.hidden = !isActive;
 		}
 		return isActive;
-	}
-	else if (menuItem.action == @selector(revealInFinder:)) {
+	} else if (menuItem.action == @selector(revealInFinder:)) {
 		BOOL active = selectedFiles.count == 1;
 		if (isInContextualMenu) {
 			if (active) {
 				menuItem.title = [NSString stringWithFormat:NSLocalizedString(@"Reveal “%@” in Finder", @"Reveal File in Finder contextual menu item (single file with name)"),
-								  selectedFiles.firstObject.path.lastPathComponent];
+															selectedFiles.firstObject.path.lastPathComponent];
 			} else {
 				menuItem.title = NSLocalizedString(@"Reveal in Finder", @"Reveal File in Finder contextual menu item (empty selection)");
 			}
 			menuItem.hidden = !active;
 		}
 		return active;
-	}
-	else if (menuItem.action == @selector(toggleAmendCommit:)) {
+	} else if (menuItem.action == @selector(toggleAmendCommit:)) {
 		menuItem.state = [[[self repository] index] isAmend] ? NSOnState : NSOffState;
 		return YES;
 	}
@@ -640,13 +635,13 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray <PBChangedFile *> *files)
 
 #pragma mark PBFileChangedTableView delegate
 
-- (void)tableView:(NSTableView*)tableView willDisplayCell:(id)cell forTableColumn:(NSTableColumn*)tableColumn row:(NSInteger)rowIndex
+- (void)tableView:(NSTableView *)tableView willDisplayCell:(id)cell forTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)rowIndex
 {
 	id controller = [tableView tag] == 0 ? unstagedFilesController : stagedFilesController;
 	[[tableColumn dataCell] setImage:[[[controller arrangedObjects] objectAtIndex:rowIndex] icon]];
 }
 
-- (void) didDoubleClickOnTable:(NSTableView *) tableView
+- (void)didDoubleClickOnTable:(NSTableView *)tableView
 {
 	NSArrayController *controller = (tableView == unstagedTable ? unstagedFilesController : stagedFilesController);
 
@@ -660,7 +655,7 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray <PBChangedFile *> *files)
 	}
 }
 
-- (BOOL) tableView:(NSTableView *)tv writeRowsWithIndexes:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard*)pboard
+- (BOOL)tableView:(NSTableView *)tv writeRowsWithIndexes:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard
 {
 	// Copy the row numbers to the pasteboard.
 	[pboard declareTypes:[NSArray arrayWithObjects:FileChangesTableViewType, NSFilenamesPboardType, nil] owner:self];
@@ -683,8 +678,8 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray <PBChangedFile *> *files)
 	return YES;
 }
 
-- (NSDragOperation)tableView:(NSTableView*)tableView
-				validateDrop:(id <NSDraggingInfo>)info
+- (NSDragOperation)tableView:(NSTableView *)tableView
+				validateDrop:(id<NSDraggingInfo>)info
 				 proposedRow:(NSInteger)row
 	   proposedDropOperation:(NSTableViewDropOperation)operation
 {
@@ -696,21 +691,20 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray <PBChangedFile *> *files)
 }
 
 - (BOOL)tableView:(NSTableView *)aTableView
-	   acceptDrop:(id <NSDraggingInfo>)info
+	   acceptDrop:(id<NSDraggingInfo>)info
 			  row:(NSInteger)row
 	dropOperation:(NSTableViewDropOperation)operation
 {
-	NSPasteboard* pboard = [info draggingPasteboard];
-	NSData* rowData = [pboard dataForType:FileChangesTableViewType];
-	NSIndexSet* rowIndexes = [NSKeyedUnarchiver unarchiveObjectWithData:rowData];
+	NSPasteboard *pboard = [info draggingPasteboard];
+	NSData *rowData = [pboard dataForType:FileChangesTableViewType];
+	NSIndexSet *rowIndexes = [NSKeyedUnarchiver unarchiveObjectWithData:rowData];
 
 	NSArrayController *controller = [aTableView tag] == 0 ? stagedFilesController : unstagedFilesController;
 	NSArray *files = [[controller arrangedObjects] objectsAtIndexes:rowIndexes];
 
 	if ([aTableView tag] == 0) {
 		[self.index unstageFiles:files];
-	}
-	else {
+	} else {
 		[self.index stageFiles:files];
 	}
 

--- a/Classes/Controllers/PBGitHistoryController.h
+++ b/Classes/Controllers/PBGitHistoryController.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) PBHistorySearchController *searchController;
 
 @property (assign) NSInteger selectedCommitDetailsIndex;
-@property PBGitTree* gitTree;
+@property PBGitTree *gitTree;
 @property NSArray<PBGitCommit *> *webCommits;
 @property NSArray<PBGitCommit *> *selectedCommits;
 
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)hasNonlinearPath;
 - (NSMenu *)tableColumnMenu;
 - (void)selectCommit:(GTOID *)commit;
-- (void)updateQuicklookForce: (BOOL) force;
+- (void)updateQuicklookForce:(BOOL)force;
 
 - (void)setHistorySearch:(NSString *)searchString mode:(PBHistorySearchMode)mode;
 
@@ -77,4 +77,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-

--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -58,9 +58,9 @@
 	NSArray<PBGitCommit *> *selectedCommits;
 }
 
-- (void) updateBranchFilterMatrix;
-- (void) restoreFileBrowserSelection;
-- (void) saveFileBrowserSelection;
+- (void)updateBranchFilterMatrix;
+- (void)restoreFileBrowserSelection;
+- (void)saveFileBrowserSelection;
 
 @end
 
@@ -80,55 +80,77 @@
 	 */
 }
 
-- (void)loadView {
+- (void)loadView
+{
 	[super loadView];
 
 	[historySplitView pb_restoreAutosavedPositions];
 
 	self.selectedCommitDetailsIndex = [[NSUserDefaults standardUserDefaults] integerForKey:kHistorySelectedDetailIndexKey];
 
-	[commitController addObserver:self keyPath:@"selection" options:0 block:^(MAKVONotification *notification) {
-		PBGitHistoryController *observer = notification.observer;
-		[observer updateKeys];
-	}];
+	[commitController addObserver:self
+						  keyPath:@"selection"
+						  options:0
+							block:^(MAKVONotification *notification) {
+								PBGitHistoryController *observer = notification.observer;
+								[observer updateKeys];
+							}];
 
-	[commitController addObserver:self keyPath:@"arrangedObjects.@count" options:NSKeyValueObservingOptionInitial block:^(MAKVONotification *notification) {
-		PBGitHistoryController *observer = notification.observer;
-		[observer reselectCommitAfterUpdate];
-	}];
+	[commitController addObserver:self
+						  keyPath:@"arrangedObjects.@count"
+						  options:NSKeyValueObservingOptionInitial
+							block:^(MAKVONotification *notification) {
+								PBGitHistoryController *observer = notification.observer;
+								[observer reselectCommitAfterUpdate];
+							}];
 
-	[treeController addObserver:self keyPath:@"selection" options:0 block:^(MAKVONotification *notification) {
-		PBGitHistoryController *observer = notification.observer;
-		[observer updateQuicklookForce: NO];
-		[observer saveFileBrowserSelection];
-	}];
+	[treeController addObserver:self
+						keyPath:@"selection"
+						options:0
+						  block:^(MAKVONotification *notification) {
+							  PBGitHistoryController *observer = notification.observer;
+							  [observer updateQuicklookForce:NO];
+							  [observer saveFileBrowserSelection];
+						  }];
 
-	[repository.revisionList addObserver:self keyPath:@"isUpdating" options:0 block:^(MAKVONotification *notification) {
-		PBGitHistoryController *observer = notification.observer;
-		[observer reselectCommitAfterUpdate];
-	}];
+	[repository.revisionList addObserver:self
+								 keyPath:@"isUpdating"
+								 options:0
+								   block:^(MAKVONotification *notification) {
+									   PBGitHistoryController *observer = notification.observer;
+									   [observer reselectCommitAfterUpdate];
+								   }];
 
-	[repository addObserver:self keyPath:@"currentBranch" options:0 block:^(MAKVONotification *notification) {
-		PBGitHistoryController *observer = notification.observer;
-		// Reset the sorting
-		if ([[observer.commitController sortDescriptors] count]) {
-			[observer.commitController setSortDescriptors:[NSArray array]];
-			[observer.commitController rearrangeObjects];
-		}
+	[repository addObserver:self
+					keyPath:@"currentBranch"
+					options:0
+					  block:^(MAKVONotification *notification) {
+						  PBGitHistoryController *observer = notification.observer;
+						  // Reset the sorting
+						  if ([[observer.commitController sortDescriptors] count]) {
+							  [observer.commitController setSortDescriptors:[NSArray array]];
+							  [observer.commitController rearrangeObjects];
+						  }
 
-		[observer updateBranchFilterMatrix];
-	}];
+						  [observer updateBranchFilterMatrix];
+					  }];
 
-	[repository addObserver:self keyPath:@"refs" options:0 block:^(MAKVONotification *notification) {
-		PBGitHistoryController *observer = notification.observer;
-		[observer.commitController rearrangeObjects];
-	}];
+	[repository addObserver:self
+					keyPath:@"refs"
+					options:0
+					  block:^(MAKVONotification *notification) {
+						  PBGitHistoryController *observer = notification.observer;
+						  [observer.commitController rearrangeObjects];
+					  }];
 
-	[repository addObserver:self keyPath:@"currentBranchFilter" options:0 block:^(MAKVONotification *notification) {
-		PBGitHistoryController *observer = notification.observer;
-		[PBGitDefaults setBranchFilter:observer.repository.currentBranchFilter];
-		[observer updateBranchFilterMatrix];
-	}];
+	[repository addObserver:self
+					keyPath:@"currentBranchFilter"
+					options:0
+					  block:^(MAKVONotification *notification) {
+						  PBGitHistoryController *observer = notification.observer;
+						  [PBGitDefaults setBranchFilter:observer.repository.currentBranchFilter];
+						  [observer updateBranchFilterMatrix];
+					  }];
 
 	forceSelectionUpdate = YES;
 	NSSize cellSpacing = [commitList intercellSpacing];
@@ -140,15 +162,13 @@
 	if (!repository.currentBranch) {
 		[repository reloadRefs];
 		[repository readCurrentBranch];
-	}
-	else
+	} else
 		[repository lazyReload];
 
-    if (![repository hasSVNRemote])
-    {
-        // Remove the SVN revision table column for repositories with no SVN remote configured
-        [commitList removeTableColumn:[commitList tableColumnWithIdentifier:@"GitSVNRevision"]];
-    }
+	if (![repository hasSVNRemote]) {
+		// Remove the SVN revision table column for repositories with no SVN remote configured
+		[commitList removeTableColumn:[commitList tableColumnWithIdentifier:@"GitSVNRevision"]];
+	}
 
 	// Set a sort descriptor for the subject column in the history list, as
 	// It can't be sorted by default (because it's bound to a PBGitCommit)
@@ -158,7 +178,7 @@
 
 	[commitList registerForDraggedTypes:[NSArray arrayWithObject:@"PBGitRef"]];
 
-	[upperToolbarView setTopShade:237/255.0f bottomShade:216/255.0f];
+	[upperToolbarView setTopShade:237 / 255.0f bottomShade:216 / 255.0f];
 	[scopeBarView setTopColor:[NSColor colorWithCalibratedHue:0.579 saturation:0.068 brightness:0.898 alpha:1.000]
 				  bottomColor:[NSColor colorWithCalibratedHue:0.579 saturation:0.119 brightness:0.765 alpha:1.000]];
 	[self updateBranchFilterMatrix];
@@ -169,15 +189,17 @@
 	[super awakeFromNib];
 }
 
-- (void) _repositoryUpdatedNotification:(NSNotification *)notification {
-    PBGitRepositoryWatcherEventType eventType = [(NSNumber *)[[notification userInfo] objectForKey:kPBGitRepositoryEventTypeUserInfoKey] unsignedIntValue];
-    if(eventType & PBGitRepositoryWatcherEventTypeGitDirectory){
-      // refresh if the .git repository is modified
-      [self refresh:self];
-    }
+- (void)_repositoryUpdatedNotification:(NSNotification *)notification
+{
+	PBGitRepositoryWatcherEventType eventType = [(NSNumber *)[[notification userInfo] objectForKey:kPBGitRepositoryEventTypeUserInfoKey] unsignedIntValue];
+	if (eventType & PBGitRepositoryWatcherEventTypeGitDirectory) {
+		// refresh if the .git repository is modified
+		[self refresh:self];
+	}
 }
 
-- (void)reselectCommitAfterUpdate {
+- (void)reselectCommitAfterUpdate
+{
 	[self updateStatus];
 
 	if ([self.repository.currentBranch isSimpleRef])
@@ -186,9 +208,10 @@
 		[self selectCommit:self.firstCommit.OID];
 }
 
-- (NSTableRowView *)tableView:(NSTableView *)tableView rowViewForRow:(NSInteger)row {
+- (NSTableRowView *)tableView:(NSTableView *)tableView rowViewForRow:(NSInteger)row
+{
 	NSTableRowView *view = [tableView rowViewAtRow:row makeIfNecessary:NO];
-	
+
 	if (view) {
 		return view;
 	}
@@ -200,20 +223,19 @@
 	return rowView;
 }
 
-- (void) updateKeys
+- (void)updateKeys
 {
 	NSArray<PBGitCommit *> *newSelectedCommits = commitController.selectedObjects;
-	if  (![self.selectedCommits isEqualToArray:newSelectedCommits]) {
+	if (![self.selectedCommits isEqualToArray:newSelectedCommits]) {
 		self.selectedCommits = newSelectedCommits;
 	}
-	
+
 	PBGitCommit *firstSelectedCommit = self.selectedCommits.firstObject;
-	
+
 	if (self.selectedCommitDetailsIndex == kHistoryTreeViewIndex) {
 		self.gitTree = firstSelectedCommit.tree;
 		[self restoreFileBrowserSelection];
-	}
-	else {
+	} else {
 		// kHistoryDetailViewIndex
 		if (![self.webCommits isEqualToArray:self.selectedCommits]) {
 			self.webCommits = self.selectedCommits;
@@ -221,26 +243,27 @@
 	}
 }
 
-- (BOOL) singleCommitSelected
+- (BOOL)singleCommitSelected
 {
 	return self.selectedCommits.count == 1;
 }
 
-+ (NSSet *) keyPathsForValuesAffectingSingleCommitSelected {
++ (NSSet *)keyPathsForValuesAffectingSingleCommitSelected
+{
 	return [NSSet setWithObjects:@"selectedCommits", nil];
 }
 
-- (BOOL) singleNonHeadCommitSelected
+- (BOOL)singleNonHeadCommitSelected
 {
-	return self.singleCommitSelected
-		&& ![self.selectedCommits.firstObject isOnHeadBranch];
+	return self.singleCommitSelected && ![self.selectedCommits.firstObject isOnHeadBranch];
 }
 
-+ (NSSet *) keyPathsForValuesAffectingSingleNonHeadCommitSelected {
++ (NSSet *)keyPathsForValuesAffectingSingleNonHeadCommitSelected
+{
 	return [self keyPathsForValuesAffectingSingleCommitSelected];
 }
 
-- (void) updateBranchFilterMatrix
+- (void)updateBranchFilterMatrix
 {
 	if ([repository.currentBranch isSimpleRef]) {
 		[allBranchesFilterItem setEnabled:YES];
@@ -250,8 +273,7 @@
 		[allBranchesFilterItem setState:(filter == kGitXAllBranchesFilter)];
 		[localRemoteBranchesFilterItem setState:(filter == kGitXLocalRemoteBranchesFilter)];
 		[selectedBranchFilterItem setState:(filter == kGitXSelectedBranchFilter)];
-	}
-	else {
+	} else {
 		[allBranchesFilterItem setState:NO];
 		[localRemoteBranchesFilterItem setState:NO];
 
@@ -264,12 +286,10 @@
 	[selectedBranchFilterItem setTitle:[repository.currentBranch title]];
 	[selectedBranchFilterItem sizeToFit];
 
-	[localRemoteBranchesFilterItem setTitle:[[repository.currentBranch ref] isRemote]
-		? NSLocalizedString(@"Remote", @"Filter button for all remote commits in history view")
-		: NSLocalizedString(@"Local", @"Filter button for all local commits in history view")];
+	[localRemoteBranchesFilterItem setTitle:[[repository.currentBranch ref] isRemote] ? NSLocalizedString(@"Remote", @"Filter button for all remote commits in history view") : NSLocalizedString(@"Local", @"Filter button for all local commits in history view")];
 }
 
-- (PBGitCommit *) firstCommit
+- (PBGitCommit *)firstCommit
 {
 	NSArray *arrangedObjects = [commitController arrangedObjects];
 	if ([arrangedObjects count] > 0)
@@ -283,7 +303,7 @@
 	return [self.selectedCommits isEqualToArray:[commitController selectedObjects]];
 }
 
-- (void) setSelectedCommitDetailsIndex:(NSInteger)detailsIndex
+- (void)setSelectedCommitDetailsIndex:(NSInteger)detailsIndex
 {
 	if (selectedCommitDetailsIndex == detailsIndex)
 		return;
@@ -294,18 +314,18 @@
 	[self updateKeys];
 }
 
-- (NSInteger) selectedCommitDetailsIndex
+- (NSInteger)selectedCommitDetailsIndex
 {
 	return selectedCommitDetailsIndex;
 }
 
-- (void) updateStatus
+- (void)updateStatus
 {
 	self.isBusy = repository.revisionList.isUpdating;
 	self.status = [NSString stringWithFormat:@"%lu commits loaded", [[commitController arrangedObjects] count]];
 }
 
-- (void) restoreFileBrowserSelection
+- (void)restoreFileBrowserSelection
 {
 	if (self.selectedCommitDetailsIndex != kHistoryTreeViewIndex)
 		return;
@@ -337,7 +357,7 @@
 	[treeController setSelectionIndexPath:path];
 }
 
-- (void) saveFileBrowserSelection
+- (void)saveFileBrowserSelection
 {
 	NSArray *objects = [treeController selectedObjects];
 	NSArray *content = [treeController content];
@@ -348,13 +368,13 @@
 	}
 }
 
-- (IBAction) openSelectedFile:(id)sender
+- (IBAction)openSelectedFile:(id)sender
 {
-	NSArray* selectedFiles = [treeController selectedObjects];
+	NSArray *selectedFiles = [treeController selectedObjects];
 	if ([selectedFiles count] == 0)
 		return;
-	PBGitTree* tree = [selectedFiles objectAtIndex:0];
-	NSString* name = [tree tmpFileNameForContents];
+	PBGitTree *tree = [selectedFiles objectAtIndex:0];
+	NSString *name = [tree tmpFileNameForContents];
 	[[NSWorkspace sharedWorkspace] openFile:name];
 }
 
@@ -362,56 +382,53 @@
 {
 	SEL action = menuItem.action;
 
-    if (action == @selector(setDetailedView:)) {
+	if (action == @selector(setDetailedView:)) {
 		[menuItem setState:(self.selectedCommitDetailsIndex == kHistoryDetailViewIndex) ? NSOnState : NSOffState];
-    } else if (action == @selector(setTreeView:)) {
+	} else if (action == @selector(setTreeView:)) {
 		[menuItem setState:(self.selectedCommitDetailsIndex == kHistoryTreeViewIndex) ? NSOnState : NSOffState];
 	}
-	
+
 	if ([self respondsToSelector:action]) {
 		if (action == @selector(createBranch:) || action == @selector(createTag:)) {
 			return self.singleCommitSelected;
 		}
-		
-        return YES;
+
+		return YES;
 	}
 
-	if (action == @selector(copy:)
-		|| action == @selector(copySHA:)
-		|| action == @selector(copyShortName:)
-		|| action == @selector(copyPatch:)) {
+	if (action == @selector(copy:) || action == @selector(copySHA:) || action == @selector(copyShortName:) || action == @selector(copyPatch:)) {
 		return self.commitController.selectedObjects.count > 0;
 	}
-	
-    return [[self nextResponder] validateMenuItem:menuItem];
+
+	return [[self nextResponder] validateMenuItem:menuItem];
 }
 
-- (IBAction) setDetailedView:(id)sender
+- (IBAction)setDetailedView:(id)sender
 {
 	self.selectedCommitDetailsIndex = kHistoryDetailViewIndex;
 	forceSelectionUpdate = YES;
 }
 
-- (IBAction) setTreeView:(id)sender
+- (IBAction)setTreeView:(id)sender
 {
 	self.selectedCommitDetailsIndex = kHistoryTreeViewIndex;
 	forceSelectionUpdate = YES;
 }
 
-- (IBAction) setBranchFilter:(id)sender
+- (IBAction)setBranchFilter:(id)sender
 {
-	repository.currentBranchFilter = [(NSView*)sender tag];
+	repository.currentBranchFilter = [(NSView *)sender tag];
 	[PBGitDefaults setBranchFilter:repository.currentBranchFilter];
 	[self updateBranchFilterMatrix];
 	forceSelectionUpdate = YES;
 }
 
-- (void)keyDown:(NSEvent*)event
+- (void)keyDown:(NSEvent *)event
 {
-	if ([[event charactersIgnoringModifiers] isEqualToString: @"f"] && [event modifierFlags] & NSAlternateKeyMask && [event modifierFlags] & NSCommandKeyMask)
-		[superController.window makeFirstResponder: searchField];
+	if ([[event charactersIgnoringModifiers] isEqualToString:@"f"] && [event modifierFlags] & NSAlternateKeyMask && [event modifierFlags] & NSCommandKeyMask)
+		[superController.window makeFirstResponder:searchField];
 	else
-		[super keyDown: event];
+		[super keyDown:event];
 }
 
 - (void)setHistorySearch:(NSString *)searchString mode:(PBHistorySearchMode)mode
@@ -448,14 +465,14 @@
 	[searchController selectPreviousResult];
 }
 
-- (IBAction) selectParentCommit:(id)sender
+- (IBAction)selectParentCommit:(id)sender
 {
 	NSArray *selectedObjects = commitController.selectedObjects;
 	if (selectedObjects.count != 1) return;
 
 	PBGitCommit *selectedCommit = selectedObjects[0];
 
-	NSArray <GTOID *> *parents = selectedCommit.parents;
+	NSArray<GTOID *> *parents = selectedCommit.parents;
 	/* TODO: This is a merge commit. It would be nice to choose the parent with
 	 * the most commits, but for now we will use whatever commit is our first parent.
 	 */
@@ -463,27 +480,27 @@
 	[self selectCommit:parents[0]];
 }
 
-- (IBAction) copy:(id)sender
+- (IBAction)copy:(id)sender
 {
 	[GitXCommitCopier putStringToPasteboard:[GitXCommitCopier toSHAAndHeadingString:commitController.selectedObjects]];
 }
 
-- (IBAction) copySHA:(id)sender
+- (IBAction)copySHA:(id)sender
 {
 	[GitXCommitCopier putStringToPasteboard:[GitXCommitCopier toFullSHA:commitController.selectedObjects]];
 }
 
-- (IBAction) copyShortName:(id)sender
+- (IBAction)copyShortName:(id)sender
 {
 	[GitXCommitCopier putStringToPasteboard:[GitXCommitCopier toShortName:commitController.selectedObjects]];
 }
 
-- (IBAction) copyPatch:(id)sender
+- (IBAction)copyPatch:(id)sender
 {
 	[GitXCommitCopier putStringToPasteboard:[GitXCommitCopier toPatch:commitController.selectedObjects]];
 }
 
-- (IBAction) toggleQLPreviewPanel:(id)sender
+- (IBAction)toggleQLPreviewPanel:(id)sender
 {
 	if ([QLPreviewPanel sharedPreviewPanelExists] && [[QLPreviewPanel sharedPreviewPanel] isVisible])
 		[[QLPreviewPanel sharedPreviewPanel] orderOut:nil];
@@ -491,7 +508,7 @@
 		[[QLPreviewPanel sharedPreviewPanel] makeKeyAndOrderFront:nil];
 }
 
-- (void) updateQuicklookForce:(BOOL)force
+- (void)updateQuicklookForce:(BOOL)force
 {
 	if (!force && (![QLPreviewPanel sharedPreviewPanelExists] || ![[QLPreviewPanel sharedPreviewPanel] isVisible]))
 		return;
@@ -499,12 +516,12 @@
 	[[QLPreviewPanel sharedPreviewPanel] reloadData];
 }
 
-- (IBAction) refresh:(id)sender
+- (IBAction)refresh:(id)sender
 {
 	[repository forceUpdateRevisions];
 }
 
-- (void) updateView
+- (void)updateView
 {
 	[self updateKeys];
 }
@@ -514,7 +531,7 @@
 	return commitList;
 }
 
-- (void) scrollSelectionToTopOfViewFrom:(NSInteger)oldIndex
+- (void)scrollSelectionToTopOfViewFrom:(NSInteger)oldIndex
 {
 	if (oldIndex == NSNotFound)
 		oldIndex = 0;
@@ -522,31 +539,31 @@
 	NSInteger newIndex = commitController.selectionIndexes.firstIndex;
 
 	if (newIndex > oldIndex) {
-        CGFloat sviewHeight = commitList.superview.bounds.size.height;
-        CGFloat rowHeight = commitList.rowHeight;
+		CGFloat sviewHeight = commitList.superview.bounds.size.height;
+		CGFloat rowHeight = commitList.rowHeight;
 		NSInteger visibleRows = lround(sviewHeight / rowHeight);
 		newIndex += (visibleRows - 1);
 		if (newIndex >= [commitController.content count])
 			newIndex = [commitController.content count] - 1;
 	}
 
-    if (newIndex != oldIndex) {
-        commitList.useAdjustScroll = YES;
-    }
+	if (newIndex != oldIndex) {
+		commitList.useAdjustScroll = YES;
+	}
 
 	[commitList scrollRowToVisible:newIndex];
-    commitList.useAdjustScroll = NO;
+	commitList.useAdjustScroll = NO;
 }
 
-- (NSArray *) selectedObjectsForOID:(GTOID *)commitOID
+- (NSArray *)selectedObjectsForOID:(GTOID *)commitOID
 {
 	NSPredicate *selection = [NSPredicate predicateWithFormat:@"OID == %@", commitOID];
 	NSArray *selectionCommits = [[commitController content] filteredArrayUsingPredicate:selection];
 
 	if ((selectionCommits.count == 0) && [self firstCommit] != nil) {
-		selectionCommits = @[[self firstCommit]];
+		selectionCommits = @[ [self firstCommit] ];
 	}
-	
+
 	return selectionCommits;
 }
 
@@ -565,7 +582,7 @@
 	forceSelectionUpdate = NO;
 }
 
-- (BOOL) hasNonlinearPath
+- (BOOL)hasNonlinearPath
 {
 	return [commitController filterPredicate] || [[commitController sortDescriptors] count] > 0;
 }
@@ -588,9 +605,9 @@
 		NSMenuItem *item = [[NSMenuItem alloc] init];
 		[item setTitle:[[column headerCell] stringValue]];
 		[item bind:@"value"
-		  toObject:column
-	   withKeyPath:@"hidden"
-		   options:[NSDictionary dictionaryWithObject:@"NSNegateBoolean" forKey:NSValueTransformerNameBindingOption]];
+			   toObject:column
+			withKeyPath:@"hidden"
+				options:[NSDictionary dictionaryWithObject:@"NSNegateBoolean" forKey:NSValueTransformerNameBindingOption]];
 		[menu addItem:item];
 	}
 	return menu;
@@ -604,7 +621,7 @@
 	[self setHistorySearch:searchString mode:PBHistorySearchModePath];
 }
 
-- (void) checkoutFiles:(id)sender
+- (void)checkoutFiles:(id)sender
 {
 	NSMutableArray *files = [NSMutableArray array];
 	for (NSString *filePath in [sender representedObject])
@@ -615,10 +632,9 @@
 	if (!success) {
 		[self.windowController showErrorSheet:error];
 	}
-
 }
 
-- (void) diffFilesAction:(id)sender
+- (void)diffFilesAction:(id)sender
 {
 	/* TODO: Move that to the document */
 	[PBDiffWindowController showDiffWindowWithFiles:[sender representedObject] fromCommit:self.selectedCommits.firstObject diffCommit:nil];
@@ -627,7 +643,7 @@
 #pragma mark -
 #pragma mark History table view delegate
 
-- (BOOL)tableView:(NSTableView *)tv writeRowsWithIndexes:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard*)pboard
+- (BOOL)tableView:(NSTableView *)tv writeRowsWithIndexes:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard
 {
 	NSPoint location = [(PBCommitList *)tv mouseDownPoint];
 	NSInteger row = [tv rowAtPoint:location];
@@ -670,8 +686,8 @@
 	return YES;
 }
 
-- (NSDragOperation)tableView:(NSTableView*)tv
-				validateDrop:(id <NSDraggingInfo>)info
+- (NSDragOperation)tableView:(NSTableView *)tv
+				validateDrop:(id<NSDraggingInfo>)info
 				 proposedRow:(NSInteger)row
 	   proposedDropOperation:(NSTableViewDropOperation)operation
 {
@@ -686,7 +702,7 @@
 }
 
 - (BOOL)tableView:(NSTableView *)aTableView
-	   acceptDrop:(id <NSDraggingInfo>)info
+	   acceptDrop:(id<NSDraggingInfo>)info
 			  row:(NSInteger)row
 	dropOperation:(NSTableViewDropOperation)operation
 {
@@ -722,17 +738,17 @@
 
 	PBGitWindowController *wc = self.windowController;
 	[wc confirmDialog:alert
-suppressionIdentifier:kDialogAcceptDroppedRef
-			forAction:^{
-				NSError *error = nil;
-				if (![wc.repository updateReference:ref toPointAtCommit:dropCommit error:&error]) {
-					[wc showErrorSheet:error];
-					return;
-				}
+		suppressionIdentifier:kDialogAcceptDroppedRef
+					forAction:^{
+						NSError *error = nil;
+						if (![wc.repository updateReference:ref toPointAtCommit:dropCommit error:&error]) {
+							[wc showErrorSheet:error];
+							return;
+						}
 
-				[dropCommit addRef:ref];
-				[oldCommit removeRef:ref];
-			}];
+						[dropCommit addRef:ref];
+						[oldCommit removeRef:ref];
+					}];
 
 	return YES;
 }
@@ -758,39 +774,31 @@ suppressionIdentifier:kDialogAcceptDroppedRef
 		[filePaths addObject:[filePath stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]];
 
 	BOOL multiple = [filePaths count] != 1;
-	NSString *historyItemTitle = multiple
-		? NSLocalizedString(@"Show history of files", @"Show history menu item for multiple files")
-		: NSLocalizedString(@"Show history of file", @"Show history menu item for single file");
+	NSString *historyItemTitle = multiple ? NSLocalizedString(@"Show history of files", @"Show history menu item for multiple files") : NSLocalizedString(@"Show history of file", @"Show history menu item for single file");
 	NSMenuItem *historyItem = [[NSMenuItem alloc] initWithTitle:historyItemTitle
 														 action:@selector(showCommitsFromTree:)
 												  keyEquivalent:@""];
 
 	PBGitRef *headRef = [[repository headRef] ref];
 	NSString *headRefName = [headRef shortName];
-	NSString *diffTitleFormat = multiple
-		? NSLocalizedString(@"Diff files with %@", @"Diff with ref menu item for multiple files")
-		: NSLocalizedString(@"Diff file with %@", @"Diff with ref menu item for single file");
+	NSString *diffTitleFormat = multiple ? NSLocalizedString(@"Diff files with %@", @"Diff with ref menu item for multiple files") : NSLocalizedString(@"Diff file with %@", @"Diff with ref menu item for single file");
 	NSString *diffTitle = [NSString stringWithFormat:diffTitleFormat, headRefName];
 	BOOL isHead = [self.selectedCommits.firstObject.OID isEqual:repository.headOID];
 	NSMenuItem *diffItem = [[NSMenuItem alloc] initWithTitle:diffTitle
 													  action:isHead ? nil : @selector(diffFilesAction:)
 											   keyEquivalent:@""];
 
-	NSString *checkoutItemTitle = multiple
-		? NSLocalizedString(@"Checkout files", @"Checkout menu item for multiple files")
-		: NSLocalizedString(@"Checkout file", @"Checkout menu item for single file");
+	NSString *checkoutItemTitle = multiple ? NSLocalizedString(@"Checkout files", @"Checkout menu item for multiple files") : NSLocalizedString(@"Checkout file", @"Checkout menu item for single file");
 	NSMenuItem *checkoutItem = [[NSMenuItem alloc] initWithTitle:checkoutItemTitle
 														  action:@selector(checkoutFiles:)
 												   keyEquivalent:@""];
-	
+
 	NSString *finderItemTitle = NSLocalizedString(@"Reveal in Finder", @"Show in Finder menu item");
 	NSMenuItem *finderItem = [[NSMenuItem alloc] initWithTitle:finderItemTitle
 														action:@selector(revealInFinder:)
 												 keyEquivalent:@""];
-	
-	NSString *openFilesItemTitle = multiple
-		? NSLocalizedString(@"Open Files", @"Open menu item for multiple files")
-		: NSLocalizedString(@"Open File", @"Open menu item for single file");
+
+	NSString *openFilesItemTitle = multiple ? NSLocalizedString(@"Open Files", @"Open menu item for multiple files") : NSLocalizedString(@"Open File", @"Open menu item for single file");
 	NSMenuItem *openFilesItem = [[NSMenuItem alloc] initWithTitle:openFilesItemTitle
 														   action:@selector(openFiles:)
 													keyEquivalent:@""];
@@ -810,51 +818,51 @@ suppressionIdentifier:kDialogAcceptDroppedRef
 
 - (NSInteger)numberOfPreviewItemsInPreviewPanel:(id)panel
 {
-    return [[fileBrowser selectedRowIndexes] count];
+	return [[fileBrowser selectedRowIndexes] count];
 }
 
-- (id <QLPreviewItem>)previewPanel:(id)panel previewItemAtIndex:(NSInteger)index
+- (id<QLPreviewItem>)previewPanel:(id)panel previewItemAtIndex:(NSInteger)index
 {
 	PBGitTree *treeItem = (PBGitTree *)[[treeController selectedObjects] objectAtIndex:index];
 	NSURL *previewURL = [NSURL fileURLWithPath:[treeItem tmpFileNameForContents]];
 
-    return (id <QLPreviewItem>)previewURL;
+	return (id<QLPreviewItem>)previewURL;
 }
 
 #pragma mark <QLPreviewPanelDelegate>
 
 - (BOOL)previewPanel:(id)panel handleEvent:(NSEvent *)event
 {
-    // redirect all key down events to the table view
-    if ([event type] == NSKeyDown) {
-        [fileBrowser keyDown:event];
-        return YES;
-    }
-    return NO;
+	// redirect all key down events to the table view
+	if ([event type] == NSKeyDown) {
+		[fileBrowser keyDown:event];
+		return YES;
+	}
+	return NO;
 }
 
 // This delegate method provides the rect on screen from which the panel will zoom.
-- (NSRect)previewPanel:(id)panel sourceFrameOnScreenForPreviewItem:(id <QLPreviewItem>)item
+- (NSRect)previewPanel:(id)panel sourceFrameOnScreenForPreviewItem:(id<QLPreviewItem>)item
 {
-    NSInteger index = [fileBrowser rowForItem:[[treeController selectedNodes] objectAtIndex:0]];
-    if (index == NSNotFound) {
-        return NSZeroRect;
-    }
+	NSInteger index = [fileBrowser rowForItem:[[treeController selectedNodes] objectAtIndex:0]];
+	if (index == NSNotFound) {
+		return NSZeroRect;
+	}
 
-    NSRect iconRect = [fileBrowser frameOfCellAtColumn:0 row:index];
+	NSRect iconRect = [fileBrowser frameOfCellAtColumn:0 row:index];
 
-    // check that the icon rect is visible on screen
-    NSRect visibleRect = [fileBrowser visibleRect];
+	// check that the icon rect is visible on screen
+	NSRect visibleRect = [fileBrowser visibleRect];
 
-    if (!NSIntersectsRect(visibleRect, iconRect)) {
-        return NSZeroRect;
-    }
+	if (!NSIntersectsRect(visibleRect, iconRect)) {
+		return NSZeroRect;
+	}
 
-    // convert icon rect to screen coordinates
+	// convert icon rect to screen coordinates
 	iconRect = [fileBrowser.window.contentView convertRect:iconRect fromView:fileBrowser];
 	iconRect = [fileBrowser.window convertRectToScreen:iconRect];
 
-    return iconRect;
+	return iconRect;
 }
 
 @end
@@ -953,9 +961,7 @@ suppressionIdentifier:kDialogAcceptDroppedRef
 		[items addObject:[NSMenuItem separatorItem]];
 
 		// create branch
-		NSString *createBranchTitle = ref.isRemoteBranch
-		? [NSString stringWithFormat:NSLocalizedString(@"Create Branch tracking “%@”…", @"Contextual Menu Item to create a branch tracking the selected remote branch"), refName]
-		: NSLocalizedString(@"Create Branch…", @"Contextual Menu Item to create a new branch at the selected ref");
+		NSString *createBranchTitle = ref.isRemoteBranch ? [NSString stringWithFormat:NSLocalizedString(@"Create Branch tracking “%@”…", @"Contextual Menu Item to create a branch tracking the selected remote branch"), refName] : NSLocalizedString(@"Create Branch…", @"Contextual Menu Item to create a new branch at the selected ref");
 		[items addObject:[NSMenuItem pb_itemWithTitle:createBranchTitle action:@selector(createBranch:) enabled:YES]];
 
 		// create tag
@@ -972,15 +978,11 @@ suppressionIdentifier:kDialogAcceptDroppedRef
 		[items addObject:[NSMenuItem separatorItem]];
 
 		// merge ref
-		NSString *mergeTitle = isOnHeadBranch
-		? NSLocalizedString(@"Merge", @"Inactive Contextual Menu Item for merging")
-		: [NSString stringWithFormat:@"Merge %@ into %@", refName, headRefName];
+		NSString *mergeTitle = isOnHeadBranch ? NSLocalizedString(@"Merge", @"Inactive Contextual Menu Item for merging") : [NSString stringWithFormat:@"Merge %@ into %@", refName, headRefName];
 		[items addObject:[NSMenuItem pb_itemWithTitle:mergeTitle action:@selector(merge:) enabled:!isOnHeadBranch]];
 
 		// rebase
-		NSString *rebaseTitle = isOnHeadBranch
-		? NSLocalizedString(@"Rebase", @"Inactive Contextual Menu Item for rebasing")
-		: [NSString stringWithFormat:NSLocalizedString(@"Rebase ”%@“ onto “%@”", @"Contextual Menu Item to rebase HEAD onto the selected ref"), headRefName, refName];
+		NSString *rebaseTitle = isOnHeadBranch ? NSLocalizedString(@"Rebase", @"Inactive Contextual Menu Item for rebasing") : [NSString stringWithFormat:NSLocalizedString(@"Rebase ”%@“ onto “%@”", @"Contextual Menu Item to rebase HEAD onto the selected ref"), headRefName, refName];
 		[items addObject:[NSMenuItem pb_itemWithTitle:rebaseTitle action:@selector(rebaseHeadBranch:) enabled:!isOnHeadBranch]];
 
 		[items addObject:[NSMenuItem separatorItem]];
@@ -993,15 +995,11 @@ suppressionIdentifier:kDialogAcceptDroppedRef
 	}
 
 	// fetch
-	NSString *fetchTitle = hasRemote
-	? [NSString stringWithFormat:NSLocalizedString(@"Fetch “%@”", @"Contextual Menu Item to fetch the selected remote"), remoteName]
-	: NSLocalizedString(@"Fetch", @"Inactive Contextual Menu Item for fetching");
+	NSString *fetchTitle = hasRemote ? [NSString stringWithFormat:NSLocalizedString(@"Fetch “%@”", @"Contextual Menu Item to fetch the selected remote"), remoteName] : NSLocalizedString(@"Fetch", @"Inactive Contextual Menu Item for fetching");
 	[items addObject:[NSMenuItem pb_itemWithTitle:fetchTitle action:@selector(fetchRemote:) enabled:hasRemote]];
 
 	// pull
-	NSString *pullTitle = hasRemote
-	? [NSString stringWithFormat:NSLocalizedString(@"Pull “%@” and Update “%@”", @"Contextual Menu Item to pull the remote and update the selected branch"), remoteName, headRefName]
-	: NSLocalizedString(@"Pull", @"Inactive Contextual Menu Item for pulling");
+	NSString *pullTitle = hasRemote ? [NSString stringWithFormat:NSLocalizedString(@"Pull “%@” and Update “%@”", @"Contextual Menu Item to pull the remote and update the selected branch"), remoteName, headRefName] : NSLocalizedString(@"Pull", @"Inactive Contextual Menu Item for pulling");
 	[items addObject:[NSMenuItem pb_itemWithTitle:pullTitle action:@selector(pullRemote:) enabled:hasRemote]];
 
 	// push
@@ -1009,11 +1007,9 @@ suppressionIdentifier:kDialogAcceptDroppedRef
 		// push updates to remote
 		NSString *pushTitle = [NSString stringWithFormat:NSLocalizedString(@"Push Updates to “%@”", @"Contextual Menu Item to push updates of the selected ref to he named remote"), remoteName];
 		[items addObject:[NSMenuItem pb_itemWithTitle:pushTitle action:@selector(pushUpdatesToRemote:) enabled:YES]];
-	}
-	else if (isDetachedHead) {
+	} else if (isDetachedHead) {
 		[items addObject:[NSMenuItem pb_itemWithTitle:NSLocalizedString(@"Push", @"Inactive Contextual Menu Item for pushing") action:nil enabled:NO]];
-	}
-	else {
+	} else {
 		// push to default remote
 		BOOL hasDefaultRemote = NO;
 		if (!ref.isTag && hasRemote) {
@@ -1044,9 +1040,7 @@ suppressionIdentifier:kDialogAcceptDroppedRef
 	BOOL isStash = [[ref ref] hasPrefix:@"refs/stash"];
 	BOOL isDeleteEnabled = !(isDetachedHead || isHead || isStash);
 	if (isDeleteEnabled) {
-		NSString *deleteFormat = ref.isRemote
-		? NSLocalizedString(@"Delete “%@”…", @"Contextual Menu Item to delete a local ref (e.g. branch)")
-		: NSLocalizedString(@"Remove “%@”…", @"Contextual Menu Item to remove a remote");
+		NSString *deleteFormat = ref.isRemote ? NSLocalizedString(@"Delete “%@”…", @"Contextual Menu Item to delete a local ref (e.g. branch)") : NSLocalizedString(@"Remove “%@”…", @"Contextual Menu Item to remove a remote");
 		NSString *deleteItemTitle = [NSString stringWithFormat:deleteFormat, refName];
 		NSMenuItem *deleteItem = [NSMenuItem pb_itemWithTitle:deleteItemTitle action:@selector(deleteRef:) enabled:YES];
 		[items addObject:deleteItem];
@@ -1091,21 +1085,15 @@ suppressionIdentifier:kDialogAcceptDroppedRef
 		[items addObject:[NSMenuItem separatorItem]];
 
 		// merge commit
-		NSString *mergeTitle = isOnHeadBranch
-		? NSLocalizedString(@"Merge Commit", @"Inactive Contextual Menu Item for merging commits")
-		: [NSString stringWithFormat:NSLocalizedString(@"Merge Commit into “%@”", @"Contextual Menu Item to merge the selected commit into HEAD"), headBranchName];
+		NSString *mergeTitle = isOnHeadBranch ? NSLocalizedString(@"Merge Commit", @"Inactive Contextual Menu Item for merging commits") : [NSString stringWithFormat:NSLocalizedString(@"Merge Commit into “%@”", @"Contextual Menu Item to merge the selected commit into HEAD"), headBranchName];
 		[items addObject:[NSMenuItem pb_itemWithTitle:mergeTitle action:@selector(merge:) enabled:!isOnHeadBranch]];
 
 		// cherry pick
-		NSString *cherryPickTitle = isOnHeadBranch
-		? NSLocalizedString(@"Cherry Pick Commit", @"Inactive Contextual Menu Item for cherry-picking commits")
-		: [NSString stringWithFormat:NSLocalizedString(@"Cherry Pick Commit to “%@”", @"Contextual Menu Item to cherry-pick the selected commit on top of HEAD"), headBranchName];
+		NSString *cherryPickTitle = isOnHeadBranch ? NSLocalizedString(@"Cherry Pick Commit", @"Inactive Contextual Menu Item for cherry-picking commits") : [NSString stringWithFormat:NSLocalizedString(@"Cherry Pick Commit to “%@”", @"Contextual Menu Item to cherry-pick the selected commit on top of HEAD"), headBranchName];
 		[items addObject:[NSMenuItem pb_itemWithTitle:cherryPickTitle action:@selector(cherryPick:) enabled:!isOnHeadBranch]];
 
 		// rebase
-		NSString *rebaseTitle = isOnHeadBranch
-		? NSLocalizedString(@"Rebase Commit", @"Inactive Contextual Menu Item for rebasing onto commits")
-		: [NSString stringWithFormat:NSLocalizedString(@"Rebase “%@” onto Commit", @"Contextual Menu Item to rebase the HEAD branch onto the selected commit"), headBranchName];
+		NSString *rebaseTitle = isOnHeadBranch ? NSLocalizedString(@"Rebase Commit", @"Inactive Contextual Menu Item for rebasing onto commits") : [NSString stringWithFormat:NSLocalizedString(@"Rebase “%@” onto Commit", @"Contextual Menu Item to rebase the HEAD branch onto the selected commit"), headBranchName];
 		[items addObject:[NSMenuItem pb_itemWithTitle:rebaseTitle action:@selector(rebaseHeadBranch:) enabled:!isOnHeadBranch]];
 
 		// reset
@@ -1123,4 +1111,3 @@ suppressionIdentifier:kDialogAcceptDroppedRef
 }
 
 @end
-

--- a/Classes/Controllers/PBGitRepositoryDocument.m
+++ b/Classes/Controllers/PBGitRepositoryDocument.m
@@ -23,8 +23,7 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 
 - (BOOL)readFromURL:(NSURL *)absoluteURL ofType:(NSString *)typeName error:(NSError **)outError
 {
-	if (![PBGitBinary path])
-	{
+	if (![PBGitBinary path]) {
 		return PBReturnError(outError, @"Unable to find git", [PBGitBinary notFoundError], nil);
 	}
 
@@ -40,12 +39,12 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 	}
 	if (_repository.isShallowRepository) {
 		if (outError) {
-			NSDictionary* userInfo = @{
-				NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(
+			NSDictionary *userInfo = @{
+				NSLocalizedRecoverySuggestionErrorKey : NSLocalizedString(
 					@"The repository is shallowly cloned, which is not supported by GitX. Please run “git fetch --unshallow” on the repository before opening it with GitX.",
 					@"Recovery suggestion when opening a shallow repository"),
-				NSLocalizedRecoveryOptionsErrorKey: [PBOpenShallowRepositoryErrorRecoveryAttempter errorDialogButtonNames],
-				NSRecoveryAttempterErrorKey: [[PBOpenShallowRepositoryErrorRecoveryAttempter alloc] initWithURL:_repository.workingDirectoryURL]
+				NSLocalizedRecoveryOptionsErrorKey : [PBOpenShallowRepositoryErrorRecoveryAttempter errorDialogButtonNames],
+				NSRecoveryAttempterErrorKey : [[PBOpenShallowRepositoryErrorRecoveryAttempter alloc] initWithURL:_repository.workingDirectoryURL]
 			};
 			*outError = [NSError errorWithDomain:PBGitXErrorDomain code:0 userInfo:userInfo];
 		}
@@ -59,7 +58,7 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 - (void)close
 {
 	/* FIXME: Check that this deallocs the repo */
-//	[revisionList cleanup];
+	//	[revisionList cleanup];
 
 	[super close];
 }
@@ -71,8 +70,8 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 
 - (NSString *)displayName
 {
-    // Build our display name depending on the current HEAD and whether it's detached or not
-    if (self.repository.gtRepo.isHEADDetached)
+	// Build our display name depending on the current HEAD and whether it's detached or not
+	if (self.repository.gtRepo.isHEADDetached)
 		return [NSString stringWithFormat:NSLocalizedString(@"%@ (detached HEAD)", @""), self.repository.projectName];
 
 	if (self.repository.gtRepo.isHEADUnborn)
@@ -83,7 +82,7 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 
 - (void)makeWindowControllers
 {
-    // Create our custom window controller
+	// Create our custom window controller
 #ifndef CLI
 	[self addWindowController:[[PBGitWindowController alloc] init]];
 #endif
@@ -97,15 +96,18 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 	return [[self windowControllers] objectAtIndex:0];
 }
 
-- (IBAction)showCommitView:(id)sender {
+- (IBAction)showCommitView:(id)sender
+{
 	[[self windowController] showCommitView:sender];
 }
 
-- (IBAction)showHistoryView:(id)sender {
+- (IBAction)showHistoryView:(id)sender
+{
 	[[self windowController] showHistoryView:sender];
 }
 
-- (void)selectRevisionSpecifier:(PBGitRevSpecifier *)specifier {
+- (void)selectRevisionSpecifier:(PBGitRevSpecifier *)specifier
+{
 	PBGitRevSpecifier *spec = [self.repository addBranch:specifier];
 	self.repository.currentBranch = spec;
 	[self showHistoryView:self];

--- a/Classes/Controllers/PBGitSidebarController.m
+++ b/Classes/Controllers/PBGitSidebarController.m
@@ -39,9 +39,9 @@
 - (void)populateList;
 - (PBSourceViewItem *)addRevSpec:(PBGitRevSpecifier *)revSpec;
 - (PBSourceViewItem *)itemForRev:(PBGitRevSpecifier *)rev;
-- (void) removeRevSpec:(PBGitRevSpecifier *)rev;
-- (void) updateActionMenu;
-- (void) updateRemoteControls;
+- (void)removeRevSpec:(PBGitRevSpecifier *)rev;
+- (void)updateActionMenu;
+- (void)updateRemoteControls;
 @end
 
 @implementation PBGitSidebarController
@@ -67,44 +67,52 @@
 	window.contentView = self.view;
 	[self populateList];
 
-	[repository addObserver:self keyPath:@"currentBranch" options:0 block:^(MAKVONotification *notification) {
-		PBGitSidebarController *observer = notification.observer;
-		NSInteger row = observer.sourceView.selectedRow;
-		[observer.sourceView reloadData];
-		[observer.sourceView selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
-		[observer selectCurrentBranch];
-	}];
+	[repository addObserver:self
+					keyPath:@"currentBranch"
+					options:0
+					  block:^(MAKVONotification *notification) {
+						  PBGitSidebarController *observer = notification.observer;
+						  NSInteger row = observer.sourceView.selectedRow;
+						  [observer.sourceView reloadData];
+						  [observer.sourceView selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
+						  [observer selectCurrentBranch];
+					  }];
 
-	[repository addObserver:self keyPath:@"branches" options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew) block:^(MAKVONotification *notification) {
-		PBGitSidebarController *observer = notification.observer;
-		if (notification.kind == NSKeyValueChangeInsertion) {
-			NSArray *newRevSpecs = notification.newValue;
-			for (PBGitRevSpecifier *rev in newRevSpecs) {
-				PBSourceViewItem *item = [observer addRevSpec:rev];
-				[observer.sourceView PBExpandItem:item expandParents:YES];
-			}
-		}
-		else if (notification.kind == NSKeyValueChangeRemoval) {
-			NSArray *removedRevSpecs = notification.oldValue;
-			for (PBGitRevSpecifier *rev in removedRevSpecs)
-				[observer removeRevSpec:rev];
-		}
-	}];
+	[repository addObserver:self
+					keyPath:@"branches"
+					options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew)
+					  block:^(MAKVONotification *notification) {
+						  PBGitSidebarController *observer = notification.observer;
+						  if (notification.kind == NSKeyValueChangeInsertion) {
+							  NSArray *newRevSpecs = notification.newValue;
+							  for (PBGitRevSpecifier *rev in newRevSpecs) {
+								  PBSourceViewItem *item = [observer addRevSpec:rev];
+								  [observer.sourceView PBExpandItem:item expandParents:YES];
+							  }
+						  } else if (notification.kind == NSKeyValueChangeRemoval) {
+							  NSArray *removedRevSpecs = notification.oldValue;
+							  for (PBGitRevSpecifier *rev in removedRevSpecs)
+								  [observer removeRevSpec:rev];
+						  }
+					  }];
 
-	[repository addObserver:self keyPath:@"stashes" options:0 block:^(MAKVONotification *notification) {
-		PBGitSidebarController *observer = notification.observer;
-		for (PBSourceViewGitStashItem *stashItem in observer->stashes.sortedChildren)
-			[observer->stashes removeChild:stashItem];
+	[repository addObserver:self
+					keyPath:@"stashes"
+					options:0
+					  block:^(MAKVONotification *notification) {
+						  PBGitSidebarController *observer = notification.observer;
+						  for (PBSourceViewGitStashItem *stashItem in observer->stashes.sortedChildren)
+							  [observer->stashes removeChild:stashItem];
 
-		for (PBGitStash *stash in observer.repository.stashes)
-			[observer->stashes addChild: [PBSourceViewGitStashItem itemWithStash:stash]];
+						  for (PBGitStash *stash in observer.repository.stashes)
+							  [observer->stashes addChild:[PBSourceViewGitStashItem itemWithStash:stash]];
 
-		[observer.sourceView expandItem:observer->stashes];
-		[observer.sourceView reloadItem:observer->stashes reloadChildren:YES];
-	}];
+						  [observer.sourceView expandItem:observer->stashes];
+						  [observer.sourceView reloadItem:observer->stashes reloadChildren:YES];
+					  }];
 
-    [sourceView setTarget:self];
-    [sourceView setDoubleAction:@selector(doubleClicked:)];
+	[sourceView setTarget:self];
+	[sourceView setDoubleAction:@selector(doubleClicked:)];
 
 	[self menuNeedsUpdate:[actionButton menu]];
 
@@ -113,18 +121,17 @@
 	else
 		[self selectCurrentBranch];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(expandCollapseItem:) name:NSOutlineViewItemWillExpandNotification object:sourceView];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(expandCollapseItem:) name:NSOutlineViewItemWillCollapseNotification object:sourceView];
-
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(expandCollapseItem:) name:NSOutlineViewItemWillExpandNotification object:sourceView];
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(expandCollapseItem:) name:NSOutlineViewItemWillCollapseNotification object:sourceView];
 }
 
 - (void)dealloc
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:NSOutlineViewItemWillExpandNotification object:sourceView];
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:NSOutlineViewItemWillCollapseNotification object:sourceView];
+	[[NSNotificationCenter defaultCenter] removeObserver:self name:NSOutlineViewItemWillExpandNotification object:sourceView];
+	[[NSNotificationCenter defaultCenter] removeObserver:self name:NSOutlineViewItemWillCollapseNotification object:sourceView];
 }
 
-- (PBSourceViewItem *) selectedItem
+- (PBSourceViewItem *)selectedItem
 {
 	NSInteger index = [sourceView selectedRow];
 	PBSourceViewItem *item = [sourceView itemAtRow:index];
@@ -132,13 +139,13 @@
 	return item;
 }
 
-- (void) selectStage
+- (void)selectStage
 {
 	NSIndexSet *index = [NSIndexSet indexSetWithIndex:[sourceView rowForItem:stage]];
 	[sourceView selectRowIndexes:index byExtendingSelection:NO];
 }
 
-- (void) selectCurrentBranch
+- (void)selectCurrentBranch
 {
 	PBGitRevSpecifier *rev = repository.currentBranch;
 	if (!rev) {
@@ -160,21 +167,21 @@
 	}
 }
 
-- (PBSourceViewItem *) itemForRev:(PBGitRevSpecifier *)rev
+- (PBSourceViewItem *)itemForRev:(PBGitRevSpecifier *)rev
 {
 	PBSourceViewItem *foundItem = nil;
 	for (PBSourceViewItem *item in items)
-		if ( (foundItem = [item findRev:rev]) != nil )
+		if ((foundItem = [item findRev:rev]) != nil)
 			return foundItem;
 	return nil;
 }
 
 - (PBSourceViewItem *)addRevSpec:(PBGitRevSpecifier *)rev
 {
-    PBSourceViewItem *item = nil;
-    for (PBSourceViewItem *it in items)
-        if ( (item = [it findRev:rev]) != nil )
-            return item;
+	PBSourceViewItem *item = nil;
+	for (PBSourceViewItem *it in items)
+		if ((item = [it findRev:rev]) != nil)
+			return item;
 
 	if (![rev isSimpleRef]) {
 		[others addChild:[PBSourceViewItem itemWithRevSpec:rev]];
@@ -190,10 +197,10 @@
 		[tags addRev:rev toPath:[pathComponents subarrayWithRange:NSMakeRange(2, [pathComponents count] - 2)]];
 	else if ([[rev simpleRef] hasPrefix:@"refs/remotes/"])
 		[remotes addRev:rev toPath:[pathComponents subarrayWithRange:NSMakeRange(2, [pathComponents count] - 2)]];
-    return item;
+	return item;
 }
 
-- (void) removeRevSpec:(PBGitRevSpecifier *)rev
+- (void)removeRevSpec:(PBGitRevSpecifier *)rev
 {
 	PBSourceViewItem *item = [self itemForRev:rev];
 
@@ -205,18 +212,20 @@
 	[sourceView reloadData];
 }
 
-- (void) openSubmoduleFromMenuItem:(NSMenuItem *)menuItem
+- (void)openSubmoduleFromMenuItem:(NSMenuItem *)menuItem
 {
-    [self openSubmoduleAtURL:[menuItem representedObject]];
+	[self openSubmoduleAtURL:[menuItem representedObject]];
 }
 
-- (void) openSubmoduleAtURL:(NSURL *)submoduleURL
+- (void)openSubmoduleAtURL:(NSURL *)submoduleURL
 {
-	[[NSDocumentController sharedDocumentController] openDocumentWithContentsOfURL:submoduleURL display:YES completionHandler:^(NSDocument *document, BOOL documentWasAlreadyOpen, NSError *error) {
-		if (error) {
-			[self.windowController showErrorSheet:error];
-		}
-	}];
+	[[NSDocumentController sharedDocumentController] openDocumentWithContentsOfURL:submoduleURL
+																		   display:YES
+																 completionHandler:^(NSDocument *document, BOOL documentWasAlreadyOpen, NSError *error) {
+																	 if (error) {
+																		 [self.windowController showErrorSheet:error];
+																	 }
+																 }];
 }
 
 #pragma mark NSOutlineView delegate methods
@@ -230,7 +239,7 @@
 		if (![repository.currentBranch isEqual:[item revSpecifier]]) {
 			repository.currentBranch = [item revSpecifier];
 		}
-		
+
 		[superController changeContentController:superController.historyViewController];
 		[PBGitDefaults setShowStageView:NO];
 	}
@@ -244,9 +253,10 @@
 	[self updateRemoteControls];
 }
 
-- (void)doubleClicked:(id)object {
+- (void)doubleClicked:(id)object
+{
 	NSInteger rowNumber = [sourceView selectedRow];
-	
+
 	id item = [sourceView itemAtRow:rowNumber];
 	if ([item isKindOfClass:[PBSourceViewGitSubmoduleItem class]]) {
 		PBSourceViewGitSubmoduleItem *subModule = item;
@@ -254,7 +264,7 @@
 		[self openSubmoduleAtURL:[subModule path]];
 	} else if ([item isKindOfClass:[PBSourceViewGitBranchItem class]]) {
 		PBSourceViewGitBranchItem *branch = item;
-		
+
 		NSError *error = nil;
 		BOOL success = [repository checkoutRefish:[branch ref] error:&error];
 		if (!success) {
@@ -265,10 +275,10 @@
 
 - (BOOL)outlineView:(NSOutlineView *)outlineView shouldEditTableColumn:(NSTableColumn *)tableColumn item:(id)item
 {
-    if ([item isKindOfClass:[PBSourceViewGitSubmoduleItem class]]) {
-        NSLog(@"hi");
-    }
-    return NO;
+	if ([item isKindOfClass:[PBSourceViewGitSubmoduleItem class]]) {
+		NSLog(@"hi");
+	}
+	return NO;
 }
 #pragma mark NSOutlineView delegate methods
 - (BOOL)outlineView:(NSOutlineView *)outlineView isGroupItem:(id)item
@@ -276,23 +286,25 @@
 	return [item isGroupItem];
 }
 
-- (NSView *)outlineView:(NSOutlineView *)outlineView viewForTableColumn:(NSTableColumn *)tableColumn item:(PBSourceViewItem*)item {
+- (NSView *)outlineView:(NSOutlineView *)outlineView viewForTableColumn:(NSTableColumn *)tableColumn item:(PBSourceViewItem *)item
+{
 	PBSidebarTableViewCell *cell = [outlineView makeViewWithIdentifier:PBSidebarCellIdentifier owner:outlineView];
-	
+
 	cell.textField.stringValue = [[item title] copy];
 	cell.imageView.image = item.icon;
 	cell.isCheckedOut = [item.revSpecifier isEqual:[repository headRef]];
-	
+
 	return cell;
 }
 
-- (NSTableRowView *)outlineView:(NSOutlineView *)outlineView rowViewForItem:(id)item {
+- (NSTableRowView *)outlineView:(NSOutlineView *)outlineView rowViewForItem:(id)item
+{
 	NSTableRowView *view = [sourceView rowViewAtRow:[sourceView rowForItem:item] makeIfNecessary:NO];
-	
+
 	if (view) {
 		return view;
 	}
-	
+
 	return [NSTableRowView new];
 }
 
@@ -305,7 +317,7 @@
 // The next method is necessary to hide the triangle for uncollapsible items
 // That is, items which should always be displayed, such as the Project group.
 // This also moves the group item to the left edge.
-- (BOOL) outlineView:(NSOutlineView *)outlineView shouldShowOutlineCellForItem:(id)item
+- (BOOL)outlineView:(NSOutlineView *)outlineView shouldShowOutlineCellForItem:(id)item
 {
 	return ![item isUncollapsible];
 }
@@ -317,25 +329,25 @@
 
 	stage = [PBSourceViewStageItem stageItem];
 	[project addChild:stage];
-	
+
 	branches = [PBSourceViewItem groupItemWithTitle:@"Branches"];
 	remotes = [PBSourceViewItem groupItemWithTitle:@"Remotes"];
 	tags = [PBSourceViewItem groupItemWithTitle:@"Tags"];
-    stashes = [PBSourceViewItem groupItemWithTitle:@"Stashes"];
+	stashes = [PBSourceViewItem groupItemWithTitle:@"Stashes"];
 	submodules = [PBSourceViewItem groupItemWithTitle:@"Submodules"];
 	others = [PBSourceViewItem groupItemWithTitle:@"Other"];
 
 	for (PBGitStash *stash in repository.stashes)
-		[stashes addChild: [PBSourceViewGitStashItem itemWithStash:stash]];
+		[stashes addChild:[PBSourceViewGitStashItem itemWithStash:stash]];
 
 	for (PBGitRevSpecifier *rev in repository.branches) {
 		[self addRevSpec:rev];
 	}
-    
-    for (GTSubmodule *sub in repository.submodules) {
-        [submodules addChild: [PBSourceViewGitSubmoduleItem itemWithSubmodule:sub]];
+
+	for (GTSubmodule *sub in repository.submodules) {
+		[submodules addChild:[PBSourceViewGitSubmoduleItem itemWithSubmodule:sub]];
 	}
-    
+
 	[items addObject:project];
 	[items addObject:branches];
 	[items addObject:remotes];
@@ -348,18 +360,18 @@
 	[sourceView expandItem:project];
 	[sourceView expandItem:branches expandChildren:YES];
 	[sourceView expandItem:remotes];
-    [sourceView expandItem:stashes];
-    [sourceView expandItem:submodules];
+	[sourceView expandItem:stashes];
+	[sourceView expandItem:submodules];
 
 	[sourceView reloadItem:nil reloadChildren:YES];
 }
 
-- (void)expandCollapseItem:(NSNotification*)aNotification
+- (void)expandCollapseItem:(NSNotification *)aNotification
 {
-    NSObject* child = [[aNotification userInfo] valueForKey:@"NSObject"];
-    if ([child isKindOfClass:[PBSourceViewItem class]]) {
-        ((PBSourceViewItem *)child).expanded = [aNotification.name isEqualToString:NSOutlineViewItemWillExpandNotification];
-    }
+	NSObject *child = [[aNotification userInfo] valueForKey:@"NSObject"];
+	if ([child isKindOfClass:[PBSourceViewItem class]]) {
+		((PBSourceViewItem *)child).expanded = [aNotification.name isEqualToString:NSOutlineViewItemWillExpandNotification];
+	}
 }
 
 #pragma mark NSOutlineView Datasource methods
@@ -393,12 +405,12 @@
 
 #pragma mark Menus
 
-- (void) updateActionMenu
+- (void)updateActionMenu
 {
 	[actionButton setEnabled:([[self selectedItem] ref] != nil || [[self selectedItem] isKindOfClass:[PBSourceViewGitSubmoduleItem class]])];
 }
 
-- (void) addMenuItemsForRef:(PBGitRef *)ref toMenu:(NSMenu *)menu
+- (void)addMenuItemsForRef:(PBGitRef *)ref toMenu:(NSMenu *)menu
 {
 	if (!ref)
 		return;
@@ -407,18 +419,18 @@
 		[menu addItem:menuItem];
 }
 
-- (void) addMenuItemsForSubmodule:(PBSourceViewGitSubmoduleItem *)submodule toMenu:(NSMenu *)menu
+- (void)addMenuItemsForSubmodule:(PBSourceViewGitSubmoduleItem *)submodule toMenu:(NSMenu *)menu
 {
-    if (!submodule)
-        return;
+	if (!submodule)
+		return;
 
-    NSMenuItem *menuItem = [menu addItemWithTitle:NSLocalizedString(@"Open Submodule", @"Open Submodule menu item") action:@selector(openSubmoduleFromMenuItem:) keyEquivalent:@""];
+	NSMenuItem *menuItem = [menu addItemWithTitle:NSLocalizedString(@"Open Submodule", @"Open Submodule menu item") action:@selector(openSubmoduleFromMenuItem:) keyEquivalent:@""];
 
-    [menuItem setTarget:self];
-    [menuItem setRepresentedObject:[submodule path]];
+	[menuItem setTarget:self];
+	[menuItem setRepresentedObject:[submodule path]];
 }
 
-- (NSMenuItem *) actionIconItem
+- (NSMenuItem *)actionIconItem
 {
 	NSMenuItem *actionIconItem = [[NSMenuItem alloc] initWithTitle:@"" action:NULL keyEquivalent:@""];
 	NSImage *actionIcon = [NSImage imageNamed:@"NSActionTemplate"];
@@ -428,7 +440,7 @@
 	return actionIconItem;
 }
 
-- (NSMenu *) menuForRow:(NSInteger)row
+- (NSMenu *)menuForRow:(NSInteger)row
 {
 	PBSourceViewItem *viewItem = [sourceView itemAtRow:row];
 	PBGitRef *ref = [viewItem ref];
@@ -448,7 +460,7 @@
 }
 
 // delegate of the action menu
-- (void) menuNeedsUpdate:(NSMenu *)menu
+- (void)menuNeedsUpdate:(NSMenu *)menu
 {
 	[actionButton removeAllItems];
 	[menu addItem:[self actionIconItem]];
@@ -456,22 +468,22 @@
 	PBGitRef *ref = [[self selectedItem] ref];
 	[self addMenuItemsForRef:ref toMenu:menu];
 
-    if ([[self selectedItem] isKindOfClass:[PBSourceViewGitSubmoduleItem class]]) {
-        [self addMenuItemsForSubmodule:(PBSourceViewGitSubmoduleItem *)[self selectedItem] toMenu:menu];
-    }
+	if ([[self selectedItem] isKindOfClass:[PBSourceViewGitSubmoduleItem class]]) {
+		[self addMenuItemsForSubmodule:(PBSourceViewGitSubmoduleItem *)[self selectedItem] toMenu:menu];
+	}
 }
 
 
 #pragma mark Remote controls
 
-enum  {
+enum {
 	kAddRemoteSegment = 0,
 	kFetchSegment = 1,
 	kPullSegment = 2,
 	kPushSegment = 3
 };
 
-- (void) updateRemoteControls
+- (void)updateRemoteControls
 {
 	BOOL hasRemote = NO;
 
@@ -484,7 +496,7 @@ enum  {
 	[remoteControls setEnabled:hasRemote forSegment:kPushSegment];
 }
 
-- (IBAction) fetchPullPushAction:(id)sender
+- (IBAction)fetchPullPushAction:(id)sender
 {
 	NSInteger selectedSegment = [sender selectedSegment];
 

--- a/Classes/Controllers/PBGitWindowController.h
+++ b/Classes/Controllers/PBGitWindowController.h
@@ -40,8 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)showErrorSheet:(NSError *)error;
 
 
-- (void)openURLs:(NSArray <NSURL *> *)fileURLs;
-- (void)revealURLsInFinder:(NSArray <NSURL *> *)fileURLs;
+- (void)openURLs:(NSArray<NSURL *> *)fileURLs;
+- (void)revealURLsInFinder:(NSArray<NSURL *> *)fileURLs;
 
 - (IBAction)showCommitView:(id)sender;
 - (IBAction)showHistoryView:(id)sender;
@@ -74,9 +74,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (IBAction)pushDefaultRemoteForRef:(id)sender;
 - (IBAction)pushToRemote:(id)sender;
 
-- (IBAction)stashSave:(id) sender;
-- (IBAction)stashSaveWithKeepIndex:(id) sender;
-- (IBAction)stashPop:(id) sender;
+- (IBAction)stashSave:(id)sender;
+- (IBAction)stashSaveWithKeepIndex:(id)sender;
+- (IBAction)stashPop:(id)sender;
 - (IBAction)stashApply:(id)sender;
 - (IBAction)stashDrop:(id)sender;
 

--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -65,7 +65,7 @@
 
 - (void)synchronizeWindowTitleWithDocumentName
 {
-    [super synchronizeWindowTitleWithDocumentName];
+	[super synchronizeWindowTitleWithDocumentName];
 
 	if ([self isWindowLoaded]) {
 		// Point window proxy icon at project directory, not internal .git dir
@@ -75,7 +75,7 @@
 
 - (void)windowWillClose:(NSNotification *)notification
 {
-//	NSLog(@"Window will close!");
+	//	NSLog(@"Window will close!");
 
 	[self.sidebarViewController closeView];
 	[self.historyViewController closeView];
@@ -100,11 +100,11 @@
 	} else if (menuItem.action == @selector(pullRebaseRemote:)) {
 		return [self validateMenuItem:menuItem remoteTitle:@"Pull From “%@” and Rebase" plainTitle:@"Pull and Rebase"];
 	}
-	
+
 	return YES;
 }
 
-- (BOOL) validateMenuItem:(NSMenuItem *)menuItem remoteTitle:(NSString *)localisationKeyWithRemote plainTitle:(NSString *)localizationKeyWithoutRemote
+- (BOOL)validateMenuItem:(NSMenuItem *)menuItem remoteTitle:(NSString *)localisationKeyWithRemote plainTitle:(NSString *)localizationKeyWithoutRemote
 {
 	PBGitRef *ref = [self selectedRef];
 	if (!ref)
@@ -122,7 +122,7 @@
 }
 
 
-- (void) windowDidLoad
+- (void)windowDidLoad
 {
 	[super windowDidLoad];
 
@@ -143,14 +143,14 @@
 	[progressIndicator setUsesThreadedAnimation:YES];
 }
 
-- (void) removeAllContentSubViews
+- (void)removeAllContentSubViews
 {
 	if ([contentSplitView subviews])
 		while ([[contentSplitView subviews] count] > 0)
 			[[[contentSplitView subviews] lastObject] removeFromSuperviewWithoutNeedingDisplay];
 }
 
-- (void) changeContentController:(PBViewController *)controller
+- (void)changeContentController:(PBViewController *)controller
 {
 	if (!controller || (contentController == controller))
 		return;
@@ -161,24 +161,27 @@
 	[self removeAllContentSubViews];
 
 	contentController = controller;
-	
+
 	[[contentController view] setFrame:[contentSplitView bounds]];
 	[contentSplitView addSubview:[contentController view]];
 
-//	[self setNextResponder: contentController];
+	//	[self setNextResponder: contentController];
 	[[self window] makeFirstResponder:[contentController firstResponder]];
 	[contentController updateView];
-	[contentController addObserver:self keyPath:@"status" options:NSKeyValueObservingOptionInitial block:^(MAKVONotification *notification) {
-		[self updateStatus];
-	}];
+	[contentController addObserver:self
+						   keyPath:@"status"
+						   options:NSKeyValueObservingOptionInitial
+							 block:^(MAKVONotification *notification) {
+								 [self updateStatus];
+							 }];
 }
 
-- (void) showCommitView:(id)sender
+- (void)showCommitView:(id)sender
 {
 	[_sidebarController selectStage];
 }
 
-- (void) showHistoryView:(id)sender
+- (void)showHistoryView:(id)sender
 {
 	[_sidebarController selectCurrentBranch];
 }
@@ -188,11 +191,11 @@
 	[PBCommitHookFailedSheet beginWithMessageText:messageText
 										 infoText:infoText
 								 commitController:controller
-	 completionHandler:^(id  _Nonnull sheet, NSModalResponse returnCode) {
-		 if (returnCode != NSModalResponseOK) return;
+								completionHandler:^(id _Nonnull sheet, NSModalResponse returnCode) {
+									if (returnCode != NSModalResponseOK) return;
 
-		 [self.commitViewController forceCommit:self];
-	 }];
+									[self.commitViewController forceCommit:self];
+								}];
 }
 
 - (void)showMessageSheet:(NSString *)messageText infoText:(NSString *)infoText
@@ -202,22 +205,19 @@
 
 - (void)showErrorSheet:(NSError *)error
 {
-	if ([[error domain] isEqualToString:PBGitXErrorDomain])
-	{
+	if ([[error domain] isEqualToString:PBGitXErrorDomain]) {
 		[PBGitXMessageSheet beginSheetWithError:error windowController:self];
-	}
-	else
-	{
+	} else {
 		NSAlert *alert = [NSAlert alertWithError:error];
 
 		[alert beginSheetModalForWindow:self.window
-					  completionHandler:^(NSModalResponse returnCode) {
+					  completionHandler:^(NSModalResponse returnCode){
 
 					  }];
 	}
 }
 
-- (void) updateStatus
+- (void)updateStatus
 {
 	NSString *status = contentController.status;
 	BOOL isBusy = contentController.isBusy;
@@ -232,8 +232,7 @@
 	if (isBusy) {
 		[progressIndicator startAnimation:self];
 		[progressIndicator setHidden:NO];
-	}
-	else {
+	} else {
 		[progressIndicator stopAnimation:self];
 		[progressIndicator setHidden:YES];
 	}
@@ -245,8 +244,7 @@
 }
 
 
-
-- (void)openURLs:(NSArray <NSURL *> *)fileURLs
+- (void)openURLs:(NSArray<NSURL *> *)fileURLs
 {
 	if (fileURLs.count == 0) return;
 
@@ -260,7 +258,7 @@
 			NSURL *submoduleURL = [submodule.parentRepository.fileURL URLByAppendingPathComponent:submodule.path isDirectory:YES];
 			[[NSDocumentController sharedDocumentController] openDocumentWithContentsOfURL:submoduleURL
 																				   display:YES
-																		 completionHandler:^(NSDocument * _Nullable document, BOOL documentWasAlreadyOpen, NSError * _Nullable error) {
+																		 completionHandler:^(NSDocument *_Nullable document, BOOL documentWasAlreadyOpen, NSError *_Nullable error) {
 																			 // Do nothing on completion.
 																			 return;
 																		 }];
@@ -274,7 +272,7 @@
 						  launchIdentifiers:NULL];
 }
 
-- (void)revealURLsInFinder:(NSArray <NSURL *> *)fileURLs
+- (void)revealURLsInFinder:(NSArray<NSURL *> *)fileURLs
 {
 	if (fileURLs.count == 0) return;
 
@@ -296,18 +294,21 @@
 																			 description:desc
 																		windowController:self];
 
-	[progressSheet beginProgressSheetForBlock:^{
-		NSError *error = nil;
-		BOOL success = [self.repository fetchRemoteForRef:ref error:&error];
-		return (success ? nil : error);
-	} completionHandler:^(NSError *error) {
-		if (error) {
-			[self showErrorSheet:error];
+	[progressSheet
+		beginProgressSheetForBlock:^{
+			NSError *error = nil;
+			BOOL success = [self.repository fetchRemoteForRef:ref error:&error];
+			return (success ? nil : error);
 		}
-	}];
+		completionHandler:^(NSError *error) {
+			if (error) {
+				[self showErrorSheet:error];
+			}
+		}];
 }
 
-- (void)performPullForBranch:(PBGitRef *)branchRef remote:(PBGitRef *)remoteRef rebase:(BOOL)rebase {
+- (void)performPullForBranch:(PBGitRef *)branchRef remote:(PBGitRef *)remoteRef rebase:(BOOL)rebase
+{
 	NSString *description = nil;
 	if (!branchRef && !remoteRef) {
 		NSAssert(NO, @"Asked to pull no branch from no remote");
@@ -323,22 +324,22 @@
 																			 description:description
 																		windowController:self];
 
-	[progressSheet beginProgressSheetForBlock:^{
-		NSError *error = nil;
-		BOOL success = [self.repository pullBranch:branchRef fromRemote:remoteRef rebase:rebase error:&error];
-		return success ? nil : error;
-	} completionHandler:^(NSError *error) {
-		if (error) {
-			[self showErrorSheet:error];
+	[progressSheet
+		beginProgressSheetForBlock:^{
+			NSError *error = nil;
+			BOOL success = [self.repository pullBranch:branchRef fromRemote:remoteRef rebase:rebase error:&error];
+			return success ? nil : error;
 		}
-	}];
+		completionHandler:^(NSError *error) {
+			if (error) {
+				[self showErrorSheet:error];
+			}
+		}];
 }
 
 - (void)performPushForBranch:(PBGitRef *)branchRef toRemote:(PBGitRef *)remoteRef
 {
-	if ((!branchRef && !remoteRef)
-		|| (branchRef && !branchRef.isBranch && !branchRef.isRemoteBranch && !branchRef.isTag)
-		|| (remoteRef && !remoteRef.isRemote))
+	if ((!branchRef && !remoteRef) || (branchRef && !branchRef.isBranch && !branchRef.isRemoteBranch && !branchRef.isTag) || (remoteRef && !remoteRef.isRemote))
 		return;
 
 	NSString *description = nil;
@@ -357,32 +358,37 @@
 	[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"Push alert - cancel button")];
 	[alert setShowsSuppressionButton:YES];
 
-	[self confirmDialog:alert suppressionIdentifier:@"Confirm Push" forAction:^{
-		NSString *description = nil;
-		if (branchRef && remoteRef)
-			description = [NSString stringWithFormat:@"Pushing %@ '%@' to remote %@", branchRef.refishType, branchRef.shortName, remoteRef.remoteName];
-		else if (branchRef)
-			description = [NSString stringWithFormat:@"Pushing %@ '%@' to default remote", branchRef.refishType, branchRef.shortName];
-		else
-			description = [NSString stringWithFormat:@"Pushing updates to remote %@", remoteRef.remoteName];
+	[self confirmDialog:alert
+		suppressionIdentifier:@"Confirm Push"
+					forAction:^{
+						NSString *description = nil;
+						if (branchRef && remoteRef)
+							description = [NSString stringWithFormat:@"Pushing %@ '%@' to remote %@", branchRef.refishType, branchRef.shortName, remoteRef.remoteName];
+						else if (branchRef)
+							description = [NSString stringWithFormat:@"Pushing %@ '%@' to default remote", branchRef.refishType, branchRef.shortName];
+						else
+							description = [NSString stringWithFormat:@"Pushing updates to remote %@", remoteRef.remoteName];
 
-		PBRemoteProgressSheet *progressSheet = [PBRemoteProgressSheet progressSheetWithTitle:@"Pushing remote…"
-																				 description:description
-																			windowController:self];
+						PBRemoteProgressSheet *progressSheet = [PBRemoteProgressSheet progressSheetWithTitle:@"Pushing remote…"
+																								 description:description
+																							windowController:self];
 
-		[progressSheet beginProgressSheetForBlock:^{
-			NSError *error = nil;
-			BOOL success = [self.repository pushBranch:branchRef toRemote:remoteRef error:&error];
-			return (success ? nil : error);
-		} completionHandler:^(NSError *error) {
-			if (error) {
-				[self showErrorSheet:error];
-			}
-		}];
-	}];
+						[progressSheet
+							beginProgressSheetForBlock:^{
+								NSError *error = nil;
+								BOOL success = [self.repository pushBranch:branchRef toRemote:remoteRef error:&error];
+								return (success ? nil : error);
+							}
+							completionHandler:^(NSError *error) {
+								if (error) {
+									[self showErrorSheet:error];
+								}
+							}];
+					}];
 }
 
-- (NSArray <NSURL *> *)selectedURLsFromSender:(id)sender {
+- (NSArray<NSURL *> *)selectedURLsFromSender:(id)sender
+{
 	NSArray *selectedFiles = [sender representedObject];
 	if (![selectedFiles isKindOfClass:[NSArray class]] || [selectedFiles count] == 0)
 		return nil;
@@ -405,18 +411,17 @@
 
 #pragma mark IBActions
 
-- (id <PBGitRefish>)refishForSender:(id)sender refishTypes:(NSArray *)types
+- (id<PBGitRefish>)refishForSender:(id)sender refishTypes:(NSArray *)types
 {
 	if ([sender isKindOfClass:[NSMenuItem class]]) {
-		id <PBGitRefish> refish = nil;
+		id<PBGitRefish> refish = nil;
 		if ([(refish = [(NSMenuItem *)sender representedObject]) conformsToProtocol:@protocol(PBGitRefish)]) {
 			if (!types || [types indexOfObject:[refish refishType]] != NSNotFound)
 				return refish;
 		}
 		NSString *remoteName = nil;
 		if ([(remoteName = [(NSMenuItem *)sender representedObject]) isKindOfClass:[NSString class]]) {
-			if ([types indexOfObject:kGitXRemoteType] != NSNotFound
-				&& [self.repository.remotes indexOfObject:remoteName] != NSNotFound) {
+			if ([types indexOfObject:kGitXRemoteType] != NSNotFound && [self.repository.remotes indexOfObject:remoteName] != NSNotFound) {
 				return [PBGitRef refFromString:[kGitXRemoteRefPrefix stringByAppendingString:remoteName]];
 			}
 		}
@@ -430,7 +435,8 @@
 	return _historyViewController.selectedCommits.firstObject;
 }
 
-- (PBGitRef *)selectedRef {
+- (PBGitRef *)selectedRef
+{
 	id firstResponder = self.window.firstResponder;
 	if (firstResponder == self.sidebarViewController.sourceView) {
 		NSOutlineView *sourceView = self.sidebarViewController.sourceView;
@@ -451,44 +457,47 @@
 	return nil;
 }
 
-- (IBAction) showAddRemoteSheet:(id)sender
+- (IBAction)showAddRemoteSheet:(id)sender
 {
 	[self addRemote:sender];
 }
 
 - (IBAction)addRemote:(id)sender
 {
-	[PBAddRemoteSheet beginSheetWithWindowController:self completionHandler:^(PBAddRemoteSheet *addSheet, NSModalResponse returnCode) {
-		if (returnCode != NSModalResponseOK) return;
+	[PBAddRemoteSheet beginSheetWithWindowController:self
+								   completionHandler:^(PBAddRemoteSheet *addSheet, NSModalResponse returnCode) {
+									   if (returnCode != NSModalResponseOK) return;
 
-		NSString *remoteName = addSheet.remoteName.stringValue;
-		NSString *remoteURL = addSheet.remoteURL.stringValue;
+									   NSString *remoteName = addSheet.remoteName.stringValue;
+									   NSString *remoteURL = addSheet.remoteURL.stringValue;
 
-		NSString *description = [NSString stringWithFormat:@"Adding remote \"%@\"", remoteName];
+									   NSString *description = [NSString stringWithFormat:@"Adding remote \"%@\"", remoteName];
 
-		PBRemoteProgressSheet *progressSheet = [PBRemoteProgressSheet progressSheetWithTitle:@"Adding remote"
-																				 description:description
-																			windowController:self];
-		[progressSheet beginProgressSheetForBlock:^{
-			NSError *error = nil;
-			BOOL success = [self.repository addRemote:remoteName withURL:remoteURL error:&error];
-			return success ? nil : error;
-		} completionHandler:^(NSError *error) {
-			if (error) {
-				[self showErrorSheet:error];
-				return;
-			}
+									   PBRemoteProgressSheet *progressSheet = [PBRemoteProgressSheet progressSheetWithTitle:@"Adding remote"
+																												description:description
+																										   windowController:self];
+									   [progressSheet
+										   beginProgressSheetForBlock:^{
+											   NSError *error = nil;
+											   BOOL success = [self.repository addRemote:remoteName withURL:remoteURL error:&error];
+											   return success ? nil : error;
+										   }
+										   completionHandler:^(NSError *error) {
+											   if (error) {
+												   [self showErrorSheet:error];
+												   return;
+											   }
 
-			// Now fetch that remote
-			PBGitRef *remoteRef = [self.repository refForName:remoteName];
-			[self performFetchForRef:remoteRef];
-		}];
-	}];
+											   // Now fetch that remote
+											   PBGitRef *remoteRef = [self.repository refForName:remoteName];
+											   [self performFetchForRef:remoteRef];
+										   }];
+								   }];
 }
 
 - (IBAction)deleteRef:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXBranchType, kGitXRemoteType, kGitXTagType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXBranchType, kGitXRemoteType, kGitXTagType ]];
 	if (!refish || ![refish isKindOfClass:[PBGitRef class]])
 		return;
 
@@ -502,42 +511,44 @@
 	[alert addButtonWithTitle:NSLocalizedString(@"Delete", @"Delete ref alert - default button")];
 	[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"Delete ref alert - cancel button")];
 
-	[self confirmDialog:alert suppressionIdentifier:@"Delete Ref" forAction:^{
-		NSError *error = nil;
-		BOOL success = [self.repository deleteRef:ref error:&error];
-		if (!success) {
-			[self showErrorSheet:error];
-		}
-		return;
-	}];
+	[self confirmDialog:alert
+		suppressionIdentifier:@"Delete Ref"
+					forAction:^{
+						NSError *error = nil;
+						BOOL success = [self.repository deleteRef:ref error:&error];
+						if (!success) {
+							[self showErrorSheet:error];
+						}
+						return;
+					}];
 }
 
 - (IBAction)fetchRemote:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXBranchType, kGitXRemoteType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXBranchType, kGitXRemoteType ]];
 	if (!refish || ![refish isKindOfClass:[PBGitRef class]])
 		return;
 
 	[self performFetchForRef:refish];
 }
 
-- (IBAction) fetchAllRemotes:(id)sender
+- (IBAction)fetchAllRemotes:(id)sender
 {
 	[self performFetchForRef:nil];
 }
 
 - (IBAction)pullRemote:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXBranchType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXBranchType ]];
 	if (!refish || ![refish isKindOfClass:[PBGitRef class]])
 		return;
 
 	[self performPullForBranch:refish remote:nil rebase:NO];
 }
 
-- (IBAction) pullRebaseRemote:(id)sender
+- (IBAction)pullRebaseRemote:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXBranchType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXBranchType ]];
 	if (!refish || ![refish isKindOfClass:[PBGitRef class]])
 		return;
 
@@ -546,7 +557,7 @@
 
 - (IBAction)pullDefaultRemote:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXBranchType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXBranchType ]];
 	if (!refish || ![refish isKindOfClass:[PBGitRef class]])
 		return;
 
@@ -555,7 +566,7 @@
 
 - (IBAction)pullRebaseDefaultRemote:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXBranchType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXBranchType ]];
 	if (!refish || ![refish isKindOfClass:[PBGitRef class]])
 		return;
 	[self performPullForBranch:refish remote:nil rebase:YES];
@@ -563,7 +574,7 @@
 
 - (IBAction)pushUpdatesToRemote:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXRemoteType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXRemoteType ]];
 	if (!refish || ![refish isKindOfClass:[PBGitRef class]])
 		return;
 
@@ -574,7 +585,7 @@
 
 - (IBAction)pushDefaultRemoteForRef:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXBranchType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXBranchType ]];
 	if (!refish || ![refish isKindOfClass:[PBGitRef class]])
 		return;
 
@@ -588,11 +599,11 @@
 	NSMenuItem *remoteSubmenu = sender;
 	if (![remoteSubmenu isKindOfClass:[NSMenuItem class]]) return;
 
-	id <PBGitRefish> ref = [self refishForSender:remoteSubmenu.parentItem refishTypes:@[kGitXBranchType]];
+	id<PBGitRefish> ref = [self refishForSender:remoteSubmenu.parentItem refishTypes:@[ kGitXBranchType ]];
 	if (!ref || ![ref isKindOfClass:[PBGitRef class]])
 		return;
 
-	id <PBGitRefish> remoteRef = [self refishForSender:sender refishTypes:@[kGitXRemoteType]];
+	id<PBGitRefish> remoteRef = [self refishForSender:sender refishTypes:@[ kGitXRemoteType ]];
 	if (!remoteRef || ![remoteRef isKindOfClass:[PBGitRef class]])
 		return;
 
@@ -601,7 +612,7 @@
 
 - (IBAction)checkout:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXBranchType, kGitXRemoteBranchType, kGitXCommitType, kGitXTagType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXBranchType, kGitXRemoteBranchType, kGitXCommitType, kGitXTagType ]];
 	if (!refish) return;
 
 	NSError *error = nil;
@@ -613,7 +624,7 @@
 
 - (IBAction)merge:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXBranchType, kGitXRemoteBranchType, kGitXCommitType, kGitXTagType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXBranchType, kGitXRemoteBranchType, kGitXCommitType, kGitXTagType ]];
 	if (!refish) return;
 
 	NSError *error = nil;
@@ -625,7 +636,7 @@
 
 - (IBAction)rebase:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXCommitType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXCommitType ]];
 	if (!refish) return;
 
 	NSError *error = nil;
@@ -637,7 +648,7 @@
 
 - (IBAction)rebaseHeadBranch:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXCommitType, kGitXBranchType, kGitXRemoteBranchType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXCommitType, kGitXBranchType, kGitXRemoteBranchType ]];
 	if (!refish || ![refish conformsToProtocol:@protocol(PBGitRefish)])
 		return;
 
@@ -650,7 +661,7 @@
 
 - (IBAction)cherryPick:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXCommitType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXCommitType ]];
 	if (!refish) return;
 
 	NSError *error = nil;
@@ -662,9 +673,9 @@
 
 - (IBAction)resetSoft:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXBranchType, kGitXCommitType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXBranchType, kGitXCommitType ]];
 	if (!refish) return;
-	
+
 	NSError *error = nil;
 	BOOL success = [self.repository resetRefish:GTRepositoryResetTypeSoft to:refish error:&error];
 	if (!success) {
@@ -682,7 +693,7 @@
 	}
 }
 
-- (IBAction)stashSaveWithKeepIndex:(id) sender
+- (IBAction)stashSaveWithKeepIndex:(id)sender
 {
 	NSError *error = nil;
 	BOOL success = [self.repository stashSaveWithKeepIndex:YES error:&error];
@@ -694,7 +705,7 @@
 
 - (IBAction)stashPop:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXStashType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXStashType ]];
 	PBGitStash *stash = [self.repository stashForRef:refish];
 	if (!stash) {
 		stash = self.repository.stashes.firstObject;
@@ -709,7 +720,7 @@
 
 - (IBAction)stashApply:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXStashType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXStashType ]];
 	PBGitStash *stash = [self.repository stashForRef:refish];
 	NSError *error = nil;
 	BOOL success = [self.repository stashApply:stash error:&error];
@@ -721,7 +732,7 @@
 
 - (IBAction)stashDrop:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXStashType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXStashType ]];
 	PBGitStash *stash = [self.repository stashForRef:refish];
 	if (!stash) return;
 
@@ -731,41 +742,44 @@
 	[alert addButtonWithTitle:NSLocalizedString(@"Drop", @"Stash drop alert - default button")];
 	[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"Stash drop alert - cancel button")];
 
-	[self confirmDialog:alert suppressionIdentifier:@"Stash Drop" forAction:^{
-		NSError *error = nil;
-		BOOL success = [self.repository stashDrop:stash error:&error];
-		if (!success) {
-			[self showErrorSheet:error];
-		}
-	}];
+	[self confirmDialog:alert
+		suppressionIdentifier:@"Stash Drop"
+					forAction:^{
+						NSError *error = nil;
+						BOOL success = [self.repository stashDrop:stash error:&error];
+						if (!success) {
+							[self showErrorSheet:error];
+						}
+					}];
 }
 
-- (IBAction) openFiles:(id)sender {
-	NSArray <NSURL *> *fileURLs = [self selectedURLsFromSender:sender];
+- (IBAction)openFiles:(id)sender
+{
+	NSArray<NSURL *> *fileURLs = [self selectedURLsFromSender:sender];
 	[self openURLs:fileURLs];
 }
 
-- (IBAction) revealInFinder:(id)sender
+- (IBAction)revealInFinder:(id)sender
 {
-	[self revealURLsInFinder:@[self.repository.workingDirectoryURL]];
+	[self revealURLsInFinder:@[ self.repository.workingDirectoryURL ]];
 }
 
-- (IBAction) openInTerminal:(id)sender
+- (IBAction)openInTerminal:(id)sender
 {
 	[PBTerminalUtil runCommand:@"git status" inDirectory:self.repository.workingDirectoryURL];
 }
 
-- (IBAction) refresh:(id)sender
+- (IBAction)refresh:(id)sender
 {
 	[contentController refresh:self];
 }
 
-- (IBAction) createBranch:(id)sender
+- (IBAction)createBranch:(id)sender
 {
 	PBGitRef *currentRef = [self.repository.currentBranch ref];
 
 	/* WIP: must check */
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:nil];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:nil];
 	if (!refish) {
 		PBGitCommit *selectedCommit = _historyViewController.selectedCommits.firstObject;
 		if (!selectedCommit || [selectedCommit hasRef:currentRef]) {
@@ -775,32 +789,34 @@
 		}
 	}
 
-	[PBCreateBranchSheet beginSheetWithRefish:refish windowController:self completionHandler:^(PBCreateBranchSheet *sheet, NSModalResponse returnCode) {
-		if (returnCode != NSModalResponseOK) return;
+	[PBCreateBranchSheet beginSheetWithRefish:refish
+							 windowController:self
+							completionHandler:^(PBCreateBranchSheet *sheet, NSModalResponse returnCode) {
+								if (returnCode != NSModalResponseOK) return;
 
-		NSError *error = nil;
-		BOOL success = [self.repository createBranch:[sheet.branchNameField stringValue] atRefish:sheet.startRefish error:&error];
-		if (!success) {
-			[self showErrorSheet:error];
-			return;
-		}
+								NSError *error = nil;
+								BOOL success = [self.repository createBranch:[sheet.branchNameField stringValue] atRefish:sheet.startRefish error:&error];
+								if (!success) {
+									[self showErrorSheet:error];
+									return;
+								}
 
-		[PBGitDefaults setShouldCheckoutBranch:sheet.shouldCheckoutBranch];
+								[PBGitDefaults setShouldCheckoutBranch:sheet.shouldCheckoutBranch];
 
-		if (sheet.shouldCheckoutBranch) {
-			success = [self.repository checkoutRefish:sheet.selectedRef error:&error];
-			if (!success) {
-				[self showErrorSheet:error];
-				return;
-			}
-		}
-	}];
+								if (sheet.shouldCheckoutBranch) {
+									success = [self.repository checkoutRefish:sheet.selectedRef error:&error];
+									if (!success) {
+										[self showErrorSheet:error];
+										return;
+									}
+								}
+							}];
 }
 
-- (IBAction) createTag:(id)sender
+- (IBAction)createTag:(id)sender
 {
 	/* WIP: must check */
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:nil];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:nil];
 	if (!refish) {
 		PBGitCommit *selectedCommit = _historyViewController.selectedCommits.firstObject;
 		if (selectedCommit)
@@ -809,22 +825,24 @@
 			refish = self.repository.currentBranch.ref;
 	}
 
-	[PBCreateTagSheet beginSheetWithRefish:refish windowController:self completionHandler:^(PBCreateTagSheet *sheet, NSModalResponse returnCode) {
-		if (returnCode != NSModalResponseOK) return;
+	[PBCreateTagSheet beginSheetWithRefish:refish
+						  windowController:self
+						 completionHandler:^(PBCreateTagSheet *sheet, NSModalResponse returnCode) {
+							 if (returnCode != NSModalResponseOK) return;
 
-		NSString *tagName = [sheet.tagNameField stringValue];
-		NSString *message = [sheet.tagMessageText string];
-		NSError *error = nil;
-		BOOL success = [self.repository createTag:tagName message:message atRefish:sheet.targetRefish error:&error];
-		if (!success) {
-			[self showErrorSheet:error];
-		}
-	}];
+							 NSString *tagName = [sheet.tagNameField stringValue];
+							 NSString *message = [sheet.tagMessageText string];
+							 NSError *error = nil;
+							 BOOL success = [self.repository createTag:tagName message:message atRefish:sheet.targetRefish error:&error];
+							 if (!success) {
+								 [self showErrorSheet:error];
+							 }
+						 }];
 }
 
 - (IBAction)diffWithHEAD:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:nil];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:nil];
 	if (!refish)
 		return;
 
@@ -841,14 +859,14 @@
 
 - (IBAction)stashViewDiff:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXStashType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXStashType ]];
 	PBGitStash *stash = [self.repository stashForRef:refish];
 	[PBDiffWindowController showDiffWindowWithFiles:nil fromCommit:stash.ancestorCommit diffCommit:stash.commit];
 }
 
 - (IBAction)showTagInfoSheet:(id)sender
 {
-	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXTagType]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXTagType ]];
 	if (!refish)
 		return;
 
@@ -865,7 +883,7 @@
 	NSString *title = [NSString stringWithFormat:@"Info for tag: %@", tagName];
 	NSString *info = @"";
 	if ([object isKindOfClass:[GTTag class]]) {
-		GTTag *tag = (GTTag*)object;
+		GTTag *tag = (GTTag *)object;
 		info = tag.message;
 	}
 
@@ -888,17 +906,18 @@
 
 	[alert setShowsSuppressionButton:YES];
 
-	[alert beginSheetModalForWindow:self.window completionHandler:^(NSModalResponse returnCode) {
-		if (returnCode != NSAlertFirstButtonReturn) {
-			didAct = NO;
-			return;
-		}
+	[alert beginSheetModalForWindow:self.window
+				  completionHandler:^(NSModalResponse returnCode) {
+					  if (returnCode != NSAlertFirstButtonReturn) {
+						  didAct = NO;
+						  return;
+					  }
 
-		if (identifier && [alert.suppressionButton state] == NSOnState)
-			[PBGitDefaults suppressDialogWarningForDialog:identifier];
+					  if (identifier && [alert.suppressionButton state] == NSOnState)
+						  [PBGitDefaults suppressDialogWarningForDialog:identifier];
 
-		actionBlock();
-	}];
+					  actionBlock();
+				  }];
 
 	return didAct;
 }

--- a/Classes/Controllers/PBHistorySearchController.m
+++ b/Classes/Controllers/PBHistorySearchController.m
@@ -68,7 +68,7 @@
 
 - (void)selectSearchMode:(id)sender
 {
-	[self setSearchMode:PBSearchModeForInteger([(NSView*)sender tag])];
+	[self setSearchMode:PBSearchModeForInteger([(NSView *)sender tag])];
 	[self updateSearch:self];
 }
 
@@ -127,10 +127,13 @@
 
 	[self updateUI];
 
-	[commitController addObserver:self keyPath:@"arrangedObjects" options:0 block:^(MAKVONotification *notification) {
-		// the objects in the commitlist changed so the result indexes are no longer valid
-		[self clearSearch];
-	}];
+	[commitController addObserver:self
+						  keyPath:@"arrangedObjects"
+						  options:0
+							block:^(MAKVONotification *notification) {
+								// the objects in the commitlist changed so the result indexes are no longer valid
+								[self clearSearch];
+							}];
 }
 
 #pragma mark -
@@ -184,8 +187,8 @@
 		return NSLocalizedString(@"1 match", @"Search count (left of search field): exactly one result");
 
 	return [NSString stringWithFormat:
-			NSLocalizedString(@"%lu matches", @"Search count (left of search field): number of results"),
-			numberOfMatches];
+						 NSLocalizedString(@"%lu matches", @"Search count (left of search field): number of results"),
+						 numberOfMatches];
 }
 
 - (void)updateUI
@@ -193,8 +196,7 @@
 	if ([[searchField stringValue] isEqualToString:@""]) {
 		[numberOfMatchesField setHidden:YES];
 		[stepper setHidden:YES];
-	}
-	else {
+	} else {
 		[numberOfMatchesField setStringValue:[self numberOfMatchesString]];
 		[numberOfMatchesField setHidden:NO];
 		[stepper setHidden:NO];
@@ -225,26 +227,26 @@
 - (void)setupSearchMenuTemplate
 {
 	NSMenu *searchMenu = [[NSMenu alloc] initWithTitle:NSLocalizedString(@"Search Menu", @"Title of the Search menu.")];
-    NSMenuItem *item;
+	NSMenuItem *item;
 
 	item = [[NSMenuItem alloc] initWithTitle:kGitXBasicSearchLabel action:@selector(selectSearchMode:) keyEquivalent:@""];
 	[item setTarget:self];
-    [item setTag:PBHistorySearchModeBasic];
-    [searchMenu addItem:item];
+	[item setTag:PBHistorySearchModeBasic];
+	[searchMenu addItem:item];
 
 	item = [[NSMenuItem alloc] initWithTitle:kGitXPickaxeSearchLabel action:@selector(selectSearchMode:) keyEquivalent:@""];
 	[item setTarget:self];
-    [item setTag:PBHistorySearchModePickaxe];
-    [searchMenu addItem:item];
+	[item setTag:PBHistorySearchModePickaxe];
+	[searchMenu addItem:item];
 
 	item = [[NSMenuItem alloc] initWithTitle:kGitXRegexSearchLabel action:@selector(selectSearchMode:) keyEquivalent:@""];
 	[item setTarget:self];
-    [item setTag:PBHistorySearchModeRegex];
-    [searchMenu addItem:item];
+	[item setTag:PBHistorySearchModeRegex];
+	[searchMenu addItem:item];
 
 	item = [[NSMenuItem alloc] initWithTitle:kGitXPathSearchLabel action:@selector(selectSearchMode:) keyEquivalent:@""];
 	[item setTarget:self];
-    [item setTag:PBHistorySearchModePath];
+	[item setTag:PBHistorySearchModePath];
 	[searchMenu addItem:item];
 
 	item = [[NSMenuItem alloc] initWithTitle:kGitXRawSearchLabel action:@selector(selectSearchMode:) keyEquivalent:@""];
@@ -252,30 +254,30 @@
 	[item setTag:PBHistorySearchModeRaw];
 	[searchMenu addItem:item];
 
-    item = [NSMenuItem separatorItem];
-    [searchMenu addItem:item];
+	item = [NSMenuItem separatorItem];
+	[searchMenu addItem:item];
 
 	item = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Recent Searches", @"Searches menu: title of inactive headline item for Recent Searches section") action:NULL keyEquivalent:@""];
-    [item setTag:NSSearchFieldRecentsTitleMenuItemTag];
-    [searchMenu addItem:item];
+	[item setTag:NSSearchFieldRecentsTitleMenuItemTag];
+	[searchMenu addItem:item];
 
-    item = [[NSMenuItem alloc] initWithTitle:@"" action:NULL keyEquivalent:@""];
-    [item setTag:NSSearchFieldRecentsMenuItemTag];
-    [searchMenu addItem:item];
+	item = [[NSMenuItem alloc] initWithTitle:@"" action:NULL keyEquivalent:@""];
+	[item setTag:NSSearchFieldRecentsMenuItemTag];
+	[searchMenu addItem:item];
 
-    item = [NSMenuItem separatorItem];
-    [item setTag:NSSearchFieldRecentsTitleMenuItemTag];
-    [searchMenu addItem:item];
+	item = [NSMenuItem separatorItem];
+	[item setTag:NSSearchFieldRecentsTitleMenuItemTag];
+	[searchMenu addItem:item];
 
 	item = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Clear Recent Searches", @"Searches menu: title of clear recent searches item") action:NULL keyEquivalent:@""];
-    [item setTag:NSSearchFieldClearRecentsMenuItemTag];
-    [searchMenu addItem:item];
+	[item setTag:NSSearchFieldClearRecentsMenuItemTag];
+	[searchMenu addItem:item];
 
 	item = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"No Recent Searches", @"Searches menu: title of dummy item displayed in recent searches section when there are no recent searches") action:NULL keyEquivalent:@""];
-    [item setTag:NSSearchFieldNoRecentsMenuItemTag];
-    [searchMenu addItem:item];
+	[item setTag:NSSearchFieldNoRecentsMenuItemTag];
+	[searchMenu addItem:item];
 
-    [[searchField cell] setSearchMenuTemplate:searchMenu];
+	[[searchField cell] setSearchMenuTemplate:searchMenu];
 }
 
 - (void)updateSearchMenuState
@@ -290,13 +292,14 @@
 	[self updateSearchModeMenuItemWithTag:PBHistorySearchModePath inMenu:searchMenu];
 	[self updateSearchModeMenuItemWithTag:PBHistorySearchModeRaw inMenu:searchMenu];
 
-    [[searchField cell] setSearchMenuTemplate:searchMenu];
+	[[searchField cell] setSearchMenuTemplate:searchMenu];
 
 	[PBGitDefaults setHistorySearchMode:searchMode];
 }
 
-- (void) updateSearchModeMenuItemWithTag:(PBHistorySearchMode)menuItemSearchMode inMenu:(NSMenu *) searchMenu {
-	NSMenuItem * menuItem = [searchMenu itemWithTag:menuItemSearchMode];
+- (void)updateSearchModeMenuItemWithTag:(PBHistorySearchMode)menuItemSearchMode inMenu:(NSMenu *)searchMenu
+{
+	NSMenuItem *menuItem = [searchMenu itemWithTag:menuItemSearchMode];
 	[menuItem setState:(searchMode == menuItemSearchMode) ? NSOnState : NSOffState];
 }
 
@@ -335,7 +338,7 @@
 	[self updateSearchPlaceholderString];
 }
 
-- (void)searchTimerFired:(NSTimer*)theTimer
+- (void)searchTimerFired:(NSTimer *)theTimer
 {
 	[self.progressIndicator setHidden:NO];
 	[self.progressIndicator startAnimation:self];
@@ -356,7 +359,6 @@
 	[stepper setHidden:YES];
 	searchTimer = [NSTimer scheduledTimerWithTimeInterval:0.25 target:self selector:@selector(searchTimerFired:) userInfo:nil repeats:NO];
 }
-
 
 
 #pragma mark Basic Search
@@ -383,7 +385,6 @@
 
 	[self updateSelectedResult];
 }
-
 
 
 #pragma mark Background Search
@@ -471,7 +472,6 @@
 }
 
 
-
 #pragma mark -
 #pragma mark Rewind Panel
 
@@ -528,8 +528,8 @@
 {
 	CAKeyframeAnimation *animation = [CAKeyframeAnimation animation];
 	animation.duration = 1.0f;
-	animation.values = @[@1.0f, @1.0f, @0.0f, @0.0f];
-	animation.keyTimes = @[@0.1f, @0.3f, @0.7f, [NSNumber numberWithDouble:animation.duration]];
+	animation.values = @[ @1.0f, @1.0f, @0.0f, @0.0f ];
+	animation.keyTimes = @[ @0.1f, @0.3f, @0.7f, [NSNumber numberWithDouble:animation.duration] ];
 	return animation;
 }
 
@@ -550,9 +550,9 @@
 	NSImage *reversedRewindImage = [NSImage imageWithSize:rewindImage.size
 												  flipped:isReversed
 										   drawingHandler:^BOOL(NSRect destRect) {
-		[rewindImage drawInRect:destRect fromRect:NSZeroRect operation:NSCompositeCopy fraction:1.0];
-		return YES;
-	}];
+											   [rewindImage drawInRect:destRect fromRect:NSZeroRect operation:NSCompositeCopy fraction:1.0];
+											   return YES;
+										   }];
 	NSImageView *rewindImageView = [rewindPanel.contentView viewWithTag:kRewindPanelImageViewTag];
 	[rewindImageView setImage:reversedRewindImage];
 

--- a/Classes/Controllers/PBHistorySearchMode.h
+++ b/Classes/Controllers/PBHistorySearchMode.h
@@ -17,8 +17,8 @@ typedef NS_ENUM(NSInteger, PBHistorySearchMode) {
 	PBHistorySearchModeRegex,
 	PBHistorySearchModePath,
 	PBHistorySearchModeRaw,
-	PBHistorySearchModeMax    // always keep this item last
-} ;
+	PBHistorySearchModeMax // always keep this item last
+};
 
 
 PBHistorySearchMode PBSearchModeForInteger(NSInteger modeInteger);

--- a/Classes/Controllers/PBHistorySearchMode.m
+++ b/Classes/Controllers/PBHistorySearchMode.m
@@ -7,7 +7,8 @@
 
 #import "PBHistorySearchMode.h"
 
-PBHistorySearchMode PBSearchModeForInteger(NSInteger modeInteger) {
+PBHistorySearchMode PBSearchModeForInteger(NSInteger modeInteger)
+{
 	if (modeInteger >= PBHistorySearchModeBasic && modeInteger < PBHistorySearchModeMax) {
 		return (PBHistorySearchMode)modeInteger;
 	}

--- a/Classes/Controllers/PBOpenShallowRepositoryErrorRecoveryAttempter.h
+++ b/Classes/Controllers/PBOpenShallowRepositoryErrorRecoveryAttempter.h
@@ -10,8 +10,8 @@
 
 @interface PBOpenShallowRepositoryErrorRecoveryAttempter : NSObject
 
-- (instancetype) initWithURL:(NSURL *)url;
+- (instancetype)initWithURL:(NSURL *)url;
 
-+ (NSArray<NSString*>*) errorDialogButtonNames;
++ (NSArray<NSString *> *)errorDialogButtonNames;
 
 @end

--- a/Classes/Controllers/PBOpenShallowRepositoryErrorRecoveryAttempter.m
+++ b/Classes/Controllers/PBOpenShallowRepositoryErrorRecoveryAttempter.m
@@ -11,9 +11,10 @@
 
 @implementation PBOpenShallowRepositoryErrorRecoveryAttempter
 
-NSURL * workingDirectory;
+NSURL *workingDirectory;
 
-- (instancetype) initWithURL:(NSURL *)url {
+- (instancetype)initWithURL:(NSURL *)url
+{
 	if (self != nil) {
 		workingDirectory = url;
 	}
@@ -21,20 +22,22 @@ NSURL * workingDirectory;
 }
 
 - (BOOL)attemptRecoveryFromError:(NSError *)error
-					 optionIndex:(NSUInteger)recoveryOptionIndex {
-
+					 optionIndex:(NSUInteger)recoveryOptionIndex
+{
 	if (recoveryOptionIndex == 1) {
-		NSString * unshallowCommand = @"echo 'Please re-open the repository in GitX once unshallowing has finished.'; git fetch --unshallow";
+		NSString *unshallowCommand = @"echo 'Please re-open the repository in GitX once unshallowing has finished.'; git fetch --unshallow";
 		[PBTerminalUtil runCommand:unshallowCommand inDirectory:workingDirectory];
 		return NO;
 	}
 	return NO;
 }
 
-+ (NSArray<NSString*>*) errorDialogButtonNames {
++ (NSArray<NSString *> *)errorDialogButtonNames
+{
 	return @[
-	  NSLocalizedString(@"OK", @"OK"),
-	  NSLocalizedString(@"Run command in Terminal", @"Button to run unshallow command in Terminal")];
+		NSLocalizedString(@"OK", @"OK"),
+		NSLocalizedString(@"Run command in Terminal", @"Button to run unshallow command in Terminal")
+	];
 }
 
 @end

--- a/Classes/Controllers/PBPrefsWindowController.h
+++ b/Classes/Controllers/PBPrefsWindowController.h
@@ -20,13 +20,12 @@
 	IBOutlet NSImageView *badGitPathIcon;
 	IBOutlet NSView *gitPathOpenAccessory;
 	NSOpenPanel *gitPathOpenPanel;
-
 }
 
-- (IBAction) checkGitValidity: sender;
+- (IBAction)checkGitValidity:sender;
 - (void)pathCell:(NSPathCell *)pathCell willDisplayOpenPanel:(NSOpenPanel *)openPanel;
-- (IBAction) showHideAllFiles: sender;
-- (IBAction) resetGitPath: sender;
+- (IBAction)showHideAllFiles:sender;
+- (IBAction)resetGitPath:sender;
 - (IBAction)resetAllDialogWarnings:(id)sender;
 
 @end

--- a/Classes/Controllers/PBPrefsWindowController.m
+++ b/Classes/Controllers/PBPrefsWindowController.m
@@ -14,7 +14,7 @@
 
 @implementation PBPrefsWindowController
 
-# pragma mark DBPrefsWindowController overrides
+#pragma mark DBPrefsWindowController overrides
 
 - (void)setupToolbar
 {
@@ -45,13 +45,13 @@
 #pragma mark -
 #pragma mark Delegate methods
 
-- (IBAction) checkGitValidity: sender
+- (IBAction)checkGitValidity:sender
 {
 	// FIXME: This does not work reliably, probably due to: http://www.cocoabuilder.com/archive/message/cocoa/2008/9/10/217850
 	//[badGitPathIcon setHidden:[PBGitRepository validateGit:[[NSValueTransformer valueTransformerForName:@"PBNSURLPathUserDefaultsTransfomer"] reverseTransformedValue:[gitPathController URL]]]];
 }
 
-- (IBAction) resetGitPath: sender
+- (IBAction)resetGitPath:sender
 {
 	[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"gitExecutable"];
 }
@@ -77,7 +77,7 @@
 #pragma mark -
 #pragma mark Git Path open panel actions
 
-- (IBAction) showHideAllFiles: sender
+- (IBAction)showHideAllFiles:sender
 {
 	/* FIXME: This uses undocumented OpenPanel features to show hidden files! */
 	NSNumber *showHidden = [NSNumber numberWithBool:[sender state] == NSOnState];

--- a/Classes/Controllers/PBRepositoryDocumentController.m
+++ b/Classes/Controllers/PBRepositoryDocumentController.m
@@ -16,7 +16,8 @@
 @implementation PBRepositoryDocumentController
 // This method is overridden to configure the open panel to only allow
 // selection of directories
-- (void)beginOpenPanel:(NSOpenPanel *)openPanel forTypes:(NSArray<NSString *> *)inTypes completionHandler:(void (^)(NSInteger))completionHandler {
+- (void)beginOpenPanel:(NSOpenPanel *)openPanel forTypes:(NSArray<NSString *> *)inTypes completionHandler:(void (^)(NSInteger))completionHandler
+{
 	[openPanel setCanChooseFiles:YES];
 	[openPanel setCanChooseDirectories:YES];
 	[openPanel setAllowedFileTypes:[NSArray arrayWithObject:@"git"]];
@@ -26,7 +27,8 @@
 	completionHandler(response);
 }
 
-- (id)makeUntitledDocumentOfType:(NSString *)typeName error:(NSError *__autoreleasing *)outError {
+- (id)makeUntitledDocumentOfType:(NSString *)typeName error:(NSError *__autoreleasing *)outError
+{
 	NSOpenPanel *op = [NSOpenPanel openPanel];
 
 	[op setCanChooseFiles:NO];
@@ -38,14 +40,14 @@
 		if (outError) {
 			*outError = [NSError errorWithDomain:NSCocoaErrorDomain code:NSUserCancelledError userInfo:nil];
 		}
-        return nil;
-    }
+		return nil;
+	}
 
 	GTRepository *repo = [GTRepository initializeEmptyRepositoryAtFileURL:[op URL] options:nil error:outError];
-    if (!repo)
-        return nil; // Repo creation failed
+	if (!repo)
+		return nil; // Repo creation failed
 
-    return [[PBGitRepositoryDocument alloc] initWithContentsOfURL:[op URL] ofType:PBGitRepositoryDocumentType error:outError];
+	return [[PBGitRepositoryDocument alloc] initWithContentsOfURL:[op URL] ofType:PBGitRepositoryDocumentType error:outError];
 }
 
 - (BOOL)validateMenuItem:(NSMenuItem *)item

--- a/Classes/Controllers/PBServicesController.m
+++ b/Classes/Controllers/PBServicesController.m
@@ -16,10 +16,9 @@
 - (NSString *)completeSHA1For:(NSString *)sha error:(NSString **)error
 {
 	NSArray *documents = [[NSApplication sharedApplication] orderedDocuments];
-	for (PBGitRepositoryDocument *doc in documents)
-	{
+	for (PBGitRepositoryDocument *doc in documents) {
 		NSError *error = nil;
-		NSString *s = [doc.repository outputOfTaskWithArguments:@[@"log", @"-1", @"--pretty=format:%h (%s)", sha] error:&error];
+		NSString *s = [doc.repository outputOfTaskWithArguments:@[ @"log", @"-1", @"--pretty=format:%h (%s)", sha ] error:&error];
 		if (s) {
 			return s;
 		}
@@ -54,8 +53,7 @@
 - (void)completeSha:(NSPasteboard *)pboard userData:(NSString *)userData error:(NSString **)error
 {
 	NSArray *types = [pboard types];
-	if (![types containsObject:NSStringPboardType])
-	{
+	if (![types containsObject:NSStringPboardType]) {
 		*error = @"Could not get data";
 		return;
 	}

--- a/Classes/Controllers/PBViewController.h
+++ b/Classes/Controllers/PBViewController.h
@@ -28,9 +28,9 @@
 - (void)closeView;
 
 /* Updateview is called every time it is loaded into the main view */
-- (void) updateView;
+- (void)updateView;
 
 - (NSResponder *)firstResponder;
-- (IBAction) refresh:(id)sender;
+- (IBAction)refresh:(id)sender;
 
 @end

--- a/Classes/Controllers/PBViewController.m
+++ b/Classes/Controllers/PBViewController.m
@@ -15,8 +15,8 @@
 
 @implementation PBViewController
 
-@synthesize repository=repository;
-@synthesize windowController=superController;
+@synthesize repository = repository;
+@synthesize windowController = superController;
 
 - (id)initWithRepository:(PBGitRepository *)theRepository superController:(PBGitWindowController *)controller
 {
@@ -27,7 +27,7 @@
 
 	repository = theRepository;
 	superController = controller;
-	
+
 	return self;
 }
 
@@ -35,7 +35,7 @@
 {
 	[self unbind:@"repository"];
 	if (_hasViewLoaded)
-		[[self view] removeFromSuperview];	// remove the current view
+		[[self view] removeFromSuperview]; // remove the current view
 }
 
 - (void)awakeFromNib
@@ -48,7 +48,7 @@
 	return nil;
 }
 
-- (IBAction) refresh: sender
+- (IBAction)refresh:sender
 {
 }
 

--- a/Classes/Controllers/PBWebChangesController.h
+++ b/Classes/Controllers/PBWebChangesController.h
@@ -23,8 +23,8 @@
 	BOOL selectedFileIsCached;
 }
 
-- (void) refresh;
-- (void) setStateMessage:(NSString *)state;
+- (void)refresh;
+- (void)setStateMessage:(NSString *)state;
 
-- (void) showMultiple:(NSArray *)files;
+- (void)showMultiple:(NSArray *)files;
 @end

--- a/Classes/Controllers/PBWebChangesController.m
+++ b/Classes/Controllers/PBWebChangesController.m
@@ -9,15 +9,15 @@
 #import "PBWebChangesController.h"
 #import "PBGitIndex.h"
 
-static void * const UnstagedFileSelectedContext = @"UnstagedFileSelectedContext";
-static void * const CachedFileSelectedContext = @"CachedFileSelectedContext";
+static void *const UnstagedFileSelectedContext = @"UnstagedFileSelectedContext";
+static void *const CachedFileSelectedContext = @"CachedFileSelectedContext";
 
 @interface PBWebChangesController () <WebEditingDelegate, WebUIDelegate>
 @end
 
 @implementation PBWebChangesController
 
-- (void) awakeFromNib
+- (void)awakeFromNib
 {
 	selectedFile = nil;
 	selectedFileIsCached = NO;
@@ -41,7 +41,7 @@ static void * const CachedFileSelectedContext = @"CachedFileSelectedContext";
 	[super closeView];
 }
 
-- (void) didLoad
+- (void)didLoad
 {
 	[[self script] setValue:controller.index forKey:@"Index"];
 	[self refresh];
@@ -60,7 +60,7 @@ static void * const CachedFileSelectedContext = @"CachedFileSelectedContext";
 	otherController = object == unstagedFilesController ? stagedFilesController : unstagedFilesController;
 	NSUInteger count = [object selectedObjects].count;
 	if (count == 0) {
-		if([[otherController selectedObjects] count] == 0 && selectedFile) {
+		if ([[otherController selectedObjects] count] == 0 && selectedFile) {
 			selectedFile = nil;
 			selectedFileIsCached = NO;
 			[self refresh];
@@ -72,7 +72,7 @@ static void * const CachedFileSelectedContext = @"CachedFileSelectedContext";
 	[otherController setSelectionIndexes:[NSIndexSet indexSet]];
 
 	if (count > 1) {
-		[self showMultiple: [object selectedObjects]];
+		[self showMultiple:[object selectedObjects]];
 		return;
 	}
 
@@ -82,20 +82,20 @@ static void * const CachedFileSelectedContext = @"CachedFileSelectedContext";
 	[self refresh];
 }
 
-- (void) showMultiple: (NSArray *)objects
+- (void)showMultiple:(NSArray *)objects
 {
 	[[self script] callWebScriptMethod:@"showMultipleFilesSelection" withArguments:[NSArray arrayWithObject:objects]];
 }
 
-- (void) refresh
+- (void)refresh
 {
 	if (!finishedLoading)
 		return;
 
 	id script = self.view.windowScriptObject;
 	[script callWebScriptMethod:@"showFileChanges"
-		      withArguments:[NSArray arrayWithObjects:selectedFile ?: (id)[NSNull null],
-				     [NSNumber numberWithBool:selectedFileIsCached], nil]];
+				  withArguments:[NSArray arrayWithObjects:selectedFile ?: (id)[NSNull null],
+														  [NSNumber numberWithBool:selectedFileIsCached], nil]];
 }
 
 - (void)stageHunk:(NSString *)hunk reverse:(BOOL)reverse
@@ -106,10 +106,10 @@ static void * const CachedFileSelectedContext = @"CachedFileSelectedContext";
 	[self refresh];
 }
 
-- (void) discardHunk:(NSString *)hunk
+- (void)discardHunk:(NSString *)hunk
 {
-    [controller.index applyPatch:hunk stage:NO reverse:YES];
-    [self refresh];
+	[controller.index applyPatch:hunk stage:NO reverse:YES];
+	[self refresh];
 }
 
 - (void)discardHunk:(NSString *)hunk altKey:(BOOL)altKey
@@ -122,26 +122,29 @@ static void * const CachedFileSelectedContext = @"CachedFileSelectedContext";
 		[alert addButtonWithTitle:NSLocalizedString(@"OK", @"OK (discarding a hunk in the changes view)")];
 		[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"Cancel (discarding a hunk in the changes view)")];
 
-		[controller.windowController confirmDialog:alert suppressionIdentifier:nil forAction:^{
-			[self discardHunk:hunk];
-		}];
+		[controller.windowController confirmDialog:alert
+							 suppressionIdentifier:nil
+										 forAction:^{
+											 [self discardHunk:hunk];
+										 }];
 	} else {
-        [self discardHunk:hunk];
-    }
+		[self discardHunk:hunk];
+	}
 }
 
-- (void) setStateMessage:(NSString *)state
+- (void)setStateMessage:(NSString *)state
 {
 	id script = self.view.windowScriptObject;
-	[script callWebScriptMethod:@"setState" withArguments: [NSArray arrayWithObject:state]];
+	[script callWebScriptMethod:@"setState" withArguments:[NSArray arrayWithObject:state]];
 }
 
--(void)copy: (NSString *)text{
+- (void)copy:(NSString *)text
+{
 	NSArray *lines = [text componentsSeparatedByString:@"\n"];
-	NSMutableArray *processedLines = [NSMutableArray arrayWithCapacity:lines.count -1];
+	NSMutableArray *processedLines = [NSMutableArray arrayWithCapacity:lines.count - 1];
 	for (int i = 0; i < lines.count; i++) {
 		NSString *line = [lines objectAtIndex:i];
-		if (line.length>0) {
+		if (line.length > 0) {
 			[processedLines addObject:[line substringFromIndex:1]];
 		} else {
 			[processedLines addObject:line];
@@ -154,7 +157,7 @@ static void * const CachedFileSelectedContext = @"CachedFileSelectedContext";
 
 - (BOOL)webView:(WebView *)webView
 	validateUserInterfaceItem:(id<NSValidatedUserInterfaceItem>)item
-	defaultValidation:(BOOL)defaultValidation
+			defaultValidation:(BOOL)defaultValidation
 {
 	if (item.action == @selector(copy:)) {
 		return YES;

--- a/Classes/Controllers/PBWebController.h
+++ b/Classes/Controllers/PBWebController.h
@@ -21,9 +21,9 @@
 }
 
 @property (weak) IBOutlet WebView *view;
-@property  NSString *startFile;
+@property NSString *startFile;
 @property (weak) id repository;
 
-- (WebScriptObject *) script;
-- (void) closeView;
+- (WebScriptObject *)script;
+- (void)closeView;
 @end

--- a/Classes/Controllers/PBWebController.m
+++ b/Classes/Controllers/PBWebController.m
@@ -22,24 +22,24 @@
 
 @synthesize startFile, repository;
 
-- (void) awakeFromNib
+- (void)awakeFromNib
 {
 	NSString *path = [NSString stringWithFormat:@"html/views/%@", startFile];
-	NSString* file = [[NSBundle mainBundle] pathForResource:@"index" ofType:@"html" inDirectory:path];
-	NSURLRequest * request = [NSURLRequest requestWithURL:[NSURL fileURLWithPath:file]];
-	callbacks = [NSMapTable mapTableWithKeyOptions:(NSPointerFunctionsObjectPointerPersonality|NSPointerFunctionsStrongMemory) valueOptions:(NSPointerFunctionsObjectPointerPersonality|NSPointerFunctionsStrongMemory)];
+	NSString *file = [[NSBundle mainBundle] pathForResource:@"index" ofType:@"html" inDirectory:path];
+	NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL fileURLWithPath:file]];
+	callbacks = [NSMapTable mapTableWithKeyOptions:(NSPointerFunctionsObjectPointerPersonality | NSPointerFunctionsStrongMemory) valueOptions:(NSPointerFunctionsObjectPointerPersonality | NSPointerFunctionsStrongMemory)];
 
 	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
 	[nc addObserver:self
-	       selector:@selector(preferencesChangedWithNotification:)
-		   name:NSUserDefaultsDidChangeNotification
-		 object:nil];
+		   selector:@selector(preferencesChangedWithNotification:)
+			   name:NSUserDefaultsDidChangeNotification
+			 object:nil];
 
 	[nc addObserver:self
 		   selector:@selector(windowWillStartLiveResizeWithNotification:)
 			   name:NSWindowWillStartLiveResizeNotification
 			 object:self.view.window];
-	
+
 	[nc addObserver:self
 		   selector:@selector(windowDidEndLiveResizeWithNotification:)
 			   name:NSWindowDidEndLiveResizeNotification
@@ -61,7 +61,7 @@
 	[self.view.mainFrame loadRequest:request];
 }
 
-- (WebScriptObject *) script
+- (WebScriptObject *)script
 {
 	return self.view.windowScriptObject;
 }
@@ -69,7 +69,7 @@
 - (void)effectiveAppearanceDidChange:(NSNotification *)notif
 {
 	NSString *mode = [NSApp isDarkMode] ? @"DARK" : @"LIGHT";
-	[self.script callWebScriptMethod:@"setAppearance" withArguments:@[mode]];
+	[self.script callWebScriptMethod:@"setAppearance" withArguments:@[ mode ]];
 }
 
 - (void)closeView
@@ -86,7 +86,7 @@
 {
 }
 
-# pragma mark Delegate methods
+#pragma mark Delegate methods
 
 - (void)webView:(WebView *)sender didClearWindowObject:(WebScriptObject *)windowObject forFrame:(WebFrame *)frame
 {
@@ -94,7 +94,7 @@
 	[script setValue:self forKey:@"Controller"];
 }
 
-- (void) webView:(id) v didFinishLoadForFrame:(id) frame
+- (void)webView:(id)v didFinishLoadForFrame:(id)frame
 {
 	finishedLoading = YES;
 	if ([self respondsToSelector:@selector(didLoad)])
@@ -108,10 +108,10 @@
 }
 
 - (NSURLRequest *)webView:(WebView *)sender
-                 resource:(id)identifier
-          willSendRequest:(NSURLRequest *)request
-         redirectResponse:(NSURLResponse *)redirectResponse
-           fromDataSource:(WebDataSource *)dataSource
+				 resource:(id)identifier
+		  willSendRequest:(NSURLRequest *)request
+		 redirectResponse:(NSURLResponse *)redirectResponse
+		   fromDataSource:(WebDataSource *)dataSource
 {
 	if (!self.repository)
 		return request;
@@ -126,28 +126,25 @@
 }
 
 - (void)webView:(WebView *)sender
-decidePolicyForNavigationAction:(NSDictionary *)actionInformation
-        request:(NSURLRequest *)request
-		  frame:(WebFrame *)frame
-decisionListener:(id <WebPolicyDecisionListener>)listener
+	decidePolicyForNavigationAction:(NSDictionary *)actionInformation
+							request:(NSURLRequest *)request
+							  frame:(WebFrame *)frame
+				   decisionListener:(id<WebPolicyDecisionListener>)listener
 {
-	NSString* scheme = [[request URL] scheme];
+	NSString *scheme = [[request URL] scheme];
 	if ([scheme compare:@"http"] == NSOrderedSame ||
-		[scheme compare:@"https"] == NSOrderedSame)
-	{
+		[scheme compare:@"https"] == NSOrderedSame) {
 		[listener ignore];
 		[[NSWorkspace sharedWorkspace] openURL:[request URL]];
-	}
-	else
-	{
+	} else {
 		[listener use];
 	}
 }
 
 - (NSUInteger)webView:(WebView *)webView
-dragDestinationActionMaskForDraggingInfo:(id<NSDraggingInfo>)draggingInfo
+	dragDestinationActionMaskForDraggingInfo:(id<NSDraggingInfo>)draggingInfo
 {
-    return NSDragOperationNone;
+	return NSDragOperationNone;
 }
 
 + (BOOL)isSelectorExcludedFromWebScript:(SEL)aSelector
@@ -155,24 +152,25 @@ dragDestinationActionMaskForDraggingInfo:(id<NSDraggingInfo>)draggingInfo
 	return NO;
 }
 
-+ (BOOL)isKeyExcludedFromWebScript:(const char *)name {
++ (BOOL)isKeyExcludedFromWebScript:(const char *)name
+{
 	return NO;
 }
 
 #pragma mark Functions to be used from JavaScript
 
-- (void) log: (NSString*) logMessage
+- (void)log:(NSString *)logMessage
 {
 	NSLog(@"%@", logMessage);
 }
 
-- (BOOL) isReachable:(NSString *)hostname
+- (BOOL)isReachable:(NSString *)hostname
 {
-    SCNetworkReachabilityRef target;
-    SCNetworkConnectionFlags flags = 0;
-    Boolean reachable;
-    target = SCNetworkReachabilityCreateWithName(NULL, [hostname cStringUsingEncoding:NSASCIIStringEncoding]);
-    reachable = SCNetworkReachabilityGetFlags(target, &flags);
+	SCNetworkReachabilityRef target;
+	SCNetworkConnectionFlags flags = 0;
+	Boolean reachable;
+	target = SCNetworkReachabilityCreateWithName(NULL, [hostname cStringUsingEncoding:NSASCIIStringEncoding]);
+	reachable = SCNetworkReachabilityGetFlags(target, &flags);
 	CFRelease(target);
 
 	if (!reachable)
@@ -185,15 +183,15 @@ dragDestinationActionMaskForDraggingInfo:(id<NSDraggingInfo>)draggingInfo
 	return flags > 0;
 }
 
-- (BOOL) isFeatureEnabled:(NSString *)feature
+- (BOOL)isFeatureEnabled:(NSString *)feature
 {
-	if([feature isEqualToString:@"gravatar"])
+	if ([feature isEqualToString:@"gravatar"])
 		return [PBGitDefaults isGravatarEnabled];
-	else if([feature isEqualToString:@"gist"])
+	else if ([feature isEqualToString:@"gist"])
 		return [PBGitDefaults isGistEnabled];
-	else if([feature isEqualToString:@"confirmGist"])
+	else if ([feature isEqualToString:@"confirmGist"])
 		return [PBGitDefaults confirmPublicGists];
-	else if([feature isEqualToString:@"publicGist"])
+	else if ([feature isEqualToString:@"publicGist"])
 		return [PBGitDefaults isGistPublic];
 	else
 		return YES;
@@ -201,7 +199,7 @@ dragDestinationActionMaskForDraggingInfo:(id<NSDraggingInfo>)draggingInfo
 
 #pragma mark Using async function from JS
 
-- (void) runCommand:(WebScriptObject *)arguments inRepository:(PBGitRepository *)repo callBack:(WebScriptObject *)callBack
+- (void)runCommand:(WebScriptObject *)arguments inRepository:(PBGitRepository *)repo callBack:(WebScriptObject *)callBack
 {
 	// The JS bridge does not handle JS Arrays, even though the docs say it does. So, we convert it ourselves.
 	int length = [[arguments valueForKey:@"length"] intValue];
@@ -211,17 +209,17 @@ dragDestinationActionMaskForDraggingInfo:(id<NSDraggingInfo>)draggingInfo
 		[realArguments addObject:[arguments webScriptValueAtIndex:i]];
 
 	PBTask *task = [repo taskWithArguments:realArguments];
-	[task performTaskWithCompletionHandler:^(NSData * _Nullable readData, NSError * _Nullable error) {
+	[task performTaskWithCompletionHandler:^(NSData *_Nullable readData, NSError *_Nullable error) {
 		if (error) {
 			/* FIXME: Might want to inform the JS that something went wrong */
 			NSLog(@"error: %@", error);
 			return;
 		}
-		[callBack callWebScriptMethod:@"call" withArguments:@[@"", readData]];
+		[callBack callWebScriptMethod:@"call" withArguments:@[ @"", readData ]];
 	}];
 }
 
-- (void) preferencesChanged
+- (void)preferencesChanged
 {
 }
 

--- a/Classes/Controllers/PBWebDiffController.h
+++ b/Classes/Controllers/PBWebDiffController.h
@@ -14,5 +14,5 @@
 	IBOutlet PBDiffWindowController *diffController;
 }
 
-- (void) showDiff:(NSString *)diff;
+- (void)showDiff:(NSString *)diff;
 @end

--- a/Classes/Controllers/PBWebDiffController.m
+++ b/Classes/Controllers/PBWebDiffController.m
@@ -11,22 +11,25 @@
 
 @implementation PBWebDiffController
 
-- (void) awakeFromNib
+- (void)awakeFromNib
 {
 	startFile = @"diff";
 	[super awakeFromNib];
-	[diffController addObserver:self keyPath:@"diff" options:0 block:^(MAKVONotification *notification) {
-		PBDiffWindowController *target = notification.target;
-		[notification.observer showDiff:target.diff];
-	}];
+	[diffController addObserver:self
+						keyPath:@"diff"
+						options:0
+						  block:^(MAKVONotification *notification) {
+							  PBDiffWindowController *target = notification.target;
+							  [notification.observer showDiff:target.diff];
+						  }];
 }
 
-- (void) didLoad
+- (void)didLoad
 {
 	[self showDiff:diffController.diff];
 }
 
-- (void) showDiff: (NSString *) diff
+- (void)showDiff:(NSString *)diff
 {
 	if (diff == nil || !finishedLoading)
 		return;

--- a/Classes/Controllers/PBWebHistoryController.h
+++ b/Classes/Controllers/PBWebHistoryController.h
@@ -17,14 +17,14 @@
 
 
 @interface PBWebHistoryController : PBWebController {
-	__weak IBOutlet PBGitHistoryController* historyController;
+	__weak IBOutlet PBGitHistoryController *historyController;
 
 	GTOID *currentOID;
-	NSString* diff;
+	NSString *diff;
 }
 
-- (void) sendKey: (NSString*) key;
+- (void)sendKey:(NSString *)key;
 
-@property (readonly) NSString* diff;
+@property (readonly) NSString *diff;
 
 @end

--- a/Classes/Controllers/PBWebHistoryController.m
+++ b/Classes/Controllers/PBWebHistoryController.m
@@ -21,14 +21,17 @@
 
 @synthesize diff;
 
-- (void) awakeFromNib
+- (void)awakeFromNib
 {
 	startFile = @"history";
 	repository = historyController.repository;
 	[super awakeFromNib];
-	[historyController addObserver:self keyPath:@"webCommits" options:0 block:^(MAKVONotification *notification) {
-		[self changeContentTo:self->historyController.webCommits];
-	}];
+	[historyController addObserver:self
+						   keyPath:@"webCommits"
+						   options:0
+							 block:^(MAKVONotification *notification) {
+								 [self changeContentTo:self->historyController.webCommits];
+							 }];
 }
 
 - (void)closeView
@@ -38,55 +41,68 @@
 	[super closeView];
 }
 
-- (void) didLoad
+- (void)didLoad
 {
 	currentOID = nil;
 	[self changeContentTo:historyController.webCommits];
 }
 
-- (void) changeContentTo:(NSArray<PBGitCommit *> *)commits
+- (void)changeContentTo:(NSArray<PBGitCommit *> *)commits
 {
 	if (commits == nil || commits.count == 0 || !finishedLoading) {
 		return;
 	}
-	
+
 	if (commits.count == 1) {
 		[self changeContentToCommit:commits.firstObject];
-	}
-	else {
+	} else {
 		[self changeContentToMultipleSelectionMessage];
 	}
 }
 
-- (void) changeContentToMultipleSelectionMessage {
+- (void)changeContentToMultipleSelectionMessage
+{
 	NSArray *arguments = @[
-			@[NSLocalizedString(@"Multiple commits are selected.", @"Multiple selection Message: Title"),
-			  NSLocalizedString(@"Use the Copy command to copy their information.", @"Multiple selection Message: Copy Command"),
-			  NSLocalizedString(@"Or select a single commit to see its diff.", @"Multiple selection Message: Diff Hint")
-			  ]];
+		@[ NSLocalizedString(@"Multiple commits are selected.", @"Multiple selection Message: Title"),
+		   NSLocalizedString(@"Use the Copy command to copy their information.", @"Multiple selection Message: Copy Command"),
+		   NSLocalizedString(@"Or select a single commit to see its diff.", @"Multiple selection Message: Diff Hint") ]
+	];
 	[[self script] callWebScriptMethod:@"showMultipleSelectionMessage" withArguments:arguments];
 }
 
-static NSString *deltaTypeName(GTDeltaType t) {
+static NSString *deltaTypeName(GTDeltaType t)
+{
 	switch (t) {
-		case GTDeltaTypeUnmodified: return @"unmodified";
-		case GTDeltaTypeAdded: return @"added";
-		case GTDeltaTypeDeleted: return @"removed";
-		case GTDeltaTypeModified: return @"modified";
-		case GTDeltaTypeRenamed: return @"renamed";
-		case GTDeltaTypeCopied: return @"copied";
-		case GTDeltaTypeIgnored: return @"ignored";
-		case GTDeltaTypeUntracked: return @"untracked";
-		case GTDeltaTypeTypeChange: return @"type changed";
-		case GTDeltaTypeUnreadable: return @"unreadable";
-		case GTDeltaTypeConflicted: return @"conflicted";
+		case GTDeltaTypeUnmodified:
+			return @"unmodified";
+		case GTDeltaTypeAdded:
+			return @"added";
+		case GTDeltaTypeDeleted:
+			return @"removed";
+		case GTDeltaTypeModified:
+			return @"modified";
+		case GTDeltaTypeRenamed:
+			return @"renamed";
+		case GTDeltaTypeCopied:
+			return @"copied";
+		case GTDeltaTypeIgnored:
+			return @"ignored";
+		case GTDeltaTypeUntracked:
+			return @"untracked";
+		case GTDeltaTypeTypeChange:
+			return @"type changed";
+		case GTDeltaTypeUnreadable:
+			return @"unreadable";
+		case GTDeltaTypeConflicted:
+			return @"conflicted";
 	}
 }
 
 static NSDictionary *loadCommitSummary(GTRepository *repo, GTCommit *commit, BOOL (^isCanceled)(void));
 
 // A GTDiffDelta's GTDiffFile does not always set the file size. See `git_diff_get_delta`.
-static NSUInteger reallyGetFileSize(GTRepository *repo, GTDiffFile *file) {
+static NSUInteger reallyGetFileSize(GTRepository *repo, GTDiffFile *file)
+{
 	GTObjectDatabase *odb = [repo objectDatabaseWithError:nil];
 	if (!odb) return 0;
 	size_t size = 0;
@@ -97,17 +113,16 @@ static NSUInteger reallyGetFileSize(GTRepository *repo, GTDiffFile *file) {
 	return size;
 }
 
-- (void) changeContentToCommit:(PBGitCommit *)commit
+- (void)changeContentToCommit:(PBGitCommit *)commit
 {
 	// The sha is the same, but refs may have changed. reload it lazy
-	if ([currentOID isEqual:commit.OID])
-	{
-		[[self script] callWebScriptMethod:@"reload" withArguments: nil];
+	if ([currentOID isEqual:commit.OID]) {
+		[[self script] callWebScriptMethod:@"reload" withArguments:nil];
 		return;
 	}
 
-	NSArray *arguments = @[commit, [[[historyController repository] headRef] simpleRef]];
-	id scriptResult = [[self script] callWebScriptMethod:@"loadCommit" withArguments: arguments];
+	NSArray *arguments = @[ commit, [[[historyController repository] headRef] simpleRef] ];
+	id scriptResult = [[self script] callWebScriptMethod:@"loadCommit" withArguments:arguments];
 	if (!scriptResult) {
 		// the web view is not really ready for scripting???
 		[self performSelector:_cmd withObject:commit afterDelay:0.05];
@@ -120,7 +135,8 @@ static NSUInteger reallyGetFileSize(GTRepository *repo, GTDiffFile *file) {
 	// Open a new repo instance for the background queue
 	NSError *err = nil;
 	GTRepository *repo =
-	    [GTRepository repositoryWithURL:[repository gtRepo].gitDirectoryURL error:&err];
+		[GTRepository repositoryWithURL:[repository gtRepo].gitDirectoryURL
+								  error:&err];
 	if (!repo) {
 		NSLog(@"Failed to open repository: %@", err);
 		return;
@@ -138,10 +154,10 @@ static NSUInteger reallyGetFileSize(GTRepository *repo, GTDiffFile *file) {
 		if (!summary) return;
 		NSError *err = nil;
 		NSString *summaryJSON =
-		    [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:summary
-		                                                                   options:0
-		                                                                     error:&err]
-		                          encoding:NSUTF8StringEncoding];
+			[[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:summary
+																		   options:0
+																			 error:&err]
+								  encoding:NSUTF8StringEncoding];
 		if (!summaryJSON) {
 			NSLog(@"Commit summary JSON error: %@", err);
 			return;
@@ -152,7 +168,8 @@ static NSUInteger reallyGetFileSize(GTRepository *repo, GTDiffFile *file) {
 	});
 }
 
-static NSDictionary *loadCommitSummary(GTRepository *repo, GTCommit *commit, BOOL (^isCanceled)(void)) {
+static NSDictionary *loadCommitSummary(GTRepository *repo, GTCommit *commit, BOOL (^isCanceled)(void))
+{
 	if (isCanceled()) return nil;
 	GTDiffFindOptionsFlags flags = GTDiffFindOptionsFlagsFindRenames;
 	if (![PBGitDefaults showWhitespaceDifferences]) {
@@ -160,10 +177,10 @@ static NSDictionary *loadCommitSummary(GTRepository *repo, GTCommit *commit, BOO
 	}
 	NSError *err = nil;
 	GTDiff *d = [GTDiff diffOldTree:commit.parents.firstObject.tree
-	                    withNewTree:commit.tree
-	                   inRepository:repo
+						withNewTree:commit.tree
+					   inRepository:repo
 							options:@{}
-	                          error:&err];
+							  error:&err];
 
 	if (!d) {
 		NSLog(@"Commit summary diff error: %@", err);
@@ -171,7 +188,7 @@ static NSDictionary *loadCommitSummary(GTRepository *repo, GTCommit *commit, BOO
 	}
 
 	// Rewrite the diff to display moved files.
-	[d findSimilarWithOptions:@{GTDiffFindOptionsFlagsKey:@(flags)}];
+	[d findSimilarWithOptions:@{GTDiffFindOptionsFlagsKey : @(flags)}];
 
 	if (isCanceled()) return nil;
 	NSMutableArray<NSDictionary<NSString *, NSObject *> *> *fileDeltas = [NSMutableArray array];
@@ -195,12 +212,12 @@ static NSDictionary *loadCommitSummary(GTRepository *repo, GTCommit *commit, BOO
 			NSData *patchData = patch.patchData;
 			if (patchData) {
 				NSString *patchString =
-				    [[NSString alloc] initWithData:patchData
-				                          encoding:NSUTF8StringEncoding];
+					[[NSString alloc] initWithData:patchData
+										  encoding:NSUTF8StringEncoding];
 				if (!patchString) {
 					patchString =
-					    [[NSString alloc] initWithData:patchData
-					                          encoding:NSISOLatin1StringEncoding];
+						[[NSString alloc] initWithData:patchData
+											  encoding:NSISOLatin1StringEncoding];
 				}
 				if (patchString) {
 					[fullDiff appendString:patchString];
@@ -247,31 +264,31 @@ static NSDictionary *loadCommitSummary(GTRepository *repo, GTCommit *commit, BOO
 		return;
 	}
 
-	[self.view.windowScriptObject callWebScriptMethod:@"loadCommitDiff" withArguments:@[summaryJSON]];
+	[self.view.windowScriptObject callWebScriptMethod:@"loadCommitDiff" withArguments:@[ summaryJSON ]];
 }
 
 - (void)selectCommit:(NSString *)sha
 {
-	[historyController selectCommit: [GTOID oidWithSHA: sha]];
+	[historyController selectCommit:[GTOID oidWithSHA:sha]];
 }
 
-- (void) sendKey: (NSString*) key
+- (void)sendKey:(NSString *)key
 {
 	id script = self.view.windowScriptObject;
-	[script callWebScriptMethod:@"handleKeyFromCocoa" withArguments: [NSArray arrayWithObject:key]];
+	[script callWebScriptMethod:@"handleKeyFromCocoa" withArguments:[NSArray arrayWithObject:key]];
 }
 
-- (void) copySource
+- (void)copySource
 {
 	NSString *source = [(DOMHTMLElement *)self.view.mainFrame.DOMDocument.documentElement outerHTML];
-	NSPasteboard *a =[NSPasteboard generalPasteboard];
+	NSPasteboard *a = [NSPasteboard generalPasteboard];
 	[a declareTypes:[NSArray arrayWithObject:NSStringPboardType] owner:self];
-	[a setString:source forType: NSStringPboardType];
+	[a setString:source forType:NSStringPboardType];
 }
 
-- (NSArray *)	   webView:(WebView *)sender
-contextMenuItemsForElement:(NSDictionary *)element
-		  defaultMenuItems:(NSArray *)defaultMenuItems
+- (NSArray *)webView:(WebView *)sender
+	contextMenuItemsForElement:(NSDictionary *)element
+			  defaultMenuItems:(NSArray *)defaultMenuItems
 {
 	DOMNode *node = [element valueForKey:@"WebElementDOMNode"];
 
@@ -288,15 +305,15 @@ contextMenuItemsForElement:(NSDictionary *)element
 		}
 		if ([node hasAttributes] && [[node attributes] getNamedItem:@"representedFile"])
 			return [historyController menuItemsForPaths:[NSArray arrayWithObject:[[[node attributes] getNamedItem:@"representedFile"] nodeValue]]];
-        else if ([[node class] isEqual:[DOMHTMLImageElement class]]) {
-            // Copy Image is the only menu item that makes sense here since we don't need
+		else if ([[node class] isEqual:[DOMHTMLImageElement class]]) {
+			// Copy Image is the only menu item that makes sense here since we don't need
 			// to download the image or open it in a new window (besides with the
 			// current implementation these two entries can crash GitX anyway)
 			for (NSMenuItem *item in defaultMenuItems)
 				if ([item tag] == WebMenuItemTagCopyImageToClipboard)
 					return [NSArray arrayWithObject:item];
 			return nil;
-        }
+		}
 
 		node = [node parentNode];
 	}
@@ -306,10 +323,10 @@ contextMenuItemsForElement:(NSDictionary *)element
 
 
 // Open external links in the default browser
--   (void)webView:(WebView *)sender decidePolicyForNewWindowAction:(NSDictionary *)actionInformation
-   		  request:(NSURLRequest *)request
-     newFrameName:(NSString *)frameName
- decisionListener:(id < WebPolicyDecisionListener >)listener
+- (void)webView:(WebView *)sender decidePolicyForNewWindowAction:(NSDictionary *)actionInformation
+						   request:(NSURLRequest *)request
+					  newFrameName:(NSString *)frameName
+				  decisionListener:(id<WebPolicyDecisionListener>)listener
 {
 	[[NSWorkspace sharedWorkspace] openURL:[request URL]];
 }
@@ -317,12 +334,12 @@ contextMenuItemsForElement:(NSDictionary *)element
 - getConfig:(NSString *)key
 {
 	NSError *error = nil;
-    GTConfiguration* config = [historyController.repository.gtRepo configurationWithError:&error];
+	GTConfiguration *config = [historyController.repository.gtRepo configurationWithError:&error];
 	return [config stringForKey:key];
 }
 
 
-- (void) preferencesChanged
+- (void)preferencesChanged
 {
 	[[self script] callWebScriptMethod:@"enableFeatures" withArguments:nil];
 }

--- a/Classes/GitXRelativeDateFormatter.m
+++ b/Classes/GitXRelativeDateFormatter.m
@@ -10,7 +10,7 @@
 
 
 #define MINUTE 60
-#define HOUR   (60 * MINUTE)
+#define HOUR (60 * MINUTE)
 
 #define WEEK 7
 
@@ -21,15 +21,15 @@
 	if (![date isKindOfClass:[NSDate class]])
 		return nil;
 
-    NSDate *now = [NSDate date];
+	NSDate *now = [NSDate date];
 
-    NSInteger secondsAgo = lround([now timeIntervalSinceDate:date]);
+	NSInteger secondsAgo = lround([now timeIntervalSinceDate:date]);
 
-    if (secondsAgo < 0)
-        return @"In the future!";
+	if (secondsAgo < 0)
+		return @"In the future!";
 
 	if (secondsAgo < MINUTE)
-        return @"seconds ago";
+		return @"seconds ago";
 
 	if (secondsAgo < (2 * MINUTE))
 		return @"1 minute ago";

--- a/Classes/NSAppearance+PBDarkMode.m
+++ b/Classes/NSAppearance+PBDarkMode.m
@@ -14,7 +14,7 @@ NSString *const PBEffectiveAppearanceChanged = @"PBEffectiveAppearanceChanged";
 - (BOOL)isDarkMode
 {
 	if (@available(macOS 10.14, *)) {
-		if ([self bestMatchFromAppearancesWithNames:@[NSAppearanceNameDarkAqua, NSAppearanceNameAqua]] == NSAppearanceNameDarkAqua)
+		if ([self bestMatchFromAppearancesWithNames:@[ NSAppearanceNameDarkAqua, NSAppearanceNameAqua ]] == NSAppearanceNameDarkAqua)
 			return YES;
 		return NO;
 	} else {
@@ -40,9 +40,12 @@ NSString *const PBEffectiveAppearanceChanged = @"PBEffectiveAppearanceChanged";
 	if (@available(macOS 10.14, *)) {
 		/* This leaks the observation, but since it's tied to the life of NSApp
 		 * it doesn't matter ;-) */
-		[[NSApplication sharedApplication] addObserver:observer keyPath:@"effectiveAppearance" options:0 block:^(MAKVONotification *notification) {
-			[[NSNotificationCenter defaultCenter] postNotificationName:PBEffectiveAppearanceChanged object:observer];
-		}];
+		[[NSApplication sharedApplication] addObserver:observer
+											   keyPath:@"effectiveAppearance"
+											   options:0
+												 block:^(MAKVONotification *notification) {
+													 [[NSNotificationCenter defaultCenter] postNotificationName:PBEffectiveAppearanceChanged object:observer];
+												 }];
 	}
 }
 

--- a/Classes/NSColor+RGB.m
+++ b/Classes/NSColor+RGB.m
@@ -13,7 +13,7 @@
 + (NSColor *)colorWithR:(uint8_t)r G:(uint8_t)g B:(uint8_t)b
 {
 	const CGFloat MAX_RGB = 255.0;
-	NSColor *result = [NSColor colorWithCalibratedRed:(r/MAX_RGB) green:(g/MAX_RGB) blue:(b/MAX_RGB) alpha:1];
+	NSColor *result = [NSColor colorWithCalibratedRed:(r / MAX_RGB) green:(g / MAX_RGB) blue:(b / MAX_RGB) alpha:1];
 	return result;
 }
 

--- a/Classes/NSSplitView+GitX.m
+++ b/Classes/NSSplitView+GitX.m
@@ -31,7 +31,7 @@
 			[subview setHidden:hidden];
 
 			// Set height (horizontal) or width (vertical)
-			if(![self isVertical]) {
+			if (![self isVertical]) {
 				CGFloat height = [components[3] floatValue];
 
 				[subview setFrameSize:NSMakeSize(subview.frame.size.width, height)];

--- a/Classes/PBCLIProxy.h
+++ b/Classes/PBCLIProxy.h
@@ -8,16 +8,15 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface PBCLIProxy : NSObject
-{
+@interface PBCLIProxy : NSObject {
 	NSConnection *connection;
 }
-@property (retain) NSConnection* connection;
+@property (retain) NSConnection *connection;
 @end
 
 #define ConnectionName @"GitX DO Connection"
 
 @protocol GitXCliToolProtocol
-- (BOOL)openRepository:(NSURL*)repositoryPath arguments: (NSArray*) args error:(NSError**)error;
+- (BOOL)openRepository:(NSURL *)repositoryPath arguments:(NSArray *)args error:(NSError **)error;
 - (void)openDiffWindowWithDiff:(NSString *)diff;
 @end

--- a/Classes/PBCLIProxy.m
+++ b/Classes/PBCLIProxy.m
@@ -26,18 +26,17 @@
 
 		if ([self.connection registerName:ConnectionName] == NO)
 			NSBeep();
-
 	}
 	return self;
 }
 
-- (BOOL)openRepository:(NSURL*)repositoryPath arguments: (NSArray*) args error:(NSError**)error;
+- (BOOL)openRepository:(NSURL *)repositoryPath arguments:(NSArray *)args error:(NSError **)error;
 {
 	// FIXME I found that creating this redundant NSURL reference was necessary to
 	// work around an apparent bug with GC and Distributed Objects
 	// I am not familiar with GC though, so perhaps I was doing something wrong.
-	NSURL* url = [NSURL fileURLWithPath:[repositoryPath path]];
-	NSArray* arguments = [NSArray arrayWithArray:args];
+	NSURL *url = [NSURL fileURLWithPath:[repositoryPath path]];
+	NSArray *arguments = [NSArray arrayWithArray:args];
 
 	PBGitRepositoryDocument *document = [[NSDocumentController sharedDocumentController] documentForURL:url];
 	if (!document) {
@@ -52,11 +51,10 @@
 		return NO;
 	}
 
-	if ([arguments count] > 0 && ([[arguments objectAtIndex:0] isEqualToString:@"--commit"] ||
-		[[arguments objectAtIndex:0] isEqualToString:@"-c"]))
+	if ([arguments count] > 0 && ([[arguments objectAtIndex:0] isEqualToString:@"--commit"] || [[arguments objectAtIndex:0] isEqualToString:@"-c"]))
 		[document showCommitView:self];
 	else {
-		PBGitRevSpecifier* rev = [[PBGitRevSpecifier alloc] initWithParameters:arguments];
+		PBGitRevSpecifier *rev = [[PBGitRevSpecifier alloc] initWithParameters:arguments];
 		rev.workingDirectory = url;
 		[document selectRevisionSpecifier:rev];
 	}

--- a/Classes/PBChangedFile.h
+++ b/Classes/PBChangedFile.h
@@ -34,5 +34,5 @@ typedef enum {
 - (NSImage *)icon;
 - (NSString *)indexInfo;
 
-- (id) initWithPath:(NSString *)p;
+- (id)initWithPath:(NSString *)p;
 @end

--- a/Classes/PBChangedFile.m
+++ b/Classes/PBChangedFile.m
@@ -12,13 +12,13 @@
 
 @synthesize path, status, hasStagedChanges, hasUnstagedChanges, commitBlobSHA, commitBlobMode;
 
-- (id) initWithPath:(NSString *)p
+- (id)initWithPath:(NSString *)p
 {
-    self = [super init];
-    
-    if (self) {
-        path = p;
-    }
+	self = [super init];
+
+	if (self) {
+		path = p;
+	}
 	return self;
 }
 
@@ -31,7 +31,7 @@
 		return [NSString stringWithFormat:@"%@ %@\t%@\0", self.commitBlobMode, self.commitBlobSHA, self.path];
 }
 
-- (NSImage *) icon
+- (NSImage *)icon
 {
 	NSString *filename;
 	switch (status) {
@@ -53,7 +53,8 @@
 	return NO;
 }
 
-+ (BOOL)isKeyExcludedFromWebScript:(const char *)name {
++ (BOOL)isKeyExcludedFromWebScript:(const char *)name
+{
 	return NO;
 }
 

--- a/Classes/PBCommitList.h
+++ b/Classes/PBCommitList.h
@@ -14,12 +14,12 @@
 @class PBHistorySearchController;
 
 @interface PBCommitList : NSTableView {
-	__weak IBOutlet WebView* webView;
+	__weak IBOutlet WebView *webView;
 	__weak IBOutlet PBWebHistoryController *webController;
 	__weak IBOutlet PBGitHistoryController *controller;
 	__weak IBOutlet PBHistorySearchController *searchController;
 
-    BOOL useAdjustScroll;
+	BOOL useAdjustScroll;
 	NSPoint mouseDownPoint;
 }
 

--- a/Classes/PBCommitList.m
+++ b/Classes/PBCommitList.m
@@ -29,7 +29,7 @@
 
 - (void)keyDown:(NSEvent *)event
 {
-	NSString* character = [event charactersIgnoringModifiers];
+	NSString *character = [event charactersIgnoringModifiers];
 
 	// Pass on command-shift up/down to the responder. We want the splitview to capture this.
 	if ([event modifierFlags] & NSShiftKeyMask && [event modifierFlags] & NSCommandKeyMask && ([event keyCode] == 0x7E || [event keyCode] == 0x7D)) {
@@ -43,54 +43,51 @@
 				[webView scrollPageUp:self];
 			else
 				[webView scrollPageDown:self];
-		}
-		else
+		} else
 			[controller toggleQLPreviewPanel:self];
-	}
-	else if ([character rangeOfCharacterFromSet:[NSCharacterSet characterSetWithCharactersInString:@"jkcv"]].location == 0)
-		[webController sendKey: character];
-	else if (([character characterAtIndex:0] == NSDownArrowFunctionKey)
-			 && [event modifierFlags] & NSControlKeyMask) {
+	} else if ([character rangeOfCharacterFromSet:[NSCharacterSet characterSetWithCharactersInString:@"jkcv"]].location == 0)
+		[webController sendKey:character];
+	else if (([character characterAtIndex:0] == NSDownArrowFunctionKey) && [event modifierFlags] & NSControlKeyMask) {
 		[controller selectParentCommit:self];
 	} else
-		[super keyDown: event];
+		[super keyDown:event];
 }
 
 // !!! Andre Berg 20100330: Used from -scrollSelectionToTopOfViewFrom: of PBGitHistoryController
 // so that when the history controller udpates the branch filter the origin of the superview gets
 // shifted into multiples of the row height. Otherwise the top selected row will always be off by
 // a little bit depending on how much the bottom half of the split view is dragged down.
-- (NSRect)adjustScroll:(NSRect)proposedVisibleRect {
+- (NSRect)adjustScroll:(NSRect)proposedVisibleRect
+{
+	//NSLog(@"[%@ %s]: proposedVisibleRect: %@", [self class], _cmd, NSStringFromRect(proposedVisibleRect));
+	NSRect newRect = proposedVisibleRect;
 
-    //NSLog(@"[%@ %s]: proposedVisibleRect: %@", [self class], _cmd, NSStringFromRect(proposedVisibleRect));
-    NSRect newRect = proposedVisibleRect;
-
-    // !!! Andre Berg 20100330: only modify if -scrollSelectionToTopOfViewFrom: has set useAdjustScroll to YES
-    // Otherwise we'd also constrain things like middle mouse scrolling.
-    if (useAdjustScroll) {
-        NSInteger rh = (NSInteger)self.rowHeight;
-        NSInteger ny = (NSInteger)proposedVisibleRect.origin.y % (NSInteger)rh;
-        NSInteger adj = rh - ny;
-        // check the targeted row and see if we need to add or subtract the difference (if there is one)...
-        NSRect sr = [self rectOfRow:[self selectedRow]];
-        // NSLog(@"[%@ %s]: selectedRow %d, rect: %@", [self class], _cmd, [self selectedRow], NSStringFromRect(sr));
-        if (sr.origin.y > proposedVisibleRect.origin.y) {
-            // NSLog(@"[%@ %s] selectedRow.origin.y > proposedVisibleRect.origin.y. adding adj (%d)", [self class], _cmd, adj);
-            newRect = NSMakeRect(newRect.origin.x, newRect.origin.y + adj, newRect.size.width, newRect.size.height);
-        } else if (sr.origin.y < proposedVisibleRect.origin.y) {
-            // NSLog(@"[%@ %s] selectedRow.origin.y < proposedVisibleRect.origin.y. subtracting ny (%d)", [self class], _cmd, ny);
-            newRect = NSMakeRect(newRect.origin.x, newRect.origin.y - ny , newRect.size.width, newRect.size.height);
-        } else {
-            // NSLog(@"[%@ %s] selectedRow.origin.y == proposedVisibleRect.origin.y. leaving as is", [self class], _cmd);
-        }
-    }
-    //NSLog(@"[%@ %s]: newRect: %@", [self class], _cmd, NSStringFromRect(newRect));
-    return newRect;
+	// !!! Andre Berg 20100330: only modify if -scrollSelectionToTopOfViewFrom: has set useAdjustScroll to YES
+	// Otherwise we'd also constrain things like middle mouse scrolling.
+	if (useAdjustScroll) {
+		NSInteger rh = (NSInteger)self.rowHeight;
+		NSInteger ny = (NSInteger)proposedVisibleRect.origin.y % (NSInteger)rh;
+		NSInteger adj = rh - ny;
+		// check the targeted row and see if we need to add or subtract the difference (if there is one)...
+		NSRect sr = [self rectOfRow:[self selectedRow]];
+		// NSLog(@"[%@ %s]: selectedRow %d, rect: %@", [self class], _cmd, [self selectedRow], NSStringFromRect(sr));
+		if (sr.origin.y > proposedVisibleRect.origin.y) {
+			// NSLog(@"[%@ %s] selectedRow.origin.y > proposedVisibleRect.origin.y. adding adj (%d)", [self class], _cmd, adj);
+			newRect = NSMakeRect(newRect.origin.x, newRect.origin.y + adj, newRect.size.width, newRect.size.height);
+		} else if (sr.origin.y < proposedVisibleRect.origin.y) {
+			// NSLog(@"[%@ %s] selectedRow.origin.y < proposedVisibleRect.origin.y. subtracting ny (%d)", [self class], _cmd, ny);
+			newRect = NSMakeRect(newRect.origin.x, newRect.origin.y - ny, newRect.size.width, newRect.size.height);
+		} else {
+			// NSLog(@"[%@ %s] selectedRow.origin.y == proposedVisibleRect.origin.y. leaving as is", [self class], _cmd);
+		}
+	}
+	//NSLog(@"[%@ %s]: newRect: %@", [self class], _cmd, NSStringFromRect(newRect));
+	return newRect;
 }
 
 - (void)mouseDown:(NSEvent *)theEvent
 {
-    mouseDownPoint = [self convertPoint:[theEvent locationInWindow] fromView:nil];
+	mouseDownPoint = [self convertPoint:[theEvent locationInWindow] fromView:nil];
 	[super mouseDown:theEvent];
 }
 
@@ -125,7 +122,6 @@
 
 	*dragImageOffset = NSMakePoint(rect.size.width / 2 + 10, 0);
 	return newImage;
-
 }
 
 
@@ -143,16 +139,16 @@
 	NSPoint point = [self.window.contentView convertPoint:[event locationInWindow] toView:cell];
 	int i = [cell indexAtX:point.x];
 	PBGitRef *clickedRef = (i >= 0 && i < commit.refs.count ? commit.refs[i] : nil);
-	
-	NSArray <PBGitCommit*>* selectedCommits = controller.selectedCommits;
-	NSArray <NSMenuItem *>* items;
+
+	NSArray<PBGitCommit *> *selectedCommits = controller.selectedCommits;
+	NSArray<NSMenuItem *> *items;
 
 	if (clickedRef) {
 		items = [controller menuItemsForRef:clickedRef];
 	} else if ([selectedCommits containsObject:commit]) {
 		items = [controller menuItemsForCommits:controller.selectedCommits];
 	} else {
-		items = [controller menuItemsForCommits:@[commit]];
+		items = [controller menuItemsForCommits:@[ commit ]];
 	}
 
 	NSMenu *menu = [[NSMenu alloc] init];

--- a/Classes/PBGraphCellInfo.h
+++ b/Classes/PBGraphCellInfo.h
@@ -9,20 +9,19 @@
 #import <Cocoa/Cocoa.h>
 #import "PBGitGraphLine.h"
 
-@interface PBGraphCellInfo : NSObject
-{
+@interface PBGraphCellInfo : NSObject {
 	struct PBGitGraphLine *lines;
 	long nLines;
 	long position;
 	long numColumns;
-	char sign;	
+	char sign;
 }
 
 @property struct PBGitGraphLine *lines;
-@property(assign) long nLines;
-@property(assign) long position;
-@property(assign) long numColumns;
-@property(assign) char sign;
+@property (assign) long nLines;
+@property (assign) long position;
+@property (assign) long numColumns;
+@property (assign) char sign;
 
 
 - (id)initWithPosition:(long)p andLines:(struct PBGitGraphLine *)l;

--- a/Classes/PBGraphCellInfo.m
+++ b/Classes/PBGraphCellInfo.m
@@ -16,11 +16,11 @@
 {
 	position = p;
 	lines = l;
-	
+
 	return self;
 }
 
-- (struct PBGitGraphLine*)lines
+- (struct PBGitGraphLine *)lines
 {
 	return lines;
 }
@@ -31,21 +31,24 @@
 	lines = l;
 }
 
-- (NSString *)description { return [self debugDescription]; }
+- (NSString *)description
+{
+	return [self debugDescription];
+}
 
 - (NSString *)debugDescription
 {
 	NSMutableString *desc = [NSMutableString stringWithFormat:@"<%@: %p position: %ld numColumns: %ld nLines: %ld sign: '%c'>",
-							 NSStringFromClass([self class]), self, position, numColumns, nLines, sign];
+															  NSStringFromClass([self class]), self, position, numColumns, nLines, sign];
 	for (int lineIndex = 0; lineIndex < nLines; lineIndex++) {
 		struct PBGitGraphLine line = lines[lineIndex];
 		[desc appendString:[NSString stringWithFormat:@"\n\t<upper: %d from: %d to: %d colorIndex: %d>",
-							line.upper, line.from, line.to, line.colorIndex]];
+													  line.upper, line.from, line.to, line.colorIndex]];
 	}
 	return desc;
 }
 
--(void) dealloc
+- (void)dealloc
 {
 	free(lines);
 }

--- a/Classes/PBMacros.h
+++ b/Classes/PBMacros.h
@@ -8,10 +8,10 @@
 
 #import <Cocoa/Cocoa.h>
 
-#define GITX_DEPRECATED __attribute__ ((deprecated))
-#define GITX_DEPRECATED_MSG(x) __attribute__ ((deprecated(x)))
+#define GITX_DEPRECATED __attribute__((deprecated))
+#define GITX_DEPRECATED_MSG(x) __attribute__((deprecated(x)))
 
-#define PBLogFunction(x, ...) PBLogFunctionImpl(__FUNCTION__, x, ## __VA_ARGS__)
+#define PBLogFunction(x, ...) PBLogFunctionImpl(__FUNCTION__, x, ##__VA_ARGS__)
 #define PBLogError(x) PBLogErrorImpl(__FUNCTION__, x)
 
 

--- a/Classes/PBMacros.m
+++ b/Classes/PBMacros.m
@@ -10,7 +10,8 @@
 
 #include <stdarg.h>
 
-void PBLogFunctionImpl(const char *function, NSString *format, ...) {
+void PBLogFunctionImpl(const char *function, NSString *format, ...)
+{
 	va_list arg;
 
 	if (!format) {
@@ -27,7 +28,8 @@ void PBLogFunctionImpl(const char *function, NSString *format, ...) {
 	NSLog(@"%s: %@", function, log);
 }
 
-void PBLogErrorImpl(const char *function, NSError *error) {
+void PBLogErrorImpl(const char *function, NSError *error)
+{
 	if (!error) return;
 	NSLog(@"%s: %@", function, error);
 }

--- a/Classes/PBNSURLPathUserDefaultsTransfomer.h
+++ b/Classes/PBNSURLPathUserDefaultsTransfomer.h
@@ -10,7 +10,6 @@
 
 
 @interface PBNSURLPathUserDefaultsTransfomer : NSValueTransformer {
-
 }
 
 @end

--- a/Classes/PBNSURLPathUserDefaultsTransfomer.m
+++ b/Classes/PBNSURLPathUserDefaultsTransfomer.m
@@ -16,17 +16,19 @@
 
 @implementation PBNSURLPathUserDefaultsTransfomer
 
-+ (Class)transformedValueClass {
++ (Class)transformedValueClass
+{
 	return [NSURL class];
 }
 
-+ (BOOL)allowsReverseTransformation {
++ (BOOL)allowsReverseTransformation
+{
 	return YES;
 }
 
-- (id)transformedValue:(id)value {
-	if(value == nil)
-	{
+- (id)transformedValue:(id)value
+{
+	if (value == nil) {
 		return nil;
 	}
 
@@ -34,9 +36,9 @@
 				  relativeToURL:[NSURL URLWithString:@"file://localhost/"]];
 }
 
-- (id)reverseTransformedValue:(id)value {
-	if(value == nil)
-	{
+- (id)reverseTransformedValue:(id)value
+{
+	if (value == nil) {
 		return nil;
 	}
 

--- a/Classes/PBSidebarList.m
+++ b/Classes/PBSidebarList.m
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 	NSPoint point = [self convertPoint:[event locationInWindow] fromView:nil];
 	NSInteger row = [self rowAtPoint:point];
 
-	PBGitSidebarController *controller = (PBGitSidebarController*)[self delegate];
+	PBGitSidebarController *controller = (PBGitSidebarController *)[self delegate];
 
 	return [controller menuForRow:row];
 }

--- a/Classes/PBUnsortableTableHeader.m
+++ b/Classes/PBUnsortableTableHeader.m
@@ -17,8 +17,7 @@
 	NSInteger aColumnIndex = [self columnAtPoint:location];
 
 	// If the user pressed on another column, reset
-	if (aColumnIndex != columnIndex)
-	{
+	if (aColumnIndex != columnIndex) {
 		clickCount = 1;
 		columnIndex = aColumnIndex;
 		[super mouseDown:theEvent];
@@ -27,8 +26,7 @@
 
 	// On the third click, reset the sorting and
 	// Don't pass on the click
-	if (++clickCount == 3)
-	{
+	if (++clickCount == 3) {
 		clickCount = 0;
 		controller.sortDescriptors = [NSArray array];
 		[controller rearrangeObjects];

--- a/Classes/Terminal.h
+++ b/Classes/Terminal.h
@@ -20,7 +20,6 @@ typedef enum {
 } TerminalPrintingErrorHandling;
 
 
-
 /*
  * Standard Suite
  */
@@ -28,51 +27,50 @@ typedef enum {
 // The application‘s top-level scripting object.
 @interface TerminalApplication : SBApplication
 
-- (SBElementArray *) windows;
+- (SBElementArray *)windows;
 
-@property (copy, readonly) NSString *name;  // The name of the application.
-@property (readonly) BOOL frontmost;  // Is this the frontmost (active) application?
-@property (copy, readonly) NSString *version;  // The version of the application.
+@property (copy, readonly) NSString *name;	  // The name of the application.
+@property (readonly) BOOL frontmost;		  // Is this the frontmost (active) application?
+@property (copy, readonly) NSString *version; // The version of the application.
 
-- (void) open:(NSArray *)x;  // Open a document.
-- (void) print:(id)x withProperties:(NSDictionary *)withProperties printDialog:(BOOL)printDialog;  // Print a document.
-- (void) quitSaving:(TerminalSaveOptions)saving;  // Quit the application.
-- (TerminalTab *) doScript:(NSString *)x in:(id)in_;  // Runs a UNIX shell script or command.
+- (void)open:(NSArray *)x;																		 // Open a document.
+- (void)print:(id)x withProperties:(NSDictionary *)withProperties printDialog:(BOOL)printDialog; // Print a document.
+- (void)quitSaving:(TerminalSaveOptions)saving;													 // Quit the application.
+- (TerminalTab *)doScript:(NSString *)x in:(id)in_;												 // Runs a UNIX shell script or command.
 
 @end
 
 // A window.
 @interface TerminalWindow : SBObject
 
-- (SBElementArray *) tabs;
+- (SBElementArray *)tabs;
 
-@property (copy, readonly) NSString *name;  // The full title of the window.
-- (NSInteger) id;  // The unique identifier of the window.
-@property NSInteger index;  // The index of the window, ordered front to back.
-@property NSRect bounds;  // The bounding rectangle of the window.
-@property (readonly) BOOL closeable;  // Whether the window has a close box.
+@property (copy, readonly) NSString *name; // The full title of the window.
+- (NSInteger)id;						   // The unique identifier of the window.
+@property NSInteger index;				   // The index of the window, ordered front to back.
+@property NSRect bounds;				   // The bounding rectangle of the window.
+@property (readonly) BOOL closeable;	   // Whether the window has a close box.
 @property (readonly) BOOL miniaturizable;  // Whether the window can be minimized.
-@property BOOL miniaturized;  // Whether the window is currently minimized.
-@property (readonly) BOOL resizable;  // Whether the window can be resized.
-@property BOOL visible;  // Whether the window is currently visible.
-@property (readonly) BOOL zoomable;  // Whether the window can be zoomed.
-@property BOOL zoomed;  // Whether the window is currently zoomed.
-@property BOOL frontmost;  // Whether the window is currently the frontmost Terminal window.
-@property NSPoint position;  // The position of the window, relative to the upper left corner of the screen.
-@property NSPoint origin;  // The position of the window, relative to the lower left corner of the screen.
-@property NSPoint size;  // The width and height of the window
-@property NSRect frame;  // The bounding rectangle, relative to the lower left corner of the screen.
+@property BOOL miniaturized;			   // Whether the window is currently minimized.
+@property (readonly) BOOL resizable;	   // Whether the window can be resized.
+@property BOOL visible;					   // Whether the window is currently visible.
+@property (readonly) BOOL zoomable;		   // Whether the window can be zoomed.
+@property BOOL zoomed;					   // Whether the window is currently zoomed.
+@property BOOL frontmost;				   // Whether the window is currently the frontmost Terminal window.
+@property NSPoint position;				   // The position of the window, relative to the upper left corner of the screen.
+@property NSPoint origin;				   // The position of the window, relative to the lower left corner of the screen.
+@property NSPoint size;					   // The width and height of the window
+@property NSRect frame;					   // The bounding rectangle, relative to the lower left corner of the screen.
 
-- (void) closeSaving:(TerminalSaveOptions)saving savingIn:(NSURL *)savingIn;  // Close a document.
-- (void) saveIn:(NSURL *)in_;  // Save a document.
-- (void) printWithProperties:(NSDictionary *)withProperties printDialog:(BOOL)printDialog;  // Print a document.
-- (void) delete;  // Delete an object.
-- (void) duplicateTo:(SBObject *)to withProperties:(NSDictionary *)withProperties;  // Copy object(s) and put the copies at a new location.
-- (BOOL) exists;  // Verify if an object exists.
-- (void) moveTo:(SBObject *)to;  // Move object(s) to a new location.
+- (void)closeSaving:(TerminalSaveOptions)saving savingIn:(NSURL *)savingIn;				  // Close a document.
+- (void)saveIn:(NSURL *)in_;															  // Save a document.
+- (void)printWithProperties:(NSDictionary *)withProperties printDialog:(BOOL)printDialog; // Print a document.
+- (void)delete;																			  // Delete an object.
+- (void)duplicateTo:(SBObject *)to withProperties:(NSDictionary *)withProperties;		  // Copy object(s) and put the copies at a new location.
+- (BOOL)exists;																			  // Verify if an object exists.
+- (void)moveTo:(SBObject *)to;															  // Move object(s) to a new location.
 
 @end
-
 
 
 /*
@@ -81,79 +79,78 @@ typedef enum {
 
 @interface TerminalApplication (TerminalSuite)
 
-- (SBElementArray *) settingsSets;
+- (SBElementArray *)settingsSets;
 
-@property (copy) TerminalSettingsSet *defaultSettings;  // The settings set used for new windows.
-@property (copy) TerminalSettingsSet *startupSettings;  // The settings set used for the window created on application startup.
+@property (copy) TerminalSettingsSet *defaultSettings; // The settings set used for new windows.
+@property (copy) TerminalSettingsSet *startupSettings; // The settings set used for the window created on application startup.
 
 @end
 
 // A set of settings.
 @interface TerminalSettingsSet : SBObject
 
-- (NSInteger) id;  // The unique identifier of the settings set.
-@property (copy) NSString *name;  // The name of the settings set.
-@property NSInteger numberOfRows;  // The number of rows displayed in the tab.
-@property NSInteger numberOfColumns;  // The number of columns displayed in the tab.
-@property (copy) NSColor *cursorColor;  // The cursor color for the tab.
-@property (copy) NSColor *backgroundColor;  // The background color for the tab.
-@property (copy) NSColor *normalTextColor;  // The normal text color for the tab.
-@property (copy) NSColor *boldTextColor;  // The bold text color for the tab.
-@property (copy) NSString *fontName;  // The name of the font used to display the tab’s contents.
-@property NSInteger fontSize;  // The size of the font used to display the tab’s contents.
-@property BOOL fontAntialiasing;  // Whether the font used to display the tab’s contents is antialiased.
-@property (copy) NSArray *cleanCommands;  // The processes which will be ignored when checking whether a tab can be closed without showing a prompt.
-@property BOOL titleDisplaysDeviceName;  // Whether the title contains the device name.
-@property BOOL titleDisplaysShellPath;  // Whether the title contains the shell path.
-@property BOOL titleDisplaysWindowSize;  // Whether the title contains the tab’s size, in rows and columns.
+- (NSInteger)id;						   // The unique identifier of the settings set.
+@property (copy) NSString *name;		   // The name of the settings set.
+@property NSInteger numberOfRows;		   // The number of rows displayed in the tab.
+@property NSInteger numberOfColumns;	   // The number of columns displayed in the tab.
+@property (copy) NSColor *cursorColor;	   // The cursor color for the tab.
+@property (copy) NSColor *backgroundColor; // The background color for the tab.
+@property (copy) NSColor *normalTextColor; // The normal text color for the tab.
+@property (copy) NSColor *boldTextColor;   // The bold text color for the tab.
+@property (copy) NSString *fontName;	   // The name of the font used to display the tab’s contents.
+@property NSInteger fontSize;			   // The size of the font used to display the tab’s contents.
+@property BOOL fontAntialiasing;		   // Whether the font used to display the tab’s contents is antialiased.
+@property (copy) NSArray *cleanCommands;   // The processes which will be ignored when checking whether a tab can be closed without showing a prompt.
+@property BOOL titleDisplaysDeviceName;	   // Whether the title contains the device name.
+@property BOOL titleDisplaysShellPath;	   // Whether the title contains the shell path.
+@property BOOL titleDisplaysWindowSize;	   // Whether the title contains the tab’s size, in rows and columns.
 @property BOOL titleDisplaysSettingsName;  // Whether the title contains the settings name.
-@property BOOL titleDisplaysCustomTitle;  // Whether the title contains a custom title.
-@property (copy) NSString *customTitle;  // The tab’s custom title.
+@property BOOL titleDisplaysCustomTitle;   // Whether the title contains a custom title.
+@property (copy) NSString *customTitle;	   // The tab’s custom title.
 
-- (void) closeSaving:(TerminalSaveOptions)saving savingIn:(NSURL *)savingIn;  // Close a document.
-- (void) saveIn:(NSURL *)in_;  // Save a document.
-- (void) printWithProperties:(NSDictionary *)withProperties printDialog:(BOOL)printDialog;  // Print a document.
-- (void) delete;  // Delete an object.
-- (void) duplicateTo:(SBObject *)to withProperties:(NSDictionary *)withProperties;  // Copy object(s) and put the copies at a new location.
-- (BOOL) exists;  // Verify if an object exists.
-- (void) moveTo:(SBObject *)to;  // Move object(s) to a new location.
+- (void)closeSaving:(TerminalSaveOptions)saving savingIn:(NSURL *)savingIn;				  // Close a document.
+- (void)saveIn:(NSURL *)in_;															  // Save a document.
+- (void)printWithProperties:(NSDictionary *)withProperties printDialog:(BOOL)printDialog; // Print a document.
+- (void)delete;																			  // Delete an object.
+- (void)duplicateTo:(SBObject *)to withProperties:(NSDictionary *)withProperties;		  // Copy object(s) and put the copies at a new location.
+- (BOOL)exists;																			  // Verify if an object exists.
+- (void)moveTo:(SBObject *)to;															  // Move object(s) to a new location.
 
 @end
 
 // A tab.
 @interface TerminalTab : SBObject
 
-@property NSInteger numberOfRows;  // The number of rows displayed in the tab.
-@property NSInteger numberOfColumns;  // The number of columns displayed in the tab.
-@property (copy, readonly) NSString *contents;  // The currently visible contents of the tab.
-@property (copy, readonly) NSString *history;  // The contents of the entire scrolling buffer of the tab.
-@property (readonly) BOOL busy;  // Whether the tab is busy running a process.
-@property (copy, readonly) NSArray *processes;  // The processes currently running in the tab.
-@property BOOL selected;  // Whether the tab is selected.
-@property BOOL titleDisplaysCustomTitle;  // Whether the title contains a custom title.
-@property (copy) NSString *customTitle;  // The tab’s custom title.
-@property (copy, readonly) NSString *tty;  // The tab’s TTY device.
-@property (copy) TerminalSettingsSet *currentSettings;  // The set of settings which control the tab’s behavior and appearance.
-@property (copy) NSColor *cursorColor;  // The cursor color for the tab.
-@property (copy) NSColor *backgroundColor;  // The background color for the tab.
-@property (copy) NSColor *normalTextColor;  // The normal text color for the tab.
-@property (copy) NSColor *boldTextColor;  // The bold text color for the tab.
-@property (copy) NSArray *cleanCommands;  // The processes which will be ignored when checking whether a tab can be closed without showing a prompt.
-@property BOOL titleDisplaysDeviceName;  // Whether the title contains the device name.
-@property BOOL titleDisplaysShellPath;  // Whether the title contains the shell path.
-@property BOOL titleDisplaysWindowSize;  // Whether the title contains the tab’s size, in rows and columns.
-@property BOOL titleDisplaysFileName;  // Whether the title contains the file name.
-@property (copy) NSString *fontName;  // The name of the font used to display the tab’s contents.
-@property NSInteger fontSize;  // The size of the font used to display the tab’s contents.
-@property BOOL fontAntialiasing;  // Whether the font used to display the tab’s contents is antialiased.
+@property NSInteger numberOfRows;					   // The number of rows displayed in the tab.
+@property NSInteger numberOfColumns;				   // The number of columns displayed in the tab.
+@property (copy, readonly) NSString *contents;		   // The currently visible contents of the tab.
+@property (copy, readonly) NSString *history;		   // The contents of the entire scrolling buffer of the tab.
+@property (readonly) BOOL busy;						   // Whether the tab is busy running a process.
+@property (copy, readonly) NSArray *processes;		   // The processes currently running in the tab.
+@property BOOL selected;							   // Whether the tab is selected.
+@property BOOL titleDisplaysCustomTitle;			   // Whether the title contains a custom title.
+@property (copy) NSString *customTitle;				   // The tab’s custom title.
+@property (copy, readonly) NSString *tty;			   // The tab’s TTY device.
+@property (copy) TerminalSettingsSet *currentSettings; // The set of settings which control the tab’s behavior and appearance.
+@property (copy) NSColor *cursorColor;				   // The cursor color for the tab.
+@property (copy) NSColor *backgroundColor;			   // The background color for the tab.
+@property (copy) NSColor *normalTextColor;			   // The normal text color for the tab.
+@property (copy) NSColor *boldTextColor;			   // The bold text color for the tab.
+@property (copy) NSArray *cleanCommands;			   // The processes which will be ignored when checking whether a tab can be closed without showing a prompt.
+@property BOOL titleDisplaysDeviceName;				   // Whether the title contains the device name.
+@property BOOL titleDisplaysShellPath;				   // Whether the title contains the shell path.
+@property BOOL titleDisplaysWindowSize;				   // Whether the title contains the tab’s size, in rows and columns.
+@property BOOL titleDisplaysFileName;				   // Whether the title contains the file name.
+@property (copy) NSString *fontName;				   // The name of the font used to display the tab’s contents.
+@property NSInteger fontSize;						   // The size of the font used to display the tab’s contents.
+@property BOOL fontAntialiasing;					   // Whether the font used to display the tab’s contents is antialiased.
 
-- (void) closeSaving:(TerminalSaveOptions)saving savingIn:(NSURL *)savingIn;  // Close a document.
-- (void) saveIn:(NSURL *)in_;  // Save a document.
-- (void) printWithProperties:(NSDictionary *)withProperties printDialog:(BOOL)printDialog;  // Print a document.
-- (void) delete;  // Delete an object.
-- (void) duplicateTo:(SBObject *)to withProperties:(NSDictionary *)withProperties;  // Copy object(s) and put the copies at a new location.
-- (BOOL) exists;  // Verify if an object exists.
-- (void) moveTo:(SBObject *)to;  // Move object(s) to a new location.
+- (void)closeSaving:(TerminalSaveOptions)saving savingIn:(NSURL *)savingIn;				  // Close a document.
+- (void)saveIn:(NSURL *)in_;															  // Save a document.
+- (void)printWithProperties:(NSDictionary *)withProperties printDialog:(BOOL)printDialog; // Print a document.
+- (void)delete;																			  // Delete an object.
+- (void)duplicateTo:(SBObject *)to withProperties:(NSDictionary *)withProperties;		  // Copy object(s) and put the copies at a new location.
+- (BOOL)exists;																			  // Verify if an object exists.
+- (void)moveTo:(SBObject *)to;															  // Move object(s) to a new location.
 
 @end
-

--- a/Classes/Util/GitXCommitCopier.h
+++ b/Classes/Util/GitXCommitCopier.h
@@ -13,11 +13,11 @@
 
 @interface GitXCommitCopier : NSValueTransformer
 
-+ (NSString * _Nonnull) toFullSHA:(NSArray<PBGitCommit *> * _Nonnull)commits;
-+ (NSString * _Nonnull) toShortName:(NSArray<PBGitCommit *> * _Nonnull)commits;
-+ (NSString * _Nonnull) toSHAAndHeadingString:(NSArray<PBGitCommit *> * _Nonnull)commits;
-+ (NSString * _Nonnull) toPatch:(NSArray<PBGitCommit *> * _Nonnull)commits;
++ (NSString *_Nonnull)toFullSHA:(NSArray<PBGitCommit *> *_Nonnull)commits;
++ (NSString *_Nonnull)toShortName:(NSArray<PBGitCommit *> *_Nonnull)commits;
++ (NSString *_Nonnull)toSHAAndHeadingString:(NSArray<PBGitCommit *> *_Nonnull)commits;
++ (NSString *_Nonnull)toPatch:(NSArray<PBGitCommit *> *_Nonnull)commits;
 
-+ (void) putStringToPasteboard:(NSString * _Nullable)string;
++ (void)putStringToPasteboard:(NSString *_Nullable)string;
 
 @end

--- a/Classes/Util/GitXCommitCopier.m
+++ b/Classes/Util/GitXCommitCopier.m
@@ -13,60 +13,68 @@
 @implementation GitXCommitCopier
 
 
-
 #pragma mark Readymade conversions
 
-+ (NSString *) toFullSHA:(NSArray<PBGitCommit *> *)commits {
-	NSArray<NSString *> *commitStrings = [self transformCommits:commits with:^(PBGitCommit * commit) {
-		return commit.SHA;
-	}];
-	
++ (NSString *)toFullSHA:(NSArray<PBGitCommit *> *)commits
+{
+	NSArray<NSString *> *commitStrings = [self transformCommits:commits
+														   with:^(PBGitCommit *commit) {
+															   return commit.SHA;
+														   }];
+
 	return [commitStrings componentsJoinedByString:@"\n"];
 }
 
-+ (NSString *) toShortName:(NSArray<PBGitCommit *> *)commits {
-	NSArray<NSString *> *commitStrings = [self transformCommits:commits with:^(PBGitCommit * commit) {
-		return commit.shortName;
-	}];
-	
++ (NSString *)toShortName:(NSArray<PBGitCommit *> *)commits
+{
+	NSArray<NSString *> *commitStrings = [self transformCommits:commits
+														   with:^(PBGitCommit *commit) {
+															   return commit.shortName;
+														   }];
+
 	return [commitStrings componentsJoinedByString:@" "];
 }
 
-+ (NSString *) toSHAAndHeadingString:(NSArray<PBGitCommit *> *)commits {
-	NSArray<NSString *> *commitStrings = [self transformCommits:commits with:^(PBGitCommit * commit) {
-		return [NSString stringWithFormat:@"%@ (%@)", [commit.SHA substringToIndex:10], commit.subject];
-	}];
++ (NSString *)toSHAAndHeadingString:(NSArray<PBGitCommit *> *)commits
+{
+	NSArray<NSString *> *commitStrings = [self transformCommits:commits
+														   with:^(PBGitCommit *commit) {
+															   return [NSString stringWithFormat:@"%@ (%@)", [commit.SHA substringToIndex:10], commit.subject];
+														   }];
 
 	return [commitStrings componentsJoinedByString:@"\n"];
 }
 
-+ (NSString *) toPatch:(NSArray<PBGitCommit *> *)commits {
-	NSArray<NSString *> *commitStrings = [self transformCommits:commits with:^(PBGitCommit * commit) {
-		return commit.patch;
-	}];
-	
++ (NSString *)toPatch:(NSArray<PBGitCommit *> *)commits
+{
+	NSArray<NSString *> *commitStrings = [self transformCommits:commits
+														   with:^(PBGitCommit *commit) {
+															   return commit.patch;
+														   }];
+
 	return [commitStrings componentsJoinedByString:@"\n\n\n"];
 }
 
 
+#pragma mark Helpers
 
-# pragma mark Helpers
-
-+ (NSArray<NSString *> *) transformCommits:(NSArray<PBGitCommit *> *)commits with:(NSString *(^)(PBGitCommit *  commit))transformer {
-	
++ (NSArray<NSString *> *)transformCommits:(NSArray<PBGitCommit *> *)commits with:(NSString * (^)(PBGitCommit *commit))transformer
+{
 	NSMutableArray *strings = [NSMutableArray arrayWithCapacity:commits.count];
-	[commits enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(PBGitCommit * _Nonnull commit, NSUInteger idx, BOOL * _Nonnull stop) {
-		[strings addObject:transformer(commit)];
-	}];
-	
+	[commits enumerateObjectsWithOptions:NSEnumerationReverse
+							  usingBlock:^(PBGitCommit *_Nonnull commit, NSUInteger idx, BOOL *_Nonnull stop) {
+								  [strings addObject:transformer(commit)];
+							  }];
+
 	return strings;
 }
 
 
-+ (void) putStringToPasteboard:(NSString *)string {
++ (void)putStringToPasteboard:(NSString *)string
+{
 	if (string.length > 0) {
 		NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
-		[pasteboard declareTypes:@[NSStringPboardType] owner:self];
+		[pasteboard declareTypes:@[ NSStringPboardType ] owner:self];
 		[pasteboard setString:string forType:NSStringPboardType];
 	}
 }

--- a/Classes/Util/NSApplication+GitXScripting.m
+++ b/Classes/Util/NSApplication+GitXScripting.m
@@ -28,17 +28,17 @@
 
 - (void)performDiffScriptCommand:(NSScriptCommand *)command
 {
-    NSURL *repositoryURL = command.directParameter;
-    NSArray *diffOptions = command.arguments[@"diffOptions"];
+	NSURL *repositoryURL = command.directParameter;
+	NSArray *diffOptions = command.arguments[@"diffOptions"];
 
-	diffOptions = [@[@"diff", @"--no-ext-diff"] arrayByAddingObjectsFromArray:diffOptions];
+	diffOptions = [@[ @"diff", @"--no-ext-diff" ] arrayByAddingObjectsFromArray:diffOptions];
 
 	NSError *error = nil;
 	NSString *diffOutput = [PBTask outputForCommand:[PBGitBinary path] arguments:diffOptions inDirectory:repositoryURL.path error:&error];
 	if (!diffOutput) {
 		// if there is an error diffOutput should have the error output from git
 		NSLog(@"Invalid diff command: %@", error);
-        return;
+		return;
 	}
 
 	PBDiffWindowController *diffController = [[PBDiffWindowController alloc] initWithDiff:diffOutput];
@@ -47,24 +47,24 @@
 
 - (void)initRepositoryScriptCommand:(NSScriptCommand *)command
 {
-    NSError *error = nil;
+	NSError *error = nil;
 	NSURL *repositoryURL = [command directParameter];
 	if (!repositoryURL)
-        return;
+		return;
 
 	GTRepository *repo = [GTRepository initializeEmptyRepositoryAtFileURL:repositoryURL options:nil error:&error];
-    if (!repo) {
-        NSLog(@"Failed to create repository at %@: %@", repositoryURL, error);
-        return;
-    }
+	if (!repo) {
+		NSLog(@"Failed to create repository at %@: %@", repositoryURL, error);
+		return;
+	}
 
-    [[NSDocumentController sharedDocumentController] openDocumentWithContentsOfURL:repositoryURL
-                                                                           display:YES
-                                                                 completionHandler:^(NSDocument *document, BOOL documentWasAlreadyOpen, NSError *error) {
-                                                                     if (error) {
-                                                                         NSLog(@"Failed to open repository at %@: %@", repositoryURL, error);
-                                                                     }
-                                                                 }];
+	[[NSDocumentController sharedDocumentController] openDocumentWithContentsOfURL:repositoryURL
+																		   display:YES
+																 completionHandler:^(NSDocument *document, BOOL documentWasAlreadyOpen, NSError *error) {
+																	 if (error) {
+																		 NSLog(@"Failed to open repository at %@: %@", repositoryURL, error);
+																	 }
+																 }];
 }
 
 - (void)cloneRepositoryScriptCommand:(NSScriptCommand *)command

--- a/Classes/Util/NSFileHandleExt.h
+++ b/Classes/Util/NSFileHandleExt.h
@@ -15,6 +15,6 @@
 #include <netdb.h>
 #include <fcntl.h>
 
-@interface NSFileHandle(NSFileHandleExt)
--(NSString*)readLine;
+@interface NSFileHandle (NSFileHandleExt)
+- (NSString *)readLine;
 @end

--- a/Classes/Util/NSFileHandleExt.m
+++ b/Classes/Util/NSFileHandleExt.m
@@ -13,65 +13,66 @@
 #define CONN_TIMEOUT 5
 #define BUFFER_SIZE 256
 
-@implementation NSFileHandle(NSFileHandleExt)
+@implementation NSFileHandle (NSFileHandleExt)
 
--(NSString*)readLine {
+- (NSString *)readLine
+{
 	// If the socket is closed, return an empty string
 	if ([self fileDescriptor] <= 0)
 		return @"";
-	
+
 	int fd = [self fileDescriptor];
-	
+
 	// Allocate BUFFER_SIZE bytes to store the line
 	int bufferSize = BUFFER_SIZE;
-	char *buffer = (char*)malloc(bufferSize + 1);
+	char *buffer = (char *)malloc(bufferSize + 1);
 	if (buffer == NULL)
 		[[NSException exceptionWithName:@"No memory left" reason:@"No more memory for allocating buffer" userInfo:nil] raise];
 	buffer[0] = '\0';
-	
+
 	int bytesReceived = 0;
 	long n = 0;
-	
+
 	while (1) {
 		n = read(fd, buffer + bytesReceived, 1);
-		
+
 		if (n == 0)
 			break;
-		
+
 		if (n < 0) {
 			if (errno == EINTR)
 				continue;
-			
+
 			free(buffer);
 			NSString *reason = [NSString stringWithFormat:@"%s:%d: read() error: %s", __PRETTY_FUNCTION__, __LINE__, strerror(errno)];
 			[[NSException exceptionWithName:@"Socket error" reason:reason userInfo:nil] raise];
 		}
-		
+
 		bytesReceived++;
-		
+
 		if (bytesReceived >= bufferSize) {
 			// Make buffer bigger
 			bufferSize += BUFFER_SIZE;
 			buffer = (char *)reallocf(buffer, bufferSize + 1);
 			if (buffer == NULL)
 				[[NSException exceptionWithName:@"No memory left" reason:@"No more memory for allocating buffer" userInfo:nil] raise];
-		}       
-		
-		char receivedByte = buffer[bytesReceived-1];
+		}
+
+		char receivedByte = buffer[bytesReceived - 1];
 		if (receivedByte == '\n') {
 			bytesReceived--;
 			break;
 		}
-		
+
 		if (receivedByte == '\r')
 			bytesReceived--;
-	}       
-	
+	}
+
 	buffer[bytesReceived] = '\0';
-	NSString *retVal = [NSString stringWithCString: buffer  encoding: NSUTF8StringEncoding];
+	NSString *retVal = [NSString stringWithCString:buffer encoding:NSUTF8StringEncoding];
 	if ([retVal length] == 0)
-		retVal = [NSString stringWithCString: buffer encoding: NSISOLatin1StringEncoding];
-	
+		retVal = [NSString stringWithCString:buffer encoding:NSISOLatin1StringEncoding];
+
 	free(buffer);
 	return retVal;
 }

--- a/Classes/Util/NSOutlineViewExt.h
+++ b/Classes/Util/NSOutlineViewExt.h
@@ -9,7 +9,7 @@
 #import <Cocoa/Cocoa.h>
 
 
-@interface NSOutlineView (PBExpandParents) 
+@interface NSOutlineView (PBExpandParents)
 
 - (void)PBExpandItem:(id)item expandParents:(BOOL)expand;
 @end

--- a/Classes/Util/NSOutlineViewExt.m
+++ b/Classes/Util/NSOutlineViewExt.m
@@ -18,7 +18,7 @@
 		[parents insertObject:item atIndex:0];
 		item = [item parent];
 	}
-	
+
 	for (id p in parents)
 		[self expandItem:p];
 }

--- a/Classes/Util/NSString_Truncate.h
+++ b/Classes/Util/NSString_Truncate.h
@@ -8,9 +8,9 @@
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
 //  You may obtain a copy of the License at
-//  
+//
 //    http://www.apache.org/licenses/LICENSE-2.0
-//  
+//
 //  Unless required by applicable law or agreed to in writing, software
 //  distributed under the License is distributed on an "AS IS" BASIS,
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,13 +20,13 @@
 #import <Cocoa/Cocoa.h>
 
 typedef enum {
-    PBNSStringTruncateModeCenter = 0,
-    PBNSStringTruncateModeStart = 1,
-    PBNSStringTruncateModeEnd = 2
+	PBNSStringTruncateModeCenter = 0,
+	PBNSStringTruncateModeStart = 1,
+	PBNSStringTruncateModeEnd = 2
 } PBNSStringTruncateMode;
 
 @interface NSString (PBGitXTruncateExtensions)
 
-- (NSString *) truncateToLength:(NSUInteger)length mode:(PBNSStringTruncateMode)mode indicator:(NSString *)indicatorString;
+- (NSString *)truncateToLength:(NSUInteger)length mode:(PBNSStringTruncateMode)mode indicator:(NSString *)indicatorString;
 
 @end

--- a/Classes/Util/NSString_Truncate.m
+++ b/Classes/Util/NSString_Truncate.m
@@ -8,9 +8,9 @@
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
 //  You may obtain a copy of the License at
-//  
+//
 //    http://www.apache.org/licenses/LICENSE-2.0
-//  
+//
 //  Unless required by applicable law or agreed to in writing, software
 //  distributed under the License is distributed on an "AS IS" BASIS,
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,49 +21,48 @@
 
 @implementation NSString (PBGitXTruncateExtensions)
 
-- (NSString *) truncateToLength:(NSUInteger)targetLength mode:(PBNSStringTruncateMode)mode indicator:(NSString *)indicatorString {
-    
-    NSString * res = nil;
-    NSString * firstPart;
-    NSString * lastPart;
-    
-    if (!indicatorString) {
-        indicatorString = @"...";
-    }
-    
-    NSUInteger stringLength = [self length];
-    NSUInteger ilength = [indicatorString length];
-    
-    if (stringLength <= targetLength) {
-        return self;
-    } else if (stringLength <= 0 || (!self)) {
-        return nil;
-    } else {
-        switch (mode) {
-            case PBNSStringTruncateModeCenter:
-                firstPart = [self substringToIndex:(targetLength/2)];
-                lastPart = [self substringFromIndex:(stringLength-((targetLength/2))+ilength)];
-                res = [NSString stringWithFormat:@"%@%@%@", firstPart, indicatorString, lastPart];                
-                break;
-            case PBNSStringTruncateModeStart:
-                res = [NSString stringWithFormat:@"%@%@", indicatorString, [self substringFromIndex:((stringLength-targetLength)+ilength)]];
-                break;
-            case PBNSStringTruncateModeEnd:
-                res = [NSString stringWithFormat:@"%@%@", [self substringToIndex:(targetLength-ilength)], indicatorString];
-                break;
-            default:
-                ;
-                NSException * myException = [NSException exceptionWithName:NSInvalidArgumentException 
-                                                                    reason:[NSString stringWithFormat:
-                                                                            @"[%@ %@] called with nonsensical value for 'mode' (mode = %d) ***",
-                                                                            [self class], NSStringFromSelector(_cmd), mode]
-                                                                  userInfo:nil];
-                @throw myException;
-                return res;
-                break;
-        };
-    }
-    return res;
+- (NSString *)truncateToLength:(NSUInteger)targetLength mode:(PBNSStringTruncateMode)mode indicator:(NSString *)indicatorString
+{
+	NSString *res = nil;
+	NSString *firstPart;
+	NSString *lastPart;
+
+	if (!indicatorString) {
+		indicatorString = @"...";
+	}
+
+	NSUInteger stringLength = [self length];
+	NSUInteger ilength = [indicatorString length];
+
+	if (stringLength <= targetLength) {
+		return self;
+	} else if (stringLength <= 0 || (!self)) {
+		return nil;
+	} else {
+		switch (mode) {
+			case PBNSStringTruncateModeCenter:
+				firstPart = [self substringToIndex:(targetLength / 2)];
+				lastPart = [self substringFromIndex:(stringLength - ((targetLength / 2)) + ilength)];
+				res = [NSString stringWithFormat:@"%@%@%@", firstPart, indicatorString, lastPart];
+				break;
+			case PBNSStringTruncateModeStart:
+				res = [NSString stringWithFormat:@"%@%@", indicatorString, [self substringFromIndex:((stringLength - targetLength) + ilength)]];
+				break;
+			case PBNSStringTruncateModeEnd:
+				res = [NSString stringWithFormat:@"%@%@", [self substringToIndex:(targetLength - ilength)], indicatorString];
+				break;
+			default:;
+				NSException *myException = [NSException exceptionWithName:NSInvalidArgumentException
+																   reason:[NSString stringWithFormat:
+																						@"[%@ %@] called with nonsensical value for 'mode' (mode = %d) ***",
+																						[self class], NSStringFromSelector(_cmd), mode]
+																 userInfo:nil];
+				@throw myException;
+				return res;
+				break;
+		};
+	}
+	return res;
 }
 
 @end

--- a/Classes/Util/ObjectiveGit+PBCategories.h
+++ b/Classes/Util/ObjectiveGit+PBCategories.h
@@ -9,5 +9,5 @@
 #import <ObjectiveGit/ObjectiveGit.h>
 
 @interface GTCommit (PBCategories)
-- (NSArray <GTOID *> *)parentOIDs;
+- (NSArray<GTOID *> *)parentOIDs;
 @end

--- a/Classes/Util/ObjectiveGit+PBCategories.m
+++ b/Classes/Util/ObjectiveGit+PBCategories.m
@@ -13,9 +13,10 @@
 
 // This is an optimisation for the grapher.
 // We're only interested in OIDs, and we don't need objects
-- (NSArray <GTOID *> *)parentOIDs {
+- (NSArray<GTOID *> *)parentOIDs
+{
 	unsigned numberOfParents = git_commit_parentcount(self.git_commit);
-	NSMutableArray <GTOID *> *parents = [NSMutableArray arrayWithCapacity:numberOfParents];
+	NSMutableArray<GTOID *> *parents = [NSMutableArray arrayWithCapacity:numberOfParents];
 
 	for (unsigned i = 0; i < numberOfParents; i++) {
 		const git_oid *parent = git_commit_parent_id(self.git_commit, i);
@@ -24,7 +25,6 @@
 	}
 
 	return parents;
-
 }
 
 @end

--- a/Classes/Util/PBEasyFS.h
+++ b/Classes/Util/PBEasyFS.h
@@ -10,9 +10,8 @@
 
 
 @interface PBEasyFS : NSObject {
-
 }
 
-+ (NSString*) tmpDirWithPrefix: (NSString*) path;
++ (NSString *)tmpDirWithPrefix:(NSString *)path;
 
 @end

--- a/Classes/Util/PBEasyFS.m
+++ b/Classes/Util/PBEasyFS.m
@@ -11,10 +11,10 @@
 
 @implementation PBEasyFS
 
-+ (NSString*) tmpDirWithPrefix: (NSString*) path
++ (NSString *)tmpDirWithPrefix:(NSString *)path
 {
-	NSString* newName = [NSString stringWithFormat: @"%@%@.XXXXXX", NSTemporaryDirectory(), path];
-	char *template = (char*) [newName fileSystemRepresentation];
+	NSString *newName = [NSString stringWithFormat:@"%@%@.XXXXXX", NSTemporaryDirectory(), path];
+	char *template = (char *)[newName fileSystemRepresentation];
 	template = mkdtemp(template);
 	return [NSString stringWithUTF8String:template];
 }

--- a/Classes/Util/PBError.h
+++ b/Classes/Util/PBError.h
@@ -8,9 +8,9 @@
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
 //  You may obtain a copy of the License at
-//  
+//
 //    http://www.apache.org/licenses/LICENSE-2.0
-//  
+//
 //  Unless required by applicable law or agreed to in writing, software
 //  distributed under the License is distributed on an "AS IS" BASIS,
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString * const PBGitXErrorDomain;
+extern NSString *const PBGitXErrorDomain;
 
 @interface NSError (PBError)
 
@@ -74,7 +74,7 @@ extern NSString * const PBGitXErrorDomain;
  *
  * @return NO.
  */
-BOOL PBReturnError(NSError **error, NSString *description, NSString *failureReason, NSError * __nullable underlyingError);
+BOOL PBReturnError(NSError **error, NSString *description, NSString *failureReason, NSError *__nullable underlyingError);
 
 /**
  * Helper function for easily handling NSError double-pointers.
@@ -86,7 +86,7 @@ BOOL PBReturnError(NSError **error, NSString *description, NSString *failureReas
  *
  * @return NO.
  */
-BOOL PBReturnErrorWithUserInfo(NSError **error, NSString *description, NSString *failureReason, NSDictionary * _Nullable userInfo);
+BOOL PBReturnErrorWithUserInfo(NSError **error, NSString *description, NSString *failureReason, NSDictionary *_Nullable userInfo);
 
 /**
  * Helper function for easily handling NSError double-pointers.

--- a/Classes/Util/PBError.m
+++ b/Classes/Util/PBError.m
@@ -8,9 +8,9 @@
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
 //  You may obtain a copy of the License at
-//  
+//
 //    http://www.apache.org/licenses/LICENSE-2.0
-//  
+//
 //  Unless required by applicable law or agreed to in writing, software
 //  distributed under the License is distributed on an "AS IS" BASIS,
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,7 @@
 
 #import "PBError.h"
 
-NSString * const PBGitXErrorDomain      = @"PBGitXErrorDomain";
+NSString *const PBGitXErrorDomain = @"PBGitXErrorDomain";
 
 @implementation NSError (PBError)
 
@@ -38,19 +38,20 @@ NSString * const PBGitXErrorDomain      = @"PBGitXErrorDomain";
 	return [self pb_errorWithDescription:description failureReason:failureReason underlyingError:underError userInfo:nil];
 }
 
-+ (NSError *)pb_errorWithDescription:(NSString *)description failureReason:(NSString *)failureReason underlyingError:(NSError *)underError userInfo:(NSDictionary *)userInfo {
++ (NSError *)pb_errorWithDescription:(NSString *)description failureReason:(NSString *)failureReason underlyingError:(NSError *)underError userInfo:(NSDictionary *)userInfo
+{
 	NSParameterAssert(description != nil);
 	NSParameterAssert(failureReason != nil);
 
 	NSMutableDictionary *errorInfo = userInfo ? [userInfo mutableCopy] : [NSMutableDictionary dictionary];
 
 	[errorInfo addEntriesFromDictionary:@{
-										  NSLocalizedDescriptionKey: description,
-										  NSLocalizedFailureReasonErrorKey: failureReason,
-										  }];
+		NSLocalizedDescriptionKey : description,
+		NSLocalizedFailureReasonErrorKey : failureReason,
+	}];
 
 	if (underError) {
-		[errorInfo addEntriesFromDictionary:@{ NSUnderlyingErrorKey: underError }];
+		[errorInfo addEntriesFromDictionary:@{NSUnderlyingErrorKey : underError}];
 	}
 
 	return [NSError errorWithDomain:PBGitXErrorDomain code:0 userInfo:errorInfo];
@@ -59,21 +60,24 @@ NSString * const PBGitXErrorDomain      = @"PBGitXErrorDomain";
 @end
 
 
-BOOL PBReturnError(NSError **error, NSString *description, NSString *failureReason, NSError *underlyingError) {
+BOOL PBReturnError(NSError **error, NSString *description, NSString *failureReason, NSError *underlyingError)
+{
 	if (error) {
 		*error = [NSError pb_errorWithDescription:description failureReason:failureReason underlyingError:underlyingError];
 	}
 	return NO;
 }
 
-BOOL PBReturnErrorWithUserInfo(NSError **error, NSString *description, NSString *failureReason, NSDictionary *userInfo) {
+BOOL PBReturnErrorWithUserInfo(NSError **error, NSString *description, NSString *failureReason, NSDictionary *userInfo)
+{
 	if (error) {
 		*error = [NSError pb_errorWithDescription:description failureReason:failureReason userInfo:userInfo];
 	}
 	return NO;
 }
 
-BOOL PBReturnErrorWithBuilder(NSError **error, NSError * (^errorBuilder)(void)) {
+BOOL PBReturnErrorWithBuilder(NSError **error, NSError * (^errorBuilder)(void))
+{
 	if (error) {
 		*error = errorBuilder();
 	}

--- a/Classes/Util/PBTask.h
+++ b/Classes/Util/PBTask.h
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSUInteger, PBTaskErrorCode) {
 /// @param queue			  The queue on which the handler will be called.
 /// @param terminationHandler A block that will be called when the executable exits.
 ///
-- (void)performTaskOnQueue:(dispatch_queue_t)queue terminationHandler:(void (^)(NSError * __nullable error))terminationHandler;
+- (void)performTaskOnQueue:(dispatch_queue_t)queue terminationHandler:(void (^)(NSError *__nullable error))terminationHandler;
 
 ///
 /// Execute a task, and process its output
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSUInteger, PBTaskErrorCode) {
 /// @param completionHandler A block that will be called when the executable exits.
 ///							 If readData is nil, it means an error occurred.
 ///
-- (void)performTaskOnQueue:(dispatch_queue_t)queue completionHandler:(void (^)(NSData * __nullable readData, NSError * __nullable error))completionHandler;
+- (void)performTaskOnQueue:(dispatch_queue_t)queue completionHandler:(void (^)(NSData *__nullable readData, NSError *__nullable error))completionHandler;
 
 /// Execute a task synchronously
 ///
@@ -79,14 +79,14 @@ typedef NS_ENUM(NSUInteger, PBTaskErrorCode) {
 /// This uses the main queue
 ///
 /// @see performTaskOnQueue:terminationHandler:
-- (void)performTaskWithTerminationHandler:(void (^)(NSError * __nullable error))terminationHandler;
+- (void)performTaskWithTerminationHandler:(void (^)(NSError *__nullable error))terminationHandler;
 
 /// Execute a task
 ///
 /// This uses the main queue
 ///
 /// @see performTaskOnQueue:completionHandler:
-- (void)performTaskWithCompletionHandler:(void (^)(NSData * __nullable readData, NSError * __nullable error))completionHandler;
+- (void)performTaskWithCompletionHandler:(void (^)(NSData *__nullable readData, NSError *__nullable error))completionHandler;
 
 @end
 
@@ -118,7 +118,7 @@ typedef NS_ENUM(NSUInteger, PBTaskErrorCode) {
 /// @param completionHandler A block that will be called when the executable exits.
 ///							 If readData is nil, it means an error occurred.
 ///
-+ (void)launchTask:(NSString *)launchPath arguments:(nullable NSArray *)arguments inDirectory:(nullable NSString *)directory completionHandler:(void (^)(NSData * __nullable readData, NSError * __nullable error))completionHandler;
++ (void)launchTask:(NSString *)launchPath arguments:(nullable NSArray *)arguments inDirectory:(nullable NSString *)directory completionHandler:(void (^)(NSData *__nullable readData, NSError *__nullable error))completionHandler;
 
 /// Return the standard output data as a string
 ///

--- a/Classes/Util/PBTerminalUtil.h
+++ b/Classes/Util/PBTerminalUtil.h
@@ -14,6 +14,6 @@
  * Runs the given command in OS X’s Terminal.app
  * at the given directory.
  */
-+ (void) runCommand:(NSString *)command inDirectory:(NSURL *)directory;
++ (void)runCommand:(NSString *)command inDirectory:(NSURL *)directory;
 
 @end

--- a/Classes/Util/PBTerminalUtil.m
+++ b/Classes/Util/PBTerminalUtil.m
@@ -15,11 +15,13 @@
 
 @implementation PBTerminalUtil
 
-+ (void)runCommand:(NSString *)command inDirectory:(NSURL *)directory {
++ (void)runCommand:(NSString *)command inDirectory:(NSURL *)directory
+{
 	[[self terminalHandler] runCommand:command inDirectory:directory];
 }
 
-+ (instancetype)terminalHandler {
++ (instancetype)terminalHandler
+{
 	static dispatch_once_t onceToken;
 	static PBTerminalUtil *term = nil;
 	dispatch_once(&onceToken, ^{
@@ -28,7 +30,8 @@
 	return term;
 }
 
-- (void)runCommand:(NSString *)command inDirectory:(NSURL *)directory {
+- (void)runCommand:(NSString *)command inDirectory:(NSURL *)directory
+{
 	NSString *terminalHandler = [PBGitDefaults terminalHandler];
 	BOOL ran = NO;
 
@@ -48,20 +51,22 @@
 	}
 }
 
-- (nullable id)eventDidFail:(const AppleEvent *)event withError:(NSError *)error {
+- (nullable id)eventDidFail:(const AppleEvent *)event withError:(NSError *)error
+{
 	NSLog(@"terminal handler error: %@", error);
 	return nil;
 }
 
-- (BOOL)runTerminalCommand:(NSString *)command inDirectory:(NSURL *)directory {
+- (BOOL)runTerminalCommand:(NSString *)command inDirectory:(NSURL *)directory
+{
 	NSString *fullCommand = [NSString stringWithFormat:@"cd \"%@\"; clear; echo '# Opened by GitX'; %@", directory.path, command];
 
-	TerminalApplication *term = [SBApplication applicationWithBundleIdentifier: @"com.apple.Terminal"];
+	TerminalApplication *term = [SBApplication applicationWithBundleIdentifier:@"com.apple.Terminal"];
 	if (!term)
 		return NO;
 	term.delegate = self;
 
-	[term doScript:fullCommand in: nil];
+	[term doScript:fullCommand in:nil];
 
 	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
 		[term activate];
@@ -70,10 +75,11 @@
 	return YES;
 }
 
-- (BOOL)runiTerm2Command:(NSString *)command inDirectory:(NSURL *)directory {
+- (BOOL)runiTerm2Command:(NSString *)command inDirectory:(NSURL *)directory
+{
 	NSString *fullCommand = [NSString stringWithFormat:@"cd \"%@\"; clear; echo '# Opened by GitX'; %@", directory.path, command];
 
-	iTerm2Application *term = [SBApplication applicationWithBundleIdentifier: @"com.googlecode.iterm2"];
+	iTerm2Application *term = [SBApplication applicationWithBundleIdentifier:@"com.googlecode.iterm2"];
 	if (!term)
 		return NO;
 	term.delegate = self;

--- a/Classes/Util/RJModalRepoSheet.h
+++ b/Classes/Util/RJModalRepoSheet.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
-typedef void(^RJSheetCompletionHandler)(id sheet, NSModalResponse returnCode);
+typedef void (^RJSheetCompletionHandler)(id sheet, NSModalResponse returnCode);
 
 - (void)beginSheetWithCompletionHandler:(nullable RJSheetCompletionHandler)handler;
 

--- a/Classes/Util/RJModalRepoSheet.m
+++ b/Classes/Util/RJModalRepoSheet.m
@@ -42,7 +42,8 @@
 	return self;
 }
 
-- (PBGitRepositoryDocument *)document {
+- (PBGitRepositoryDocument *)document
+{
 	return self.windowController.document;
 }
 

--- a/Classes/Views/GLFileView.h
+++ b/Classes/Views/GLFileView.h
@@ -14,7 +14,7 @@
 @class PBGitHistoryController;
 
 @interface GLFileView : PBWebController <MGScopeBarDelegate> {
-	__weak IBOutlet PBGitHistoryController* historyController;
+	__weak IBOutlet PBGitHistoryController *historyController;
 	__weak IBOutlet MGScopeBar *typeBar;
 	NSMutableArray *groups;
 	__weak IBOutlet NSView *accessoryView;

--- a/Classes/Views/GLFileView.m
+++ b/Classes/Views/GLFileView.m
@@ -14,16 +14,16 @@
 #import "PBGitHistoryController.h"
 
 
-#define GROUP_LABEL				@"Label"			// string
-#define GROUP_SEPARATOR			@"HasSeparator"		// BOOL as NSNumber
-#define GROUP_SELECTION_MODE	@"SelectionMode"	// MGScopeBarGroupSelectionMode (int) as NSNumber
-#define GROUP_ITEMS				@"Items"			// array of dictionaries, each containing the following keys:
-#define ITEM_IDENTIFIER			@"Identifier"		// string
-#define ITEM_NAME				@"Name"				// string
+#define GROUP_LABEL @"Label"				  // string
+#define GROUP_SEPARATOR @"HasSeparator"		  // BOOL as NSNumber
+#define GROUP_SELECTION_MODE @"SelectionMode" // MGScopeBarGroupSelectionMode (int) as NSNumber
+#define GROUP_ITEMS @"Items"				  // array of dictionaries, each containing the following keys:
+#define ITEM_IDENTIFIER @"Identifier"		  // string
+#define ITEM_NAME @"Name"					  // string
 
-#define GROUP_ID_FILEVIEW       @"fileview"
-#define GROUP_ID_BLAME          @"blame"
-#define GROUP_ID_LOG            @"log"
+#define GROUP_ID_FILEVIEW @"fileview"
+#define GROUP_ID_BLAME @"blame"
+#define GROUP_ID_LOG @"log"
 
 @interface GLFileView ()
 
@@ -34,73 +34,76 @@
 
 @implementation GLFileView
 
-- (void) awakeFromNib
+- (void)awakeFromNib
 {
 	startFile = GROUP_ID_FILEVIEW;
 	//repository = historyController.repository;
 	[super awakeFromNib];
-	[historyController.treeController addObserver:self keyPath:@"selection" options:0 block:^(MAKVONotification *notification) {
-		[self showFile];
-	}];
-	
+	[historyController.treeController addObserver:self
+										  keyPath:@"selection"
+										  options:0
+											block:^(MAKVONotification *notification) {
+												[self showFile];
+											}];
+
 	self.groups = [NSMutableArray arrayWithCapacity:0];
-	
+
 	NSArray *items = [NSArray arrayWithObjects:
-					  [NSDictionary dictionaryWithObjectsAndKeys:
-					   startFile, ITEM_IDENTIFIER,
-					   @"Source", ITEM_NAME,
-					   nil], 
-					  [NSDictionary dictionaryWithObjectsAndKeys:
-					   GROUP_ID_BLAME, ITEM_IDENTIFIER,
-					   @"Blame", ITEM_NAME,
-					   nil], 
-					  [NSDictionary dictionaryWithObjectsAndKeys:
-					   GROUP_ID_LOG, ITEM_IDENTIFIER,
-					   @"History", ITEM_NAME,
-					   nil], 
-					  nil];
+								  [NSDictionary dictionaryWithObjectsAndKeys:
+													startFile, ITEM_IDENTIFIER,
+													@"Source", ITEM_NAME,
+													nil],
+								  [NSDictionary dictionaryWithObjectsAndKeys:
+													GROUP_ID_BLAME, ITEM_IDENTIFIER,
+													@"Blame", ITEM_NAME,
+													nil],
+								  [NSDictionary dictionaryWithObjectsAndKeys:
+													GROUP_ID_LOG, ITEM_IDENTIFIER,
+													@"History", ITEM_NAME,
+													nil],
+								  nil];
 	[self.groups addObject:[NSDictionary dictionaryWithObjectsAndKeys:
-							[NSNumber numberWithBool:NO], GROUP_SEPARATOR, 
-							[NSNumber numberWithInt:MGScopeBarGroupSelectionModeRadio], GROUP_SELECTION_MODE, // single selection group.
-							items, GROUP_ITEMS, 
-							nil]];
+											 [NSNumber numberWithBool:NO], GROUP_SEPARATOR,
+											 [NSNumber numberWithInt:MGScopeBarGroupSelectionModeRadio], GROUP_SELECTION_MODE, // single selection group.
+											 items, GROUP_ITEMS,
+											 nil]];
 	[typeBar reloadData];
 
 	[fileListSplitView setHidden:YES];
 	[self performSelector:@selector(restoreSplitViewPositiion) withObject:nil afterDelay:0];
 }
 
-- (void) showFile
+- (void)showFile
 {
-	NSArray *files=[historyController.treeController selectedObjects];
+	NSArray *files = [historyController.treeController selectedObjects];
 	if ([files count] > 0) {
 		PBGitTree *file = [files objectAtIndex:0];
 
 		NSString *fileTxt = @"";
-		if([startFile isEqualToString:GROUP_ID_FILEVIEW])
+		if ([startFile isEqualToString:GROUP_ID_FILEVIEW])
 			fileTxt = [self escapeHTML:[file textContents]];
-		else if([startFile isEqualToString:GROUP_ID_BLAME])
+		else if ([startFile isEqualToString:GROUP_ID_BLAME])
 			fileTxt = [self parseBlame:[file blame]];
-		else if([startFile isEqualToString:GROUP_ID_LOG])
+		else if ([startFile isEqualToString:GROUP_ID_LOG])
 			fileTxt = [self htmlHistory:file];
 
 		id script = self.view.windowScriptObject;
 		NSString *filePath = [file fullPath];
-        [script callWebScriptMethod:@"showFile" withArguments:[NSArray arrayWithObjects:fileTxt, filePath, nil]];
+		[script callWebScriptMethod:@"showFile" withArguments:[NSArray arrayWithObjects:fileTxt, filePath, nil]];
 	}
-	
+
 #if 0
 	NSString *dom=[[[[view mainFrame] DOMDocument] documentElement] outerHTML];
 	NSString *tmpFile=@"~/tmp/test.html";
 	[dom writeToFile:[tmpFile stringByExpandingTildeInPath] atomically:true encoding:NSUTF8StringEncoding error:nil];
-#endif 
+#endif
 }
 
 #pragma mark JavaScript log.js methods
 
-- (void) selectCommit:(NSString*)c
+- (void)selectCommit:(NSString *)c
 {
-	[historyController selectCommit: [GTOID oidWithSHA: c]];
+	[historyController selectCommit:[GTOID oidWithSHA:c]];
 }
 
 #pragma mark MGScopeBarDelegate methods
@@ -145,10 +148,10 @@
 
 - (void)scopeBar:(MGScopeBar *)theScopeBar selectedStateChanged:(BOOL)selected forItem:(NSString *)identifier inGroup:(NSInteger)groupNumber
 {
-	startFile=identifier;
+	startFile = identifier;
 	NSString *path = [NSString stringWithFormat:@"html/views/%@", identifier];
 	NSString *html = [[NSBundle mainBundle] pathForResource:@"index" ofType:@"html" inDirectory:path];
-	NSURLRequest * request = [NSURLRequest requestWithURL:[NSURL fileURLWithPath:html]];
+	NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL fileURLWithPath:html]];
 	[self.view.mainFrame loadRequest:request];
 }
 
@@ -157,7 +160,7 @@
 	return accessoryView;
 }
 
-- (void) didLoad
+- (void)didLoad
 {
 	[self showFile];
 }
@@ -169,93 +172,93 @@
 	[super closeView];
 }
 
-- (NSString *) escapeHTML:(NSString *)txt
+- (NSString *)escapeHTML:(NSString *)txt
 {
 	CFStringRef escaped = CFXMLCreateStringByEscapingEntities(NULL, (__bridge CFStringRef)txt, NULL);
 	return (__bridge_transfer NSString *)escaped;
 }
 
-- (NSString *) parseBlame:(NSString *)txt
+- (NSString *)parseBlame:(NSString *)txt
 {
-	txt=[self escapeHTML:txt];
-	
+	txt = [self escapeHTML:txt];
+
 	NSArray *lines = [txt componentsSeparatedByString:@"\n"];
 	NSString *line;
-	NSMutableDictionary *headers=[NSMutableDictionary dictionary];
-	NSMutableString *res=[NSMutableString string];
-	
+	NSMutableDictionary *headers = [NSMutableDictionary dictionary];
+	NSMutableString *res = [NSMutableString string];
+
 	[res appendString:@"<table class='blocks'>\n"];
-	int i=0;
-	while(i<[lines count]){
-		line=[lines objectAtIndex:i];
-		NSArray *header=[line componentsSeparatedByString:@" "];
-		if([header count]==4){
+	int i = 0;
+	while (i < [lines count]) {
+		line = [lines objectAtIndex:i];
+		NSArray *header = [line componentsSeparatedByString:@" "];
+		if ([header count] == 4) {
 			NSString *commitID = (NSString *)[header objectAtIndex:0];
-			int nLines=[(NSString *)[header objectAtIndex:3] intValue];
-			[res appendFormat:@"<tr class='block l%d'>\n",nLines];
-			line=[lines objectAtIndex:++i];
-			if([[[line componentsSeparatedByString:@" "] objectAtIndex:0] isEqual:@"author"]){
-				NSString *author=[line stringByReplacingOccurrencesOfString:@"author" withString:@""];
-				NSString *summary=nil;
-				while(summary==nil){
-					line=[lines objectAtIndex:i++];
-					if([[[line componentsSeparatedByString:@" "] objectAtIndex:0] isEqual:@"summary"]){
-						summary=[line stringByReplacingOccurrencesOfString:@"summary" withString:@""];
+			int nLines = [(NSString *)[header objectAtIndex:3] intValue];
+			[res appendFormat:@"<tr class='block l%d'>\n", nLines];
+			line = [lines objectAtIndex:++i];
+			if ([[[line componentsSeparatedByString:@" "] objectAtIndex:0] isEqual:@"author"]) {
+				NSString *author = [line stringByReplacingOccurrencesOfString:@"author" withString:@""];
+				NSString *summary = nil;
+				while (summary == nil) {
+					line = [lines objectAtIndex:i++];
+					if ([[[line componentsSeparatedByString:@" "] objectAtIndex:0] isEqual:@"summary"]) {
+						summary = [line stringByReplacingOccurrencesOfString:@"summary" withString:@""];
 					}
 				}
-				NSRange trunc_c={0,7};
-				NSString *truncate_c=commitID;
-				if([commitID length]>8){
-					truncate_c=[commitID substringWithRange:trunc_c];
+				NSRange trunc_c = {0, 7};
+				NSString *truncate_c = commitID;
+				if ([commitID length] > 8) {
+					truncate_c = [commitID substringWithRange:trunc_c];
 				}
-				NSRange trunc={0,22};
-				NSString *truncate_a=author;
-				if([author length]>22){
-					truncate_a=[author substringWithRange:trunc];
+				NSRange trunc = {0, 22};
+				NSString *truncate_a = author;
+				if ([author length] > 22) {
+					truncate_a = [author substringWithRange:trunc];
 				}
-				NSString *truncate_s=summary;
-				if([summary length]>30){
-					truncate_s=[summary substringWithRange:trunc];
+				NSString *truncate_s = summary;
+				if ([summary length] > 30) {
+					truncate_s = [summary substringWithRange:trunc];
 				}
-				NSString *block=[NSString stringWithFormat:@"<td><p class='author'><a class='commit-link' href='#' data-commit-id='%@'>%@</a> %@</p><p class='summary'>%@</p></td>\n<td>\n",commitID,truncate_c,truncate_a,truncate_s];
+				NSString *block = [NSString stringWithFormat:@"<td><p class='author'><a class='commit-link' href='#' data-commit-id='%@'>%@</a> %@</p><p class='summary'>%@</p></td>\n<td>\n", commitID, truncate_c, truncate_a, truncate_s];
 				[headers setObject:block forKey:[header objectAtIndex:0]];
 			}
 			[res appendString:[headers objectForKey:[header objectAtIndex:0]]];
-			
-			NSMutableString *code=[NSMutableString string];
-			do{
-				line=[lines objectAtIndex:i++];
-			}while([line characterAtIndex:0]!='\t');
-			line=[line substringFromIndex:1];
-			line=[line stringByReplacingOccurrencesOfString:@"\t" withString:@"&nbsp;&nbsp;&nbsp;&nbsp;"];
+
+			NSMutableString *code = [NSMutableString string];
+			do {
+				line = [lines objectAtIndex:i++];
+			} while ([line characterAtIndex:0] != '\t');
+			line = [line substringFromIndex:1];
+			line = [line stringByReplacingOccurrencesOfString:@"\t" withString:@"&nbsp;&nbsp;&nbsp;&nbsp;"];
 			[code appendString:line];
 			[code appendString:@"\n"];
-			
+
 			int n;
-			for(n=1;n<nLines;n++){
+			for (n = 1; n < nLines; n++) {
 				i++;
-				do{
-					line=[lines objectAtIndex:i++];
-				}while([line characterAtIndex:0]!='\t');
-				line=[line substringFromIndex:1];
-				line=[line stringByReplacingOccurrencesOfString:@"\t" withString:@"&nbsp;&nbsp;&nbsp;&nbsp;"];
+				do {
+					line = [lines objectAtIndex:i++];
+				} while ([line characterAtIndex:0] != '\t');
+				line = [line substringFromIndex:1];
+				line = [line stringByReplacingOccurrencesOfString:@"\t" withString:@"&nbsp;&nbsp;&nbsp;&nbsp;"];
 				[code appendString:line];
 				[code appendString:@"\n"];
 			}
-			[res appendFormat:@"<pre class='first-line: %@;brush: objc'>%@</pre>",[header objectAtIndex:2],code];
+			[res appendFormat:@"<pre class='first-line: %@;brush: objc'>%@</pre>", [header objectAtIndex:2], code];
 			[res appendString:@"</td>\n"];
-		}else{
+		} else {
 			break;
 		}
 		[res appendString:@"</tr>\n"];
-	}  
+	}
 	[res appendString:@"</table>\n"];
 	//NSLog(@"%@",res);
-	
+
 	return (NSString *)res;
 }
 
-- (NSString *) htmlHistory:(PBGitTree *)file
+- (NSString *)htmlHistory:(PBGitTree *)file
 {
 	// \0 can't be passed as a shell argument, so use a sufficiently long random seperator instead
 	NSString *seperator = [[NSUUID UUID] UUIDString];
@@ -271,19 +274,19 @@
 	for (NSString *rawCommit in rawCommits) {
 		NSArray<NSString *> *parts = [rawCommit componentsSeparatedByString:seperator];
 		[html appendFormat:
-		 @"<div id='%@' class='commit'>"
-			 "<p class='title'>%@</p>"
-			 "<table>"
-				 "<tr><td>Author:</td><td>%@</td></tr>"
-				 "<tr><td>Date:</td><td>%@</td></tr>"
-		 		 "<tr><td>Commit:</td><td><a class='commit-link' href='#'>%@</a></td></tr>"
-			 "</table>"
-		 "</div>",
-		 [self escapeHTML:[parts[0] stringByTrimmingCharactersInSet:whitespaceSet]], // trim leading newline from split
-		 [self escapeHTML:parts[1]],
-		 [self escapeHTML:parts[2]],
-		 [self escapeHTML:parts[3]],
-		 [self escapeHTML:parts[4]]];
+				  @"<div id='%@' class='commit'>"
+				   "<p class='title'>%@</p>"
+				   "<table>"
+				   "<tr><td>Author:</td><td>%@</td></tr>"
+				   "<tr><td>Date:</td><td>%@</td></tr>"
+				   "<tr><td>Commit:</td><td><a class='commit-link' href='#'>%@</a></td></tr>"
+				   "</table>"
+				   "</div>",
+				  [self escapeHTML:[parts[0] stringByTrimmingCharactersInSet:whitespaceSet]], // trim leading newline from split
+				  [self escapeHTML:parts[1]],
+				  [self escapeHTML:parts[2]],
+				  [self escapeHTML:parts[3]],
+				  [self escapeHTML:parts[4]]];
 	}
 	return html;
 }
@@ -349,7 +352,6 @@
 	[fileListSplitView setPosition:position ofDividerAtIndex:0];
 	[fileListSplitView setHidden:NO];
 }
-
 
 
 @synthesize groups;

--- a/Classes/Views/PBAddRemoteSheet.h
+++ b/Classes/Views/PBAddRemoteSheet.h
@@ -16,10 +16,10 @@
 
 + (void)beginSheetWithWindowController:(PBGitWindowController *)windowController completionHandler:(RJSheetCompletionHandler)handler;
 
-- (IBAction) browseFolders:(id)sender;
-- (IBAction) addRemote:(id)sender;
-- (IBAction) showHideHiddenFiles:(id)sender;
-- (IBAction) cancelOperation:(id)sender;
+- (IBAction)browseFolders:(id)sender;
+- (IBAction)addRemote:(id)sender;
+- (IBAction)showHideHiddenFiles:(id)sender;
+- (IBAction)cancelOperation:(id)sender;
 
 @property (readwrite, weak) IBOutlet NSTextField *remoteName;
 @property (readwrite, weak) IBOutlet NSTextField *remoteURL;

--- a/Classes/Views/PBAddRemoteSheet.m
+++ b/Classes/Views/PBAddRemoteSheet.m
@@ -31,33 +31,33 @@
 
 #pragma mark IBActions
 
-- (IBAction) browseFolders:(id)sender
+- (IBAction)browseFolders:(id)sender
 {
 	PBAddRemoteSheet *me = self;
 	NSOpenPanel *browseSheet = [NSOpenPanel openPanel];
 
 	[browseSheet setTitle:NSLocalizedString(@"Add remote", @"Title of sheet to enter data for a new remote")];
-    [browseSheet setMessage:NSLocalizedString(@"Select a folder with a git repository", @"Title of sheet to enter data for a new remote")];
-    [browseSheet setCanChooseFiles:NO];
-    [browseSheet setCanChooseDirectories:YES];
-    [browseSheet setAllowsMultipleSelection:NO];
-    [browseSheet setCanCreateDirectories:NO];
+	[browseSheet setMessage:NSLocalizedString(@"Select a folder with a git repository", @"Title of sheet to enter data for a new remote")];
+	[browseSheet setCanChooseFiles:NO];
+	[browseSheet setCanChooseDirectories:YES];
+	[browseSheet setAllowsMultipleSelection:NO];
+	[browseSheet setCanCreateDirectories:NO];
 	[browseSheet setAccessoryView:me.browseAccessoryView];
 
 	self.browseSheet = browseSheet;
 	[me hide];
-    [browseSheet beginSheetModalForWindow:self.windowController.window
-                        completionHandler:^(NSInteger result) {
-                            if (result == NSModalResponseOK) {
-                                NSString *directory = browseSheet.directoryURL.path;
-                                [me.remoteURL setStringValue:directory];
-                            }
-                            [me show];
-                        }];
+	[browseSheet beginSheetModalForWindow:self.windowController.window
+						completionHandler:^(NSInteger result) {
+							if (result == NSModalResponseOK) {
+								NSString *directory = browseSheet.directoryURL.path;
+								[me.remoteURL setStringValue:directory];
+							}
+							[me show];
+						}];
 }
 
 
-- (IBAction) addRemote:(id)sender
+- (IBAction)addRemote:(id)sender
 {
 	[self.errorMessage setStringValue:@""];
 
@@ -82,12 +82,12 @@
 	[self acceptSheet:sender];
 }
 
-- (IBAction) showHideHiddenFiles:(id)sender
+- (IBAction)showHideHiddenFiles:(id)sender
 {
-    [self.browseSheet setShowsHiddenFiles:[sender state] == NSOnState];
+	[self.browseSheet setShowsHiddenFiles:[sender state] == NSOnState];
 }
 
-- (IBAction) cancelOperation:(id)sender
+- (IBAction)cancelOperation:(id)sender
 {
 	[self cancelSheet:sender];
 }

--- a/Classes/Views/PBCloneRepositoryPanel.h
+++ b/Classes/Views/PBCloneRepositoryPanel.h
@@ -17,21 +17,21 @@
 	BOOL isBare;
 }
 
-+ (id) panel;
++ (id)panel;
 + (void)beginCloneRepository:(NSString *)repository toURL:(NSURL *)targetURL isBare:(BOOL)bare;
 
 - (void)showErrorSheet:(NSError *)error;
 
-- (IBAction) closeCloneRepositoryPanel:(id)sender;
-- (IBAction) clone:(id)sender;
-- (IBAction) browseRepository:(id)sender;
-- (IBAction) showHideHiddenFiles:(id)sender;
-- (IBAction) browseDestination:(id)sender;
+- (IBAction)closeCloneRepositoryPanel:(id)sender;
+- (IBAction)clone:(id)sender;
+- (IBAction)browseRepository:(id)sender;
+- (IBAction)showHideHiddenFiles:(id)sender;
+- (IBAction)browseDestination:(id)sender;
 
 @property (nonatomic, weak) IBOutlet NSTextField *repositoryURL;
 @property (nonatomic, weak) IBOutlet NSTextField *destinationPath;
 @property (nonatomic, weak) IBOutlet NSTextField *errorMessage;
-@property (nonatomic, weak) IBOutlet NSView      *repositoryAccessoryView;
+@property (nonatomic, weak) IBOutlet NSView *repositoryAccessoryView;
 
 @property (assign) BOOL isBare;
 

--- a/Classes/Views/PBCommitHookFailedSheet.h
+++ b/Classes/Views/PBCommitHookFailedSheet.h
@@ -21,6 +21,6 @@
 
 - (IBAction)forceCommit:(id)sender;
 
-@property (nonatomic, strong) PBGitCommitController* commitController;
+@property (nonatomic, strong) PBGitCommitController *commitController;
 
 @end

--- a/Classes/Views/PBCommitHookFailedSheet.m
+++ b/Classes/Views/PBCommitHookFailedSheet.m
@@ -23,23 +23,23 @@
 			commitController:(PBGitCommitController *)controller
 		   completionHandler:(RJSheetCompletionHandler)handler;
 {
-	PBCommitHookFailedSheet* sheet = [[self alloc] initWithWindowNibName:@"PBCommitHookFailedSheet"
+	PBCommitHookFailedSheet *sheet = [[self alloc] initWithWindowNibName:@"PBCommitHookFailedSheet"
 														   andController:controller];
 	[sheet beginMessageSheetWithMessageText:message
 								   infoText:info
 						  completionHandler:handler];
 }
 
-- (id)initWithWindowNibName:(NSString*)windowNibName
-			  andController:(PBGitCommitController*)controller;
+- (id)initWithWindowNibName:(NSString *)windowNibName
+			  andController:(PBGitCommitController *)controller;
 {
-    self = [self initWithWindowNibName:windowNibName windowController:controller.windowController];
+	self = [self initWithWindowNibName:windowNibName windowController:controller.windowController];
 	if (!self)
 		return nil;
-	
+
 	self.commitController = controller;
 
-    return self;
+	return self;
 }
 
 - (IBAction)forceCommit:(id)sender

--- a/Classes/Views/PBCommitMessageView.m
+++ b/Classes/Views/PBCommitMessageView.m
@@ -13,17 +13,17 @@
 
 @implementation PBCommitMessageView
 
-- (void) awakeFromNib
+- (void)awakeFromNib
 {
-    [super awakeFromNib];
+	[super awakeFromNib];
 
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
-    [defaults addObserver:self
+	[defaults addObserver:self
 				  keyPath:@[ @"PBCommitMessageViewHasVerticalLine",
 							 @"PBCommitMessageViewVerticalLineLength",
 							 @"PBCommitMessageViewVerticalBodyLineLength" ]
-                  options:NSKeyValueObservingOptionNew
+				  options:NSKeyValueObservingOptionNew
 					block:^(MAKVONotification *notification) {
 						[self setNeedsDisplay:YES];
 					}];
@@ -33,41 +33,40 @@
 {
 	[super drawRect:aRect];
 
-    if ([PBGitDefaults commitMessageViewHasVerticalLine]) {
+	if ([PBGitDefaults commitMessageViewHasVerticalLine]) {
+		CGFloat characterWidth = [@" " sizeWithAttributes:[self typingAttributes]].width;
+		CGFloat lineWidth = characterWidth * [PBGitDefaults commitMessageViewVerticalLineLength];
+		NSRect line;
+		CGFloat padding;
+		CGFloat textViewHeight = [self bounds].size.height;
 
-        CGFloat characterWidth = [@" " sizeWithAttributes:[self typingAttributes]].width;
-        CGFloat lineWidth = characterWidth * [PBGitDefaults commitMessageViewVerticalLineLength];
-        NSRect line;
-        CGFloat padding;
-        CGFloat textViewHeight = [self bounds].size.height;
+		// draw a vertical line after the given size (used as an indicator
+		// for the first line of the commit message)
+		[[NSColor lightGrayColor] set];
+		padding = [[self textContainer] lineFragmentPadding];
+		line.origin.x = padding + lineWidth;
+		line.origin.y = 0;
+		line.size.width = 1;
+		line.size.height = textViewHeight;
+		NSRectFill(line);
 
-        // draw a vertical line after the given size (used as an indicator
-        // for the first line of the commit message)
-        [[NSColor lightGrayColor] set];
-        padding = [[self textContainer] lineFragmentPadding];
-        line.origin.x = padding + lineWidth;
-        line.origin.y = 0;
-        line.size.width = 1;
-        line.size.height = textViewHeight;
-        NSRectFill(line);
-
-        // and one for the body of the commit message
-        lineWidth = characterWidth * [PBGitDefaults commitMessageViewVerticalBodyLineLength];
-        [[NSColor darkGrayColor] set];
-        padding = [[self textContainer] lineFragmentPadding];
-        line.origin.x = padding + lineWidth;
-        line.origin.y = 0;
-        line.size.width = 1;
-        line.size.height = textViewHeight;
-        NSRectFill(line);
-    }
+		// and one for the body of the commit message
+		lineWidth = characterWidth * [PBGitDefaults commitMessageViewVerticalBodyLineLength];
+		[[NSColor darkGrayColor] set];
+		padding = [[self textContainer] lineFragmentPadding];
+		line.origin.x = padding + lineWidth;
+		line.origin.y = 0;
+		line.size.width = 1;
+		line.size.height = textViewHeight;
+		NSRectFill(line);
+	}
 }
 
-- (BOOL)performDragOperation:(id <NSDraggingInfo>)sender
+- (BOOL)performDragOperation:(id<NSDraggingInfo>)sender
 {
-    NSPasteboard *pboard = [sender draggingPasteboard];
+	NSPasteboard *pboard = [sender draggingPasteboard];
 
-    if ( [[pboard types] containsObject:NSFilenamesPboardType] ) {
+	if ([[pboard types] containsObject:NSFilenamesPboardType]) {
 		NSArray *filenames = [pboard propertyListForType:NSFilenamesPboardType];
 		NSString *baseDir = [self.repository.workingDirectory stringByAppendingString:@"/"];
 		if (baseDir) {
@@ -85,7 +84,7 @@
 			[pboard clearContents];
 			[pboard writeObjects:relativeNames];
 		}
-    }
+	}
 	return [super performDragOperation:sender];
 }
 

--- a/Classes/Views/PBCreateBranchSheet.h
+++ b/Classes/Views/PBCreateBranchSheet.h
@@ -18,12 +18,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PBCreateBranchSheet : RJModalRepoSheet
 
-+ (void)beginSheetWithRefish:(id <PBGitRefish>)ref windowController:(PBGitWindowController *)windowController completionHandler:(nullable RJSheetCompletionHandler)handler;
++ (void)beginSheetWithRefish:(id<PBGitRefish>)ref windowController:(PBGitWindowController *)windowController completionHandler:(nullable RJSheetCompletionHandler)handler;
 
-- (IBAction) createBranch:(nullable id)sender;
-- (IBAction) closeCreateBranchSheet:(nullable id)sender;
+- (IBAction)createBranch:(nullable id)sender;
+- (IBAction)closeCreateBranchSheet:(nullable id)sender;
 
-@property (nonatomic, strong) id <PBGitRefish> startRefish;
+@property (nonatomic, strong) id<PBGitRefish> startRefish;
 @property (nonatomic, strong) PBGitRef *selectedRef;
 @property (nonatomic, assign) BOOL shouldCheckoutBranch;
 

--- a/Classes/Views/PBCreateBranchSheet.m
+++ b/Classes/Views/PBCreateBranchSheet.m
@@ -19,16 +19,16 @@
 #pragma mark -
 #pragma mark PBCreateBranchSheet
 
-+ (void)beginSheetWithRefish:(id <PBGitRefish>)ref windowController:(PBGitWindowController *)windowController
++ (void)beginSheetWithRefish:(id<PBGitRefish>)ref windowController:(PBGitWindowController *)windowController
 {
 	[self beginSheetWithRefish:ref windowController:windowController completionHandler:nil];
 }
 
-+ (void)beginSheetWithRefish:(id <PBGitRefish>)ref windowController:(PBGitWindowController *)windowController completionHandler:(RJSheetCompletionHandler)handler {
++ (void)beginSheetWithRefish:(id<PBGitRefish>)ref windowController:(PBGitWindowController *)windowController completionHandler:(RJSheetCompletionHandler)handler
+{
 	PBCreateBranchSheet *sheet = [[self alloc] initWithWindowController:windowController atRefish:ref];
 	[sheet beginCreateBranchSheetAtRefish:ref completionHandler:handler];
 }
-
 
 
 - (id)initWithWindowController:(PBGitWindowController *)windowController atRefish:(id<PBGitRefish>)ref
@@ -41,11 +41,11 @@
 		return nil;
 
 	self.startRefish = ref;
-	
+
 	return self;
 }
 
-- (void) beginCreateBranchSheetAtRefish:(id <PBGitRefish>)ref completionHandler:(RJSheetCompletionHandler)handler
+- (void)beginCreateBranchSheetAtRefish:(id<PBGitRefish>)ref completionHandler:(RJSheetCompletionHandler)handler
 {
 	[self window]; // loads the window (if it wasn't already)
 	[self.errorMessageField setStringValue:@""];
@@ -64,10 +64,9 @@
 }
 
 
-
 #pragma mark IBActions
 
-- (IBAction) createBranch:(id)sender
+- (IBAction)createBranch:(id)sender
 {
 	NSString *name = [self.branchNameField stringValue];
 	self.selectedRef = [PBGitRef refFromString:[kGitXBranchRefPrefix stringByAppendingString:name]];
@@ -88,7 +87,7 @@
 }
 
 
-- (IBAction) closeCreateBranchSheet:(id)sender
+- (IBAction)closeCreateBranchSheet:(id)sender
 {
 	[self cancelSheet:sender];
 }

--- a/Classes/Views/PBCreateTagSheet.h
+++ b/Classes/Views/PBCreateTagSheet.h
@@ -16,15 +16,15 @@
 
 @interface PBCreateTagSheet : RJModalRepoSheet
 
-+ (void) beginSheetWithRefish:(id <PBGitRefish>)refish windowController:(PBGitWindowController *)windowController completionHandler:(RJSheetCompletionHandler)handler;
++ (void)beginSheetWithRefish:(id<PBGitRefish>)refish windowController:(PBGitWindowController *)windowController completionHandler:(RJSheetCompletionHandler)handler;
 
-- (IBAction) createTag:(id)sender;
-- (IBAction) closeCreateTagSheet:(id)sender;
+- (IBAction)createTag:(id)sender;
+- (IBAction)closeCreateTagSheet:(id)sender;
 
-@property (nonatomic, strong) id <PBGitRefish> targetRefish;
+@property (nonatomic, strong) id<PBGitRefish> targetRefish;
 
 @property (nonatomic, weak) IBOutlet NSTextField *tagNameField;
-@property (nonatomic, strong) IBOutlet NSTextView  *tagMessageText;
+@property (nonatomic, strong) IBOutlet NSTextView *tagMessageText;
 @property (nonatomic, weak) IBOutlet NSTextField *errorMessageField;
 
 @end

--- a/Classes/Views/PBCreateTagSheet.m
+++ b/Classes/Views/PBCreateTagSheet.m
@@ -19,14 +19,14 @@
 #pragma mark -
 #pragma mark PBCreateTagSheet
 
-+ (void) beginSheetWithRefish:(id <PBGitRefish>)refish windowController:(PBGitWindowController *)windowController completionHandler:(RJSheetCompletionHandler)handler
++ (void)beginSheetWithRefish:(id<PBGitRefish>)refish windowController:(PBGitWindowController *)windowController completionHandler:(RJSheetCompletionHandler)handler
 {
 	PBCreateTagSheet *sheet = [[self alloc] initWithWindowNibName:@"PBCreateTagSheet" windowController:windowController];
 	[sheet beginCreateTagSheetAtRefish:refish completionHandler:handler];
 }
 
 
-- (void) beginCreateTagSheetAtRefish:(id <PBGitRefish>)refish completionHandler:(RJSheetCompletionHandler)handler
+- (void)beginCreateTagSheetAtRefish:(id<PBGitRefish>)refish completionHandler:(RJSheetCompletionHandler)handler
 {
 	self.targetRefish = refish;
 
@@ -37,10 +37,9 @@
 }
 
 
-
 #pragma mark IBActions
 
-- (IBAction) createTag:(id)sender
+- (IBAction)createTag:(id)sender
 {
 	NSString *tagName = [self.tagNameField stringValue];
 	[self.errorMessageField setHidden:YES];
@@ -64,11 +63,10 @@
 }
 
 
-- (IBAction) closeCreateTagSheet:(id)sender
+- (IBAction)closeCreateTagSheet:(id)sender
 {
 	[self cancelSheet:sender];
 }
-
 
 
 @end

--- a/Classes/Views/PBFileChangesTableView.m
+++ b/Classes/Views/PBFileChangesTableView.m
@@ -16,7 +16,7 @@
 - (NSMenu *)menuForEvent:(NSEvent *)theEvent
 {
 	if ([self delegate]) {
-		NSPoint eventLocation = [self convertPoint:[theEvent locationInWindow] fromView: nil];
+		NSPoint eventLocation = [self convertPoint:[theEvent locationInWindow] fromView:nil];
 		NSInteger rowIndex = [self rowAtPoint:eventLocation];
 		[self selectRowIndexes:[NSIndexSet indexSetWithIndex:rowIndex] byExtendingSelection:YES];
 		return [super menuForEvent:theEvent];
@@ -32,9 +32,9 @@
 
 #pragma mark NSView overrides
 
--(BOOL)acceptsFirstResponder
+- (BOOL)acceptsFirstResponder
 {
-    return [self numberOfRows] > 0;
+	return [self numberOfRows] > 0;
 }
 
 @end

--- a/Classes/Views/PBGitCommitTableViewCell.m
+++ b/Classes/Views/PBGitCommitTableViewCell.m
@@ -11,7 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation PBGitCommitTableViewCell
 
-- (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle {
+- (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle
+{
 	switch (backgroundStyle) {
 		case NSBackgroundStyleDark:
 			self.textField.textColor = NSColor.whiteColor;

--- a/Classes/Views/PBGitGradientBarView.h
+++ b/Classes/Views/PBGitGradientBarView.h
@@ -13,7 +13,7 @@
 	NSGradient *gradient;
 }
 
-- (void) setTopShade:(float)topShade bottomShade:(float)bottomShade;
-- (void) setTopColor:(NSColor *)topShade bottomColor:(NSColor *)bottomColor;
+- (void)setTopShade:(float)topShade bottomShade:(float)bottomShade;
+- (void)setTopColor:(NSColor *)topShade bottomColor:(NSColor *)bottomColor;
 
 @end

--- a/Classes/Views/PBGitGradientBarView.m
+++ b/Classes/Views/PBGitGradientBarView.m
@@ -9,40 +9,39 @@
 #import "PBGitGradientBarView.h"
 
 
-
 @implementation PBGitGradientBarView
 
 
-- (id) initWithFrame:(NSRect)frame
+- (id)initWithFrame:(NSRect)frame
 {
 	self = [super initWithFrame:frame];
 	if (!self)
 		return nil;
-	
+
 	[self setTopShade:1.0 bottomShade:0.0];
-	
+
 	return self;
 }
 
 
-- (void) drawRect:(NSRect)dirtyRect
+- (void)drawRect:(NSRect)dirtyRect
 {
 	if (![NSApp isDarkMode])
 		[gradient drawInRect:[self bounds] angle:90];
 }
 
 
-- (void) setTopColor:(NSColor *)topColor bottomColor:(NSColor *)bottomColor
+- (void)setTopColor:(NSColor *)topColor bottomColor:(NSColor *)bottomColor
 {
 	if (!topColor || !bottomColor)
 		return;
-	
+
 	gradient = [[NSGradient alloc] initWithStartingColor:bottomColor endingColor:topColor];
 	[self setNeedsDisplay:YES];
 }
 
 
-- (void) setTopShade:(float)topShade bottomShade:(float)bottomShade
+- (void)setTopShade:(float)topShade bottomShade:(float)bottomShade
 {
 	NSColor *topColor = [NSColor colorWithCalibratedWhite:topShade alpha:1.0];
 	NSColor *bottomColor = [NSColor colorWithCalibratedWhite:bottomShade alpha:1.0];

--- a/Classes/Views/PBGitRevisionCell.h
+++ b/Classes/Views/PBGitRevisionCell.h
@@ -19,9 +19,9 @@ NS_ASSUME_NONNULL_BEGIN
 	__weak IBOutlet PBGitHistoryController *controller;
 }
 
-- (int) indexAtX:(CGFloat)x;
-- (NSRect) rectAtIndex:(int)index;
-- (void) drawLabelAtIndex:(int)index inRect:(NSRect)rect;
+- (int)indexAtX:(CGFloat)x;
+- (NSRect)rectAtIndex:(int)index;
+- (void)drawLabelAtIndex:(int)index inRect:(NSRect)rect;
 
 @property (strong) PBGitCommit *objectValue;
 

--- a/Classes/Views/PBGitRevisionCell.m
+++ b/Classes/Views/PBGitRevisionCell.m
@@ -26,7 +26,8 @@ const BOOL SHUFFLE_COLORS = NO;
 
 @implementation PBGitRevisionCell
 
-- (BOOL)isFlipped {
+- (BOOL)isFlipped
+{
 	return YES;
 }
 
@@ -75,15 +76,15 @@ const BOOL SHUFFLE_COLORS = NO;
 	return shadowColor;
 }
 
-- (void) drawLineFromColumn: (int) from toColumn: (int) to inRect: (NSRect) r offset: (int) offset color: (int) c
+- (void)drawLineFromColumn:(int)from toColumn:(int)to inRect:(NSRect)r offset:(int)offset color:(int)c
 {
 	NSPoint origin = r.origin;
 
 	NSPoint source = NSMakePoint(origin.x + COLUMN_WIDTH * from, origin.y + offset);
-	NSPoint center = NSMakePoint( origin.x + COLUMN_WIDTH * to, origin.y + r.size.height * 0.5 + 0.5);
+	NSPoint center = NSMakePoint(origin.x + COLUMN_WIDTH * to, origin.y + r.size.height * 0.5 + 0.5);
 
-	NSArray* colors = [PBGitRevisionCell laneColors];
-	[(NSColor*)[colors objectAtIndex: (c % [colors count])] set];
+	NSArray *colors = [PBGitRevisionCell laneColors];
+	[(NSColor *)[colors objectAtIndex:(c % [colors count])] set];
 
 	if (from == to) {
 		// We're drawing a straight line, we can use NSRectFill as a fast path
@@ -92,67 +93,71 @@ const BOOL SHUFFLE_COLORS = NO;
 
 		NSRectFill(NSMakeRect(source.x - 1, yOrigin, 2, height));
 	} else {
-		NSBezierPath * path = [NSBezierPath bezierPath];
+		NSBezierPath *path = [NSBezierPath bezierPath];
 		[path setLineWidth:2];
 		[path setLineCapStyle:NSRoundLineCapStyle];
-		[path moveToPoint: source];
-		[path lineToPoint: center];
+		[path moveToPoint:source];
+		[path lineToPoint:center];
 		[path stroke];
 	}
 }
 
-- (BOOL) isCurrentCommit
+- (BOOL)isCurrentCommit
 {
 	GTOID *thisOID = self.objectValue.OID;
 
-	PBGitRepository* repository = [self.objectValue repository];
+	PBGitRepository *repository = [self.objectValue repository];
 	GTOID *currentOID = [repository headOID];
 
 	return [currentOID isEqual:thisOID];
 }
 
-- (void) drawCircleInRect: (NSRect) r
+- (void)drawCircleInRect:(NSRect)r
 {
 	const CGFloat outlineWidth = 1.4f;
 	static NSImage *circleImage;
 	static NSImage *currentCommitCircleImage;
 	static dispatch_once_t onceToken;
 	dispatch_once(&onceToken, ^{
-		circleImage = [NSImage imageWithSize:NSMakeSize(10, 10) flipped:NO drawingHandler:^BOOL(NSRect dstRect) {
-			NSBezierPath *path = [NSBezierPath bezierPathWithOvalInRect:dstRect];
+		circleImage = [NSImage imageWithSize:NSMakeSize(10, 10)
+									 flipped:NO
+							  drawingHandler:^BOOL(NSRect dstRect) {
+								  NSBezierPath *path = [NSBezierPath bezierPathWithOvalInRect:dstRect];
 
-			[[NSColor blackColor] set];
-			[path fill];
+								  [[NSColor blackColor] set];
+								  [path fill];
 
-			NSRect smallOval = CGRectInset(dstRect, outlineWidth, outlineWidth);
-			NSBezierPath *smallPath = [NSBezierPath bezierPathWithOvalInRect:smallOval];
+								  NSRect smallOval = CGRectInset(dstRect, outlineWidth, outlineWidth);
+								  NSBezierPath *smallPath = [NSBezierPath bezierPathWithOvalInRect:smallOval];
 
-			[[NSColor whiteColor] set];
-			[smallPath fill];
+								  [[NSColor whiteColor] set];
+								  [smallPath fill];
 
-			return YES;
-		}];
+								  return YES;
+							  }];
 
-		currentCommitCircleImage = [NSImage imageWithSize:NSMakeSize(10, 10) flipped:NO drawingHandler:^BOOL(NSRect dstRect) {
-			NSBezierPath *path = [NSBezierPath bezierPathWithOvalInRect:dstRect];
+		currentCommitCircleImage = [NSImage imageWithSize:NSMakeSize(10, 10)
+												  flipped:NO
+										   drawingHandler:^BOOL(NSRect dstRect) {
+											   NSBezierPath *path = [NSBezierPath bezierPathWithOvalInRect:dstRect];
 
-			[[NSColor blackColor] set];
-			[path fill];
+											   [[NSColor blackColor] set];
+											   [path fill];
 
-			NSRect smallOval = CGRectInset(dstRect, outlineWidth, outlineWidth);
-			NSBezierPath *smallPath = [NSBezierPath bezierPathWithOvalInRect:smallOval];
+											   NSRect smallOval = CGRectInset(dstRect, outlineWidth, outlineWidth);
+											   NSBezierPath *smallPath = [NSBezierPath bezierPathWithOvalInRect:smallOval];
 
-			[[NSColor colorWithCalibratedRed: 0Xfc/256.0 green:0Xa6/256.0 blue: 0X4f/256.0 alpha: 1.0] set];
-			[smallPath fill];
+											   [[NSColor colorWithCalibratedRed:0Xfc / 256.0 green:0Xa6 / 256.0 blue:0X4f / 256.0 alpha:1.0] set];
+											   [smallPath fill];
 
-			return YES;
-		}];
+											   return YES;
+										   }];
 	});
 
 	long c = cellInfo.position;
 	NSPoint origin = r.origin;
-	NSPoint columnOrigin = { origin.x + COLUMN_WIDTH * c, origin.y};
-	NSRect oval = { columnOrigin.x - 5, columnOrigin.y + r.size.height * 0.5 - 5, 10, 10};
+	NSPoint columnOrigin = {origin.x + COLUMN_WIDTH * c, origin.y};
+	NSRect oval = {columnOrigin.x - 5, columnOrigin.y + r.size.height * 0.5 - 5, 10, 10};
 
 	if ([self isCurrentCommit]) {
 		[currentCommitCircleImage drawInRect:oval];
@@ -161,7 +166,7 @@ const BOOL SHUFFLE_COLORS = NO;
 	}
 }
 
-- (void) drawTriangleInRect: (NSRect) r sign: (char) sign
+- (void)drawTriangleInRect:(NSRect)r sign:(char)sign
 {
 	long c = cellInfo.position;
 	int columnHeight = 10;
@@ -176,27 +181,27 @@ const BOOL SHUFFLE_COLORS = NO;
 	}
 	top.y = r.origin.y + (r.size.height - columnHeight) / 2;
 
-	NSBezierPath * path = [NSBezierPath bezierPath];
+	NSBezierPath *path = [NSBezierPath bezierPath];
 	// Start at top
-	[path moveToPoint: NSMakePoint(top.x, top.y)];
+	[path moveToPoint:NSMakePoint(top.x, top.y)];
 	// Go down
-	[path lineToPoint: NSMakePoint(top.x, top.y + columnHeight)];
+	[path lineToPoint:NSMakePoint(top.x, top.y + columnHeight)];
 	// Go left top
-	[path lineToPoint: NSMakePoint(top.x - columnWidth, top.y + columnHeight / 2)];
+	[path lineToPoint:NSMakePoint(top.x - columnWidth, top.y + columnHeight / 2)];
 	// Go to top again
 	[path closePath];
 
 	[[NSColor whiteColor] set];
 	[path fill];
 	[[NSColor blackColor] set];
-	[path setLineWidth: 2];
+	[path setLineWidth:2];
 	[path stroke];
 }
 
-- (NSMutableDictionary*) attributesForRefLabel
+- (NSMutableDictionary *)attributesForRefLabel
 {
 	NSMutableDictionary *attributes = [[NSMutableDictionary alloc] initWithCapacity:2];
-	NSMutableParagraphStyle* style = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
+	NSMutableParagraphStyle *style = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
 
 	[style setAlignment:NSCenterTextAlignment];
 	[attributes setObject:style forKey:NSParagraphStyleAttributeName];
@@ -206,27 +211,27 @@ const BOOL SHUFFLE_COLORS = NO;
 	return attributes;
 }
 
-- (NSColor*) colorForRef: (PBGitRef*) ref
+- (NSColor *)colorForRef:(PBGitRef *)ref
 {
 	BOOL isHEAD = [ref.ref isEqualToString:[[[controller repository] headRef] simpleRef]];
 
 	if (isHEAD) {
-		return [NSColor colorWithCalibratedRed: 0Xfc/256.0 green:0Xa6/256.0 blue: 0X4f/256.0 alpha: 1.0];
+		return [NSColor colorWithCalibratedRed:0Xfc / 256.0 green:0Xa6 / 256.0 blue:0X4f / 256.0 alpha:1.0];
 	}
 
-	NSString* type = [ref type];
+	NSString *type = [ref type];
 	if ([type isEqualToString:@"head"]) {
-		return [NSColor colorWithCalibratedRed: 0X9a/256.0 green:0Xe2/256.0 blue: 0X84/256.0 alpha: 1.0];
+		return [NSColor colorWithCalibratedRed:0X9a / 256.0 green:0Xe2 / 256.0 blue:0X84 / 256.0 alpha:1.0];
 	} else if ([type isEqualToString:@"remote"]) {
-		return [NSColor colorWithCalibratedRed: 0xa2/256.0 green:0Xcf/256.0 blue: 0Xef/256.0 alpha: 1.0];
+		return [NSColor colorWithCalibratedRed:0xa2 / 256.0 green:0Xcf / 256.0 blue:0Xef / 256.0 alpha:1.0];
 	} else if ([type isEqualToString:@"tag"]) {
-		return [NSColor colorWithCalibratedRed: 0Xfc/256.0 green:0Xed/256.0 blue: 0X6f/256.0 alpha: 1.0];
+		return [NSColor colorWithCalibratedRed:0Xfc / 256.0 green:0Xed / 256.0 blue:0X6f / 256.0 alpha:1.0];
 	}
 
 	return [NSColor yellowColor];
 }
 
--(NSArray<NSValue *> *)rectsForRefsinRect:(NSRect) rect;
+- (NSArray<NSValue *> *)rectsForRefsinRect:(NSRect)rect;
 {
 	NSMutableArray<NSValue *> *array = [NSMutableArray array];
 
@@ -238,7 +243,7 @@ const BOOL SHUFFLE_COLORS = NO;
 	lastRect.origin.y = round(lastRect.origin.y);
 
 	for (PBGitRef *ref in self.objectValue.refs) {
-		NSMutableDictionary* attributes = [self attributesForRefLabel];
+		NSMutableDictionary *attributes = [self attributesForRefLabel];
 		NSSize textSize = [[ref shortName] sizeWithAttributes:attributes];
 
 		NSRect newRect = lastRect;
@@ -256,29 +261,28 @@ const BOOL SHUFFLE_COLORS = NO;
 	return array;
 }
 
-- (void) drawLabelAtIndex:(int)index inRect:(NSRect)rect
+- (void)drawLabelAtIndex:(int)index inRect:(NSRect)rect
 {
 	NSArray *refs = self.objectValue.refs;
 	PBGitRef *ref = [refs objectAtIndex:index];
 
-	NSMutableDictionary* attributes = [self attributesForRefLabel];
+	NSMutableDictionary *attributes = [self attributesForRefLabel];
 	NSBezierPath *border = [NSBezierPath bezierPathWithRoundedRect:rect xRadius:2 yRadius:2];
 	[[self colorForRef:ref] set];
 
 	[border fill];
 
-//	[[NSColor blackColor] set];
-//	[border stroke];
+	//	[[NSColor blackColor] set];
+	//	[border stroke];
 	[[ref shortName] drawInRect:rect withAttributes:attributes];
 }
 
-- (void) drawRefsInRect:(NSRect)refRect
+- (void)drawRefsInRect:(NSRect)refRect
 {
 	[[NSColor blackColor] setStroke];
 
 	int index = 0;
-	for (NSValue *rectValue in [self rectsForRefsinRect:refRect])
-	{
+	for (NSValue *rectValue in [self rectsForRefsinRect:refRect]) {
 		NSRect rect = [rectValue rectValue];
 		[self drawLabelAtIndex:index inRect:rect];
 		++index;
@@ -300,29 +304,31 @@ const BOOL SHUFFLE_COLORS = NO;
 		struct PBGitGraphLine *lines = cellInfo.lines;
 		for (i = 0; i < cellInfo.nLines; i++) {
 			if (lines[i].upper == 0)
-				[self drawLineFromColumn: lines[i].from toColumn: lines[i].to inRect:ownRect offset: (int)ownRect.size.height color: lines[i].colorIndex];
+				[self drawLineFromColumn:lines[i].from toColumn:lines[i].to inRect:ownRect offset:(int)ownRect.size.height color:lines[i].colorIndex];
 			else
-				[self drawLineFromColumn: lines[i].from toColumn: lines[i].to inRect:ownRect offset: 0 color:lines[i].colorIndex];
+				[self drawLineFromColumn:lines[i].from toColumn:lines[i].to inRect:ownRect offset:0 color:lines[i].colorIndex];
 		}
 
 		if (cellInfo.sign == '<' || cellInfo.sign == '>')
-			[self drawTriangleInRect: ownRect sign: cellInfo.sign];
+			[self drawTriangleInRect:ownRect sign:cellInfo.sign];
 		else
-			[self drawCircleInRect: ownRect];
+			[self drawCircleInRect:ownRect];
 	}
 
 	if ([self.objectValue refs] && [[self.objectValue refs] count])
 		[self drawRefsInRect:rect];
 }
 
-- (void)setObjectValue:(PBGitCommit *)object {
+- (void)setObjectValue:(PBGitCommit *)object
+{
 	[super setObjectValue:object];
 
 	[self setNeedsDisplay:YES];
 	[self setNeedsLayout:YES];
 }
 
-- (void)layout {
+- (void)layout
+{
 	[super layout];
 
 	NSRect rect = self.bounds;
@@ -330,22 +336,22 @@ const BOOL SHUFFLE_COLORS = NO;
 
 	if (cellInfo) {
 		float pathWidth = 0;
-		
+
 		if (!controller.hasNonlinearPath) {
 			pathWidth = 10 + COLUMN_WIDTH * cellInfo.numColumns;
 		}
-		
+
 		NSRect ownRect;
 		NSDivideRect(rect, &ownRect, &rect, pathWidth, NSMinXEdge);
 
-		NSArray <NSValue *>* rectValues = [self rectsForRefsinRect:rect];
+		NSArray<NSValue *> *rectValues = [self rectsForRefsinRect:rect];
 
 		if (rectValues.count > 0) {
 			const CGFloat PADDING = 4;
 			NSRect lastRect = rectValues.lastObject.rectValue;
 
 			rect.size.width -= lastRect.origin.x - rect.origin.x + lastRect.size.width - PADDING;
-			rect.origin.x    = lastRect.origin.x + lastRect.size.width + PADDING;
+			rect.origin.x = lastRect.origin.x + lastRect.size.width + PADDING;
 		}
 
 		NSRect frame = self.textField.frame;
@@ -358,11 +364,12 @@ const BOOL SHUFFLE_COLORS = NO;
 	}
 }
 
-- (PBGitCommit*) objectValue {
-    return [super objectValue];
+- (PBGitCommit *)objectValue
+{
+	return [super objectValue];
 }
 
-- (int) indexAtX:(CGFloat)x
+- (int)indexAtX:(CGFloat)x
 {
 	cellInfo = [self.objectValue lineInfo];
 	float pathWidth = 0;
@@ -371,8 +378,7 @@ const BOOL SHUFFLE_COLORS = NO;
 
 	int index = 0;
 	NSRect refRect = NSMakeRect(pathWidth, 0, 1000, 10000);
-	for (NSValue *rectValue in [self rectsForRefsinRect:refRect])
-	{
+	for (NSValue *rectValue in [self rectsForRefsinRect:refRect]) {
 		NSRect rect = [rectValue rectValue];
 		if (x >= rect.origin.x && x <= (rect.origin.x + rect.size.width))
 			return index;
@@ -382,7 +388,7 @@ const BOOL SHUFFLE_COLORS = NO;
 	return -1;
 }
 
-- (NSRect) rectAtIndex:(int)index
+- (NSRect)rectAtIndex:(int)index
 {
 	cellInfo = [self.objectValue lineInfo];
 	float pathWidth = 0;

--- a/Classes/Views/PBGitRevisionRow.m
+++ b/Classes/Views/PBGitRevisionRow.m
@@ -21,14 +21,14 @@ NS_ASSUME_NONNULL_BEGIN
 	// if the row is selected use default colors
 	if ([self isSelected]) {
 		if ([[self window] isKeyWindow]) {
-			if ([[self window] firstResponder] == (NSTableView*)self.controller.commitList) {
+			if ([[self window] firstResponder] == (NSTableView *)self.controller.commitList) {
 				return [NSColor alternateSelectedControlColor];
 			}
 			return [NSColor selectedControlColor];
 		}
 		return [NSColor secondarySelectedControlColor];
 	}
-	
+
 	// light blue color highlighting search results
 	return [NSColor colorWithCalibratedRed:0.751f green:0.831f blue:0.943f alpha:0.800f];
 }
@@ -37,39 +37,41 @@ NS_ASSUME_NONNULL_BEGIN
 {
 	if ([self isSelected])
 		return [NSColor colorWithCalibratedWhite:0.0f alpha:0.30f];
-	
+
 	return [NSColor colorWithCalibratedWhite:0.0f alpha:0.05f];
 }
 
 
 #pragma mark - Drawing
 
-- (void)drawSelectionInRect:(NSRect)dirtyRect {
-	NSInteger position = [(NSTableView*)self.controller.commitList rowForView: self];
-	
-	if ([self.controller.searchController isRowInSearchResults: position]) {
+- (void)drawSelectionInRect:(NSRect)dirtyRect
+{
+	NSInteger position = [(NSTableView *)self.controller.commitList rowForView:self];
+
+	if ([self.controller.searchController isRowInSearchResults:position]) {
 		return;
 	}
-	
-	[super drawSelectionInRect: dirtyRect];
+
+	[super drawSelectionInRect:dirtyRect];
 }
 
-- (void)drawRect:(NSRect)dirtyRect {
-    [super drawRect:dirtyRect];
-	
+- (void)drawRect:(NSRect)dirtyRect
+{
+	[super drawRect:dirtyRect];
+
 	CGRect rect = self.bounds;
-	NSInteger position = [(NSTableView*)self.controller.commitList rowForView: self];
-	
-	if ([self.controller.searchController isRowInSearchResults: position]) {
+	NSInteger position = [(NSTableView *)self.controller.commitList rowForView:self];
+
+	if ([self.controller.searchController isRowInSearchResults:position]) {
 		NSRect highlightRect = NSInsetRect(rect, 1.0f, 1.0f);
 		CGFloat radius = highlightRect.size.height / 2.0f;
-		
+
 		NSBezierPath *highlightPath = [NSBezierPath bezierPathWithRoundedRect:highlightRect xRadius:radius yRadius:radius];
-		
-		[[self searchResultHighlightColorForRow: position] set];
+
+		[[self searchResultHighlightColorForRow:position] set];
 		[highlightPath fill];
-		
-		[[self searchResultHighlightStrokeColorForRow: position] set];
+
+		[[self searchResultHighlightStrokeColorForRow:position] set];
 		[highlightPath stroke];
 	}
 }

--- a/Classes/Views/PBGitXMessageSheet.h
+++ b/Classes/Views/PBGitXMessageSheet.h
@@ -10,8 +10,7 @@
 
 #import "RJModalRepoSheet.h"
 
-@interface PBGitXMessageSheet : RJModalRepoSheet
-{
+@interface PBGitXMessageSheet : RJModalRepoSheet {
 	NSImageView *iconView;
 	NSTextField *messageField;
 	NSTextView *infoView;
@@ -41,9 +40,9 @@
 - (IBAction)closeMessageSheet:(id)sender;
 
 
-@property  IBOutlet NSImageView *iconView;
-@property  IBOutlet NSTextField *messageField;
-@property  IBOutlet NSTextView *infoView;
-@property  IBOutlet NSScrollView *scrollView;
+@property IBOutlet NSImageView *iconView;
+@property IBOutlet NSTextField *messageField;
+@property IBOutlet NSTextView *infoView;
+@property IBOutlet NSScrollView *scrollView;
 
 @end

--- a/Classes/Views/PBGitXMessageSheet.m
+++ b/Classes/Views/PBGitXMessageSheet.m
@@ -109,7 +109,6 @@
 }
 
 
-
 #pragma mark Private
 
 - (void)beginMessageSheetWithMessageText:(NSString *)message
@@ -117,20 +116,21 @@
 					   completionHandler:(RJSheetCompletionHandler)handler;
 {
 	[self window];
-	
+
 	[self.messageField setStringValue:message];
 	[self setInfoString:info];
 	[self resizeWindow];
-		
+
 	[self beginSheetWithCompletionHandler:handler];
 }
 
 
 - (void)setInfoString:(NSString *)info
 {
-	NSDictionary *attributes = @{NSFontAttributeName: [NSFont labelFontOfSize:[NSFont smallSystemFontSize]],
-								 NSForegroundColorAttributeName: [NSColor textColor],
-								 };
+	NSDictionary *attributes = @{
+		NSFontAttributeName : [NSFont labelFontOfSize:[NSFont smallSystemFontSize]],
+		NSForegroundColorAttributeName : [NSColor textColor],
+	};
 	NSAttributedString *attributedInfoString = [[NSAttributedString alloc] initWithString:info attributes:attributes];
 	[[self.infoView textStorage] setAttributedString:attributedInfoString];
 }
@@ -149,16 +149,16 @@
 		messageFrame.size.height += heightDelta;
 		messageFrame.origin.y -= heightDelta;
 		[self.messageField setFrame:messageFrame];
-		
+
 		NSRect scrollFrame = [self.scrollView frame];
 		scrollFrame.size.height -= heightDelta;
 		[self.scrollView setFrame:scrollFrame];
-		
+
 		NSRect windowFrame = [[self window] frame];
 		windowFrame.size.height += heightDelta;
 		[[self window] setFrame:windowFrame display:NO];
 	}
-	
+
 	// resize for info text
 	NSRect scrollFrame = [self.scrollView frame];
 	boundingSize = [self.scrollView bounds].size;

--- a/Classes/Views/PBQLOutlineView.h
+++ b/Classes/Views/PBQLOutlineView.h
@@ -10,7 +10,7 @@
 #import "PBGitHistoryController.h"
 
 @interface PBQLOutlineView : NSOutlineView {
-	__weak IBOutlet PBGitHistoryController* controller;
+	__weak IBOutlet PBGitHistoryController *controller;
 }
 
 @end

--- a/Classes/Views/PBQLOutlineView.m
+++ b/Classes/Views/PBQLOutlineView.m
@@ -11,11 +11,11 @@
 
 @implementation PBQLOutlineView
 
-- initWithCoder: (NSCoder *) coder
+- initWithCoder:(NSCoder *)coder
 {
 	id a = [super initWithCoder:coder];
-	[a setDataSource: a];
-	[a registerForDraggedTypes: [NSArray arrayWithObject:NSFilesPromisePboardType]];
+	[a setDataSource:a];
+	[a registerForDraggedTypes:[NSArray arrayWithObject:NSFilesPromisePboardType]];
 	return a;
 }
 
@@ -25,7 +25,7 @@
 	return NSDragOperationCopy;
 }
 
-- (void) keyDown: (NSEvent *) event
+- (void)keyDown:(NSEvent *)event
 {
 	if ([[event characters] isEqualToString:@" "]) {
 		[controller toggleQLPreviewPanel:self];
@@ -35,24 +35,24 @@
 	[super keyDown:event];
 }
 
-- (BOOL)outlineView:(NSOutlineView *)outlineView writeItems:(NSArray *)items toPasteboard:(NSPasteboard *) pb
+- (BOOL)outlineView:(NSOutlineView *)outlineView writeItems:(NSArray *)items toPasteboard:(NSPasteboard *)pb
 {
-	NSMutableArray* fileNames = [NSMutableArray array];
+	NSMutableArray *fileNames = [NSMutableArray array];
 	for (id tree in items)
-		[fileNames addObject: [[[tree representedObject] path] pathExtension]];
+		[fileNames addObject:[[[tree representedObject] path] pathExtension]];
 
 	[pb declareTypes:[NSArray arrayWithObject:NSFilesPromisePboardType] owner:self];
-    [pb setPropertyList:fileNames forType:NSFilesPromisePboardType];
+	[pb setPropertyList:fileNames forType:NSFilesPromisePboardType];
 
 	return YES;
 }
 
 - (NSArray *)outlineView:(NSOutlineView *)outlineView namesOfPromisedFilesDroppedAtDestination:(NSURL *)dropDestination forDraggedItems:(NSArray *)items
 {
-	NSMutableArray* fileNames = [NSMutableArray array];
+	NSMutableArray *fileNames = [NSMutableArray array];
 	for (id obj in items) {
-		PBGitTree* tree = [obj representedObject];
-		[fileNames addObject: [tree path]];
+		PBGitTree *tree = [obj representedObject];
+		[fileNames addObject:[tree path]];
 		[tree saveToFolder:[dropDestination path]];
 	}
 	return fileNames;
@@ -60,8 +60,7 @@
 
 - (NSMenu *)menuForEvent:(NSEvent *)theEvent
 {
-	if ([theEvent type] == NSRightMouseDown)
-	{
+	if ([theEvent type] == NSRightMouseDown) {
 		// get the current selections for the outline view.
 		NSIndexSet *selectedRowIndexes = [self selectedRowIndexes];
 
@@ -80,17 +79,29 @@
 }
 
 /* Implemented to satisfy datasourcee protocol */
-- (BOOL) outlineView: (NSOutlineView *)ov
-         isItemExpandable: (id)item { return NO; }
+- (BOOL)outlineView:(NSOutlineView *)ov
+	isItemExpandable:(id)item
+{
+	return NO;
+}
 
-- (NSInteger)  outlineView: (NSOutlineView *)ov
-         numberOfChildrenOfItem:(id)item { return 0; }
+- (NSInteger)outlineView:(NSOutlineView *)ov
+	numberOfChildrenOfItem:(id)item
+{
+	return 0;
+}
 
-- (id)   outlineView: (NSOutlineView *)ov
-         child:(NSInteger)index
-         ofItem:(id)item { return nil; }
+- (id)outlineView:(NSOutlineView *)ov
+			child:(NSInteger)index
+		   ofItem:(id)item
+{
+	return nil;
+}
 
-- (id)   outlineView: (NSOutlineView *)ov
-         objectValueForTableColumn:(NSTableColumn*)col
-         byItem:(id)item { return nil; }
+- (id)outlineView:(NSOutlineView *)ov
+	objectValueForTableColumn:(NSTableColumn *)col
+					   byItem:(id)item
+{
+	return nil;
+}
 @end

--- a/Classes/Views/PBQLTextView.m
+++ b/Classes/Views/PBQLTextView.m
@@ -12,13 +12,13 @@
 
 @implementation PBQLTextView
 
-- (void) keyDown: (NSEvent *) event
+- (void)keyDown:(NSEvent *)event
 {
 	if ([[event characters] isEqualToString:@" "]) {
 		[controller toggleQLPreviewPanel:self];
 		return;
 	}
-	
+
 	[super keyDown:event];
 }
 

--- a/Classes/Views/PBRemoteProgressSheet.h
+++ b/Classes/Views/PBRemoteProgressSheet.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class PBGitWindowController;
 
-typedef NSError * _Nullable (^PBProgressSheetExecutionHandler)(void);
+typedef NSError *_Nullable (^PBProgressSheetExecutionHandler)(void);
 
 @interface PBRemoteProgressSheet : RJModalRepoSheet
 

--- a/Classes/Views/PBRemoteProgressSheet.m
+++ b/Classes/Views/PBRemoteProgressSheet.m
@@ -20,11 +20,13 @@
 
 @implementation PBRemoteProgressSheet
 
-+ (instancetype)progressSheetWithTitle:(NSString *)title description:(NSString *)description windowController:(PBGitWindowController *)windowController {
++ (instancetype)progressSheetWithTitle:(NSString *)title description:(NSString *)description windowController:(PBGitWindowController *)windowController
+{
 	return [[self alloc] initWithTitle:title description:description windowController:windowController];
 }
 
-+ (instancetype)progressSheetWithTitle:(NSString *)title description:(NSString *)description {
++ (instancetype)progressSheetWithTitle:(NSString *)title description:(NSString *)description
+{
 	return [[self alloc] initWithTitle:title description:description windowController:nil];
 }
 
@@ -61,7 +63,8 @@
 	}];
 }
 
-- (void)awakeFromNib {
+- (void)awakeFromNib
+{
 	[self window]; // loads the window (if it wasn't already)
 
 	// resize window if the description is larger than the default text field

--- a/Classes/Views/PBSidebarTableViewCell.h
+++ b/Classes/Views/PBSidebarTableViewCell.h
@@ -9,7 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface PBSidebarTableViewCell : NSTableCellView {	
+@interface PBSidebarTableViewCell : NSTableCellView {
 	__weak IBOutlet NSImageView *checkedOutImageView;
 }
 

--- a/Classes/Views/PBSidebarTableViewCell.m
+++ b/Classes/Views/PBSidebarTableViewCell.m
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation PBSidebarTableViewCell
 
-# pragma mark context menu delegate methods
+#pragma mark context menu delegate methods
 
 - (void)setIsCheckedOut:(BOOL)isCheckedOut
 {
@@ -32,12 +32,12 @@ NS_ASSUME_NONNULL_BEGIN
 	if (_isCheckedOut) {
 		// We hand over the textField cell because the badge derives its drawing style from that.
 		// Maybe we should replace this custom drawing with an static template image ..
-		[checkedOutImageView setImage: [PBSourceViewBadge checkedOutBadgeForCell: self]];
+		[checkedOutImageView setImage:[PBSourceViewBadge checkedOutBadgeForCell:self]];
 	} else {
-		[checkedOutImageView setImage: nil];
+		[checkedOutImageView setImage:nil];
 	}
 
-	[checkedOutImageView setHidden: !_isCheckedOut];
+	[checkedOutImageView setHidden:!_isCheckedOut];
 }
 
 @end

--- a/Classes/Views/PBSourceViewBadge.h
+++ b/Classes/Views/PBSourceViewBadge.h
@@ -10,10 +10,9 @@
 
 
 @interface PBSourceViewBadge : NSObject {
-
 }
 
-+ (NSImage *) checkedOutBadgeForCell:(NSTableCellView *)cell;
-+ (NSImage *) numericBadge:(NSInteger)number forCell:(NSTableCellView *)cell;
++ (NSImage *)checkedOutBadgeForCell:(NSTableCellView *)cell;
++ (NSImage *)numericBadge:(NSInteger)number forCell:(NSTableCellView *)cell;
 
 @end

--- a/Classes/Views/PBSourceViewBadge.m
+++ b/Classes/Views/PBSourceViewBadge.m
@@ -12,19 +12,19 @@
 @implementation PBSourceViewBadge
 
 
-+ (NSColor *) badgeHighlightColor
++ (NSColor *)badgeHighlightColor
 {
 	return [NSColor colorWithCalibratedHue:0.612 saturation:0.275 brightness:0.735 alpha:1.000];
 }
 
 
-+ (NSColor *) badgeBackgroundColor
++ (NSColor *)badgeBackgroundColor
 {
 	return [NSColor colorWithCalibratedWhite:0.6 alpha:1.00];
 }
 
 
-+ (NSColor *) badgeColorForCell:(NSTableCellView *)cell
++ (NSColor *)badgeColorForCell:(NSTableCellView *)cell
 {
 	if ([cell backgroundStyle] == NSBackgroundStyleDark)
 		return [NSColor whiteColor];
@@ -36,7 +36,7 @@
 }
 
 
-+ (NSColor *) badgeTextColorForCell:(NSTableCellView *)cell
++ (NSColor *)badgeTextColorForCell:(NSTableCellView *)cell
 {
 	if ([cell backgroundStyle] != NSBackgroundStyleDark)
 		return [NSColor whiteColor];
@@ -46,21 +46,21 @@
 			return [self badgeHighlightColor];
 		} else {
 			return [self badgeBackgroundColor];
-        }
-    }
+		}
+	}
 
 	return [self badgeBackgroundColor];
 }
 
 
-+ (NSMutableDictionary *) badgeTextAttributes
++ (NSMutableDictionary *)badgeTextAttributes
 {
 	NSMutableDictionary *badgeTextAttributes = nil;
 	if (!badgeTextAttributes) {
 		NSMutableParagraphStyle *centerStyle = [[NSMutableParagraphStyle alloc] init];
 		[centerStyle setAlignment:NSCenterTextAlignment];
 
-		badgeTextAttributes =  [NSMutableDictionary dictionary];
+		badgeTextAttributes = [NSMutableDictionary dictionary];
 		[badgeTextAttributes setObject:[NSFont boldSystemFontOfSize:[NSFont systemFontSize] - 2] forKey:NSFontAttributeName];
 		[badgeTextAttributes setObject:centerStyle forKey:NSParagraphStyleAttributeName];
 	}
@@ -69,11 +69,10 @@
 }
 
 
-
 #pragma mark -
 #pragma mark badges
 
-+ (NSImage *) badge:(NSString *)badge forCell:(NSTableCellView *)cell
++ (NSImage *)badge:(NSString *)badge forCell:(NSTableCellView *)cell
 {
 	NSColor *badgeColor = [self badgeColorForCell:cell];
 
@@ -106,12 +105,12 @@
 	return badgeImage;
 }
 
-+ (NSImage *) checkedOutBadgeForCell:(NSTableCellView *)cell
++ (NSImage *)checkedOutBadgeForCell:(NSTableCellView *)cell
 {
 	return [self badge:@"✔" forCell:cell];
 }
 
-+ (NSImage *) numericBadge:(NSInteger)number forCell:(NSTableCellView *)cell
++ (NSImage *)numericBadge:(NSInteger)number forCell:(NSTableCellView *)cell
 {
 	return [self badge:[NSString stringWithFormat:@"%ld", number] forCell:cell];
 }

--- a/Classes/Views/PBSourceViewItem.m
+++ b/Classes/Views/PBSourceViewItem.m
@@ -71,22 +71,22 @@
 
 - (NSArray *)sortedChildren
 {
-    if (!_sortedChildren) {
-        NSArray *newArray = [_childrenSet sortedArrayUsingComparator:^NSComparisonResult(PBSourceViewItem *obj1, PBSourceViewItem *obj2) {
-            return [obj1.title localizedStandardCompare:obj2.title];
-        }];
+	if (!_sortedChildren) {
+		NSArray *newArray = [_childrenSet sortedArrayUsingComparator:^NSComparisonResult(PBSourceViewItem *obj1, PBSourceViewItem *obj2) {
+			return [obj1.title localizedStandardCompare:obj2.title];
+		}];
 		self.sortedChildren = newArray;
-    }
-    return [_sortedChildren copy];
+	}
+	return [_sortedChildren copy];
 }
 
 - (void)addChild:(PBSourceViewItem *)child
 {
 	if (!child)
 		return;
-    
+
 	[self.childrenSet addObject:child];
-    self.sortedChildren = nil;
+	self.sortedChildren = nil;
 	child.parent = self;
 }
 
@@ -96,7 +96,7 @@
 		return;
 
 	[self.childrenSet removeObject:child];
-    self.sortedChildren = nil;
+	self.sortedChildren = nil;
 	if (!self.isGroupItem && ([self.childrenSet count] == 0))
 		[self.parent removeChild:self];
 }
@@ -120,8 +120,8 @@
 			node = [PBSourceViewGitRemoteItem remoteItemWithTitle:firstTitle];
 		else {
 			node = [PBSourceViewFolderItem folderItemWithTitle:firstTitle];
-            node.expanded = [[self title] isEqualToString:@"BRANCHES"];
-        }
+			node.expanded = [[self title] isEqualToString:@"BRANCHES"];
+		}
 		[self addChild:node];
 	}
 
@@ -135,7 +135,7 @@
 
 	PBSourceViewItem *item = nil;
 	for (PBSourceViewItem *child in self.childrenSet)
-		if ( (item = [child findRev:rev]) != nil )
+		if ((item = [child findRev:rev]) != nil)
 			return item;
 
 	return nil;
@@ -144,7 +144,7 @@
 - (NSImage *)icon
 {
 	NSImage *iconImage = [NSImage imageNamed:self.iconName];
-	[iconImage setSize:NSMakeSize(16,16)];
+	[iconImage setSize:NSMakeSize(16, 16)];
 	[iconImage setCacheMode:NSImageCacheAlways];
 	return iconImage;
 }
@@ -153,7 +153,7 @@
 {
 	if (_title)
 		return _title;
-	
+
 	return [[self.revSpecifier description] lastPathComponent];
 }
 

--- a/Classes/git/GTOID+JavaScript.m
+++ b/Classes/git/GTOID+JavaScript.m
@@ -15,7 +15,8 @@
 	return NO;
 }
 
-+ (BOOL)isKeyExcludedFromWebScript:(const char *)name {
++ (BOOL)isKeyExcludedFromWebScript:(const char *)name
+{
 	return NO;
 }
 

--- a/Classes/git/GitRepoFinder.m
+++ b/Classes/git/GitRepoFinder.m
@@ -10,32 +10,29 @@
 
 @implementation GitRepoFinder
 
-+ (NSURL*)workDirForURL:(NSURL*)fileURL;
++ (NSURL *)workDirForURL:(NSURL *)fileURL;
 {
-	if (!fileURL.isFileURL)
-	{
+	if (!fileURL.isFileURL) {
 		return nil;
 	}
-	git_repository* repo = nil;
+	git_repository *repo = nil;
 	git_repository_open_ext(&repo, fileURL.path.UTF8String, GIT_REPOSITORY_OPEN_CROSS_FS, NULL);
-	if (!repo)
-	{
+	if (!repo) {
 		return nil;
 	}
-	const char* workdir = git_repository_workdir(repo);
-	NSURL* result = nil;
-	if (workdir)
-	{
+	const char *workdir = git_repository_workdir(repo);
+	NSURL *result = nil;
+	if (workdir) {
 		result = [NSURL fileURLWithPath:[NSString stringWithUTF8String:workdir]];
 	}
-	git_repository_free(repo); repo = nil;
+	git_repository_free(repo);
+	repo = nil;
 	return result;
 }
 
 + (NSURL *)gitDirForURL:(NSURL *)fileURL
 {
-	if (!fileURL.isFileURL)
-	{
+	if (!fileURL.isFileURL) {
 		return nil;
 	}
 	git_buf path_buffer = {NULL, 0, 0};
@@ -43,21 +40,20 @@
 											[fileURL.path UTF8String],
 											GIT_REPOSITORY_OPEN_CROSS_FS,
 											nil);
-	
+
 	NSData *repoPathBuffer = nil;
 	if (path_buffer.ptr) {
 		repoPathBuffer = [NSData dataWithBytes:path_buffer.ptr length:path_buffer.asize];
 		git_buf_free(&path_buffer);
 	}
-	
-	if (gitResult == GIT_OK && repoPathBuffer.length)
-	{
-		NSString* repoPath = [NSString stringWithUTF8String:repoPathBuffer.bytes];
+
+	if (gitResult == GIT_OK && repoPathBuffer.length) {
+		NSString *repoPath = [NSString stringWithUTF8String:repoPathBuffer.bytes];
 		BOOL isDirectory;
 		if ([[NSFileManager defaultManager] fileExistsAtPath:repoPath
-												 isDirectory:&isDirectory] && isDirectory)
-		{
-			NSURL* result = [NSURL fileURLWithPath:repoPath
+												 isDirectory:&isDirectory] &&
+			isDirectory) {
+			NSURL *result = [NSURL fileURLWithPath:repoPath
 									   isDirectory:isDirectory];
 			return result;
 		}

--- a/Classes/git/PBGitBinary.h
+++ b/Classes/git/PBGitBinary.h
@@ -12,8 +12,8 @@
 
 @interface PBGitBinary : NSObject
 
-+ (NSString *) path;
-+ (NSString *) version;
-+ (NSArray *) searchLocations;
-+ (NSString *) notFoundError;
++ (NSString *)path;
++ (NSString *)version;
++ (NSArray *)searchLocations;
++ (NSString *)notFoundError;
 @end

--- a/Classes/git/PBGitBinary.m
+++ b/Classes/git/PBGitBinary.m
@@ -11,7 +11,7 @@
 
 @implementation PBGitBinary
 
-static NSString* gitPath = nil;
+static NSString *gitPath = nil;
 
 + (NSString *)versionForPath:(NSString *)path
 {
@@ -21,27 +21,27 @@ static NSString* gitPath = nil;
 	if (![[NSFileManager defaultManager] fileExistsAtPath:path])
 		return nil;
 
-	NSString *version = [PBTask outputForCommand:path arguments:@[@"--version"] error:NULL];
+	NSString *version = [PBTask outputForCommand:path arguments:@[ @"--version" ] error:NULL];
 
 	return [self extractGitVersion:version];
 }
 
-+ (NSString *) extractGitVersion:(NSString *)versionString
++ (NSString *)extractGitVersion:(NSString *)versionString
 {
-	NSError * error;
-	NSRegularExpression * regex = [NSRegularExpression regularExpressionWithPattern:@"git version ([0-9.]+)"
-																			options:0
-																			  error:&error];
-	NSTextCheckingResult * result = [regex firstMatchInString:versionString
-													  options:0
-														range:NSMakeRange(0, versionString.length)];
+	NSError *error;
+	NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"git version ([0-9.]+)"
+																		   options:0
+																			 error:&error];
+	NSTextCheckingResult *result = [regex firstMatchInString:versionString
+													 options:0
+													   range:NSMakeRange(0, versionString.length)];
 	if (result != nil && result.numberOfRanges == 2) {
 		return [versionString substringWithRange:[result rangeAtIndex:1]];
 	}
 	return nil;
 }
 
-+ (BOOL) acceptBinary:(NSString *)path
++ (BOOL)acceptBinary:(NSString *)path
 {
 	if (!path)
 		return NO;
@@ -60,7 +60,7 @@ static NSString* gitPath = nil;
 	return NO;
 }
 
-+ (void) initialize
++ (void)initialize
 {
 	// Check what we might have in user defaults
 	// NOTE: Currently this should NOT have a registered default, or the searching bits below won't work
@@ -73,79 +73,77 @@ static NSString* gitPath = nil;
 
 		alert.messageText = NSLocalizedString(@"Invalid git path", @"Error message for NSUserDefaults configured path to git binary that does not point to a git binary");
 		alert.informativeText = [NSString stringWithFormat:NSLocalizedString(
-									 @"The path „%@“, which is configured as a custom git path in the "
-									 "preferences window, is not a valid git v" MIN_GIT_VERSION " or higher binary. "
-									 "Using the default search paths instead.",
-									 "Informative text for NSUserDefaults configured path to git binary that does not point to a git binary"),
-								 gitPath];
+															   @"The path „%@“, which is configured as a custom git path in the "
+																"preferences window, is not a valid git v" MIN_GIT_VERSION " or higher binary. "
+																"Using the default search paths instead.",
+															   "Informative text for NSUserDefaults configured path to git binary that does not point to a git binary"),
+														   gitPath];
 		[alert addButtonWithTitle:NSLocalizedString(@"OK", @"OK")];
 
 		[alert runModal];
 	}
 
 	// Try to find the path of the Git binary
-	char* path = getenv("GIT_PATH");
+	char *path = getenv("GIT_PATH");
 	if (path && [self acceptBinary:[NSString stringWithUTF8String:path]])
 		return;
 
 	// No explicit path.
-	
+
 	// Try to find git with "which"
-	NSString* whichPath = [PBTask outputForCommand:@"/usr/bin/which" arguments:@[@"git"] error:NULL];
+	NSString *whichPath = [PBTask outputForCommand:@"/usr/bin/which" arguments:@[ @"git" ] error:NULL];
 	if ([self acceptBinary:whichPath])
 		return;
 
 	// Still no path. Let's try some default locations.
-	for (NSString* location in [PBGitBinary searchLocations]) {
+	for (NSString *location in [PBGitBinary searchLocations]) {
 		if ([self acceptBinary:location])
 			return;
 	}
-	
+
 	// Lastly, try `xcrun git`
-	NSString* xcrunPath = [PBTask outputForCommand:@"/usr/bin/xcrun" arguments:@[@"-f", @"git"] error:NULL];
-	if ([self acceptBinary:xcrunPath])
-	{
+	NSString *xcrunPath = [PBTask outputForCommand:@"/usr/bin/xcrun" arguments:@[ @"-f", @"git" ] error:NULL];
+	if ([self acceptBinary:xcrunPath]) {
 		return;
 	}
 
 	NSLog(@"Could not find a git binary higher than version " MIN_GIT_VERSION);
 }
 
-+ (NSString *) path;
++ (NSString *)path;
 {
 	return gitPath;
 }
 
 static NSMutableArray *locations = nil;
 
-+ (NSArray *) searchLocations
++ (NSArray *)searchLocations
 {
-	if (!locations)
-	{
+	if (!locations) {
 		locations = [[NSMutableArray alloc] initWithObjects:
-					 @"/opt/local/bin/git",
-					 @"/sw/bin/git",
-					 @"/opt/git/bin/git",
-					 @"/usr/local/bin/git",
-					 @"/usr/local/git/bin/git",
-					 nil];
-		
+												@"/opt/local/bin/git",
+												@"/sw/bin/git",
+												@"/opt/git/bin/git",
+												@"/usr/local/bin/git",
+												@"/usr/local/git/bin/git",
+												nil];
+
 		[locations addObject:[@"~/bin/git" stringByExpandingTildeInPath]];
 		[locations addObject:@"/usr/bin/git"];
 	}
 	return locations;
 }
 
-+ (NSString *) notFoundError
++ (NSString *)notFoundError
 {
-	NSString * searchPathsString = [[PBGitBinary searchLocations] componentsJoinedByString:@"\n\t"];
+	NSString *searchPathsString = [[PBGitBinary searchLocations] componentsJoinedByString:@"\n\t"];
 	return [NSString stringWithFormat:
-			NSLocalizedString(
-				@"Could not find a git binary version " MIN_GIT_VERSION " or higher.\n"
-				@"Please make sure there is a git binary in one of the following locations:"
-				@"\n\n\t%s",
-				@"Error message when no git client can be found."),
-			searchPathsString];
+						 NSLocalizedString(
+							 @"Could not find a git binary version " MIN_GIT_VERSION " or higher.\n"
+							 @"Please make sure there is a git binary in one of the following locations:"
+							 @"\n\n\t%s",
+							 @"Error message when no git client can be found."),
+						 searchPathsString];
 }
 
 

--- a/Classes/git/PBGitCommit.h
+++ b/Classes/git/PBGitCommit.h
@@ -16,11 +16,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString * const kGitXCommitType;
+extern NSString *const kGitXCommitType;
 
 @interface PBGitCommit : NSObject <PBGitRefish>
 
-@property (nonatomic, weak, readonly) PBGitRepository* repository;
+@property (nonatomic, weak, readonly) PBGitRepository *repository;
 
 @property (nonatomic, strong, readonly) GTCommit *gtCommit;
 @property (nonatomic, strong, readonly) GTOID *OID;
@@ -39,28 +39,28 @@ extern NSString * const kGitXCommitType;
 @property (nonatomic, strong, readonly) NSString *SHA;
 @property (nonatomic, strong, readonly, nullable) NSString *SVNRevision;
 
-@property (nonatomic, copy, readonly) NSArray <GTOID *> *parents;
-@property  NSMutableArray* refs;
+@property (nonatomic, copy, readonly) NSArray<GTOID *> *parents;
+@property NSMutableArray *refs;
 
 @property (nonatomic, strong) PBGraphCellInfo *lineInfo;
 
-@property (nonatomic, readonly) PBGitTree* tree;
-@property (readonly) NSArray* treeContents;
+@property (nonatomic, readonly) PBGitTree *tree;
+@property (readonly) NSArray *treeContents;
 
 - (instancetype)initWithRepository:(PBGitRepository *)repo andCommit:(GTCommit *)gtCommit;
 
-- (void) addRef:(PBGitRef *)ref;
-- (void) removeRef:(PBGitRef *)ref;
-- (BOOL) hasRef:(PBGitRef *)ref;
+- (void)addRef:(PBGitRef *)ref;
+- (void)removeRef:(PBGitRef *)ref;
+- (BOOL)hasRef:(PBGitRef *)ref;
 
 - (NSString *)SHA;
-- (BOOL) isOnSameBranchAs:(PBGitCommit *)other;
-- (BOOL) isOnHeadBranch;
+- (BOOL)isOnSameBranchAs:(PBGitCommit *)other;
+- (BOOL)isOnHeadBranch;
 
 // <PBGitRefish>
-- (NSString *) refishName;
-- (NSString *) shortName;
-- (NSString *) refishType;
+- (NSString *)refishName;
+- (NSString *)shortName;
+- (NSString *)refishType;
 
 @end
 

--- a/Classes/git/PBGitCommit.m
+++ b/Classes/git/PBGitCommit.m
@@ -14,7 +14,7 @@
 #import "PBGitDefaults.h"
 #import "ObjectiveGit+PBCategories.h"
 
-NSString * const kGitXCommitType = @"commit";
+NSString *const kGitXCommitType = @"commit";
 
 @interface PBGitCommit ()
 
@@ -30,7 +30,8 @@ NSString * const kGitXCommitType = @"commit";
 
 @implementation PBGitCommit
 
-+ (NSDateFormatter *)longDateFormatter {
++ (NSDateFormatter *)longDateFormatter
+{
 	static NSDateFormatter *formatter = nil;
 	static dispatch_once_t token;
 	dispatch_once(&token, ^{
@@ -42,20 +43,20 @@ NSString * const kGitXCommitType = @"commit";
 	return formatter;
 }
 
-- (NSDate *) date
+- (NSDate *)date
 {
 	return self.gtCommit.commitDate;
 	// previous behaviour was equiv. to:  return self.gtCommit.author.time;
 }
 
-- (NSString *) dateString
+- (NSString *)dateString
 {
-	NSDateFormatter * formatter = [[NSDateFormatter alloc] init];
+	NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
 	[formatter setLocalizedDateFormatFromTemplate:@"%Y-%m-%d %H:%M:%S"];
 	return [formatter stringFromDate:self.date];
 }
 
-- (NSArray*) treeContents
+- (NSArray *)treeContents
 {
 	return self.tree.children;
 }
@@ -68,12 +69,12 @@ NSString * const kGitXCommitType = @"commit";
 	}
 	self.repository = repo;
 	self.gtCommit = gtCommit;
-	
+
 	return self;
 }
 
 
-- (NSArray <GTOID *>*)parents
+- (NSArray<GTOID *> *)parents
 {
 	if (!self->_parents) {
 		self.parents = self.gtCommit.parentOIDs;
@@ -126,19 +127,17 @@ NSString * const kGitXCommitType = @"commit";
 - (NSString *)SVNRevision
 {
 	NSString *result = nil;
-	if ([self.repository hasSVNRemote])
-	{
+	if ([self.repository hasSVNRemote]) {
 		// get the git-svn-id from the message
 		NSArray *matches = nil;
 		NSString *string = self.gtCommit.message;
 		NSError *error = nil;
 		// Regular expression for pulling out the SVN revision from the git log
-        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^git-svn-id: .*@(\\d+) .*$" options:NSRegularExpressionAnchorsMatchLines error:&error];
-		
+		NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^git-svn-id: .*@(\\d+) .*$" options:NSRegularExpressionAnchorsMatchLines error:&error];
+
 		if (string) {
 			matches = [regex matchesInString:string options:0 range:NSMakeRange(0, [string length])];
-			for (NSTextCheckingResult *match in matches)
-			{
+			for (NSTextCheckingResult *match in matches) {
 				NSRange matchRange = [match rangeAtIndex:1];
 				NSString *matchString = [string substringWithRange:matchRange];
 				result = matchString;
@@ -161,7 +160,7 @@ NSString * const kGitXCommitType = @"commit";
 	return self.OID.SHA;
 }
 
-- (BOOL) isOnSameBranchAs:(PBGitCommit *)otherCommit
+- (BOOL)isOnSameBranchAs:(PBGitCommit *)otherCommit
 {
 	if (!otherCommit)
 		return NO;
@@ -172,7 +171,7 @@ NSString * const kGitXCommitType = @"commit";
 	return [self.repository isOIDOnSameBranch:otherCommit.OID asOID:self.OID];
 }
 
-- (BOOL) isOnHeadBranch
+- (BOOL)isOnHeadBranch
 {
 	return [self isOnSameBranchAs:[self.repository headCommit]];
 }
@@ -190,26 +189,26 @@ NSString * const kGitXCommitType = @"commit";
 	return self.OID.hash;
 }
 
-- (NSString *) patch
+- (NSString *)patch
 {
 	if (self->_patch != nil)
 		return _patch;
 
 	NSError *error = nil;
-	NSString *p = [self.repository outputOfTaskWithArguments:@[@"format-patch",  @"-1", @"--stdout", self.SHA] error:&error];
+	NSString *p = [self.repository outputOfTaskWithArguments:@[ @"format-patch", @"-1", @"--stdout", self.SHA ] error:&error];
 	if (!p) {
 		PBLogError(error);
 		return nil;
 	}
 
 	// Add a GitX identifier to the patch ;)
-	self.patch = [[p substringToIndex:[p length] -1] stringByAppendingString:@"+GitX"];
+	self.patch = [[p substringToIndex:[p length] - 1] stringByAppendingString:@"+GitX"];
 	return self->_patch;
 }
 
-- (PBGitTree*) tree
+- (PBGitTree *)tree
 {
-	return [PBGitTree rootForCommit: self];
+	return [PBGitTree rootForCommit:self];
 }
 
 - (void)addRef:(PBGitRef *)ref
@@ -228,7 +227,7 @@ NSString * const kGitXCommitType = @"commit";
 	[self.refs removeObject:ref];
 }
 
-- (BOOL) hasRef:(PBGitRef *)ref
+- (BOOL)hasRef:(PBGitRef *)ref
 {
 	if (!self.refs)
 		return NO;
@@ -245,7 +244,7 @@ NSString * const kGitXCommitType = @"commit";
 	return self.repository.refs[self.OID];
 }
 
-- (void) setRefs:(NSMutableArray *)refs
+- (void)setRefs:(NSMutableArray *)refs
 {
 	self.repository.refs[self.OID] = [NSMutableArray arrayWithArray:refs];
 }
@@ -256,24 +255,25 @@ NSString * const kGitXCommitType = @"commit";
 	return NO;
 }
 
-+ (BOOL)isKeyExcludedFromWebScript:(const char *)name {
++ (BOOL)isKeyExcludedFromWebScript:(const char *)name
+{
 	return NO;
 }
 
 
 #pragma mark <PBGitRefish>
 
-- (NSString *) refishName
+- (NSString *)refishName
 {
 	return self.SHA;
 }
 
-- (NSString *) shortName
+- (NSString *)shortName
 {
 	return self.gtCommit.shortSHA;
 }
 
-- (NSString *) refishType
+- (NSString *)refishType
 {
 	return kGitXCommitType;
 }

--- a/Classes/git/PBGitDefaults.h
+++ b/Classes/git/PBGitDefaults.h
@@ -7,27 +7,25 @@
 //
 
 #define kDialogAcceptDroppedRef @"Accept Dropped Ref"
-@interface PBGitDefaults : NSObject
-{
-
+@interface PBGitDefaults : NSObject {
 }
 
-+ (NSInteger) commitMessageViewVerticalLineLength;
-+ (NSInteger) commitMessageViewVerticalBodyLineLength;
-+ (BOOL) commitMessageViewHasVerticalLine;
-+ (BOOL) isGistEnabled;
-+ (BOOL) isGravatarEnabled;
-+ (BOOL) confirmPublicGists;
-+ (BOOL) isGistPublic;
++ (NSInteger)commitMessageViewVerticalLineLength;
++ (NSInteger)commitMessageViewVerticalBodyLineLength;
++ (BOOL)commitMessageViewHasVerticalLine;
++ (BOOL)isGistEnabled;
++ (BOOL)isGravatarEnabled;
++ (BOOL)confirmPublicGists;
++ (BOOL)isGistPublic;
 + (BOOL)showWhitespaceDifferences;
-+ (BOOL) shouldCheckoutBranch;
-+ (void) setShouldCheckoutBranch:(BOOL)shouldCheckout;
-+ (NSString *) recentCloneDestination;
-+ (void) setRecentCloneDestination:(NSString *)path;
-+ (BOOL) showStageView;
-+ (void) setShowStageView:(BOOL)suppress;
-+ (NSInteger) branchFilter;
-+ (void) setBranchFilter:(NSInteger)state;
++ (BOOL)shouldCheckoutBranch;
++ (void)setShouldCheckoutBranch:(BOOL)shouldCheckout;
++ (NSString *)recentCloneDestination;
++ (void)setRecentCloneDestination:(NSString *)path;
++ (BOOL)showStageView;
++ (void)setShowStageView:(BOOL)suppress;
++ (NSInteger)branchFilter;
++ (void)setBranchFilter:(NSInteger)state;
 + (NSInteger)historySearchMode;
 + (void)setHistorySearchMode:(NSInteger)mode;
 + (BOOL)useRepositoryWatcher;

--- a/Classes/git/PBGitDefaults.m
+++ b/Classes/git/PBGitDefaults.m
@@ -38,69 +38,69 @@
 {
 	NSMutableDictionary *defaultValues = [NSMutableDictionary dictionary];
 	[defaultValues setObject:[NSNumber numberWithInt:kDefaultVerticalLineLength]
-                      forKey:kCommitMessageViewVerticalLineLength];
-    [defaultValues setObject:[NSNumber numberWithInt:kDefaultVerticalBodyLineLength]
-                      forKey:kCommitMessageViewVerticalBodyLineLength];
-    [defaultValues setObject:[NSNumber numberWithBool:YES]
-                      forKey:kCommitMessageViewHasVerticalLine];
+					  forKey:kCommitMessageViewVerticalLineLength];
+	[defaultValues setObject:[NSNumber numberWithInt:kDefaultVerticalBodyLineLength]
+					  forKey:kCommitMessageViewVerticalBodyLineLength];
 	[defaultValues setObject:[NSNumber numberWithBool:YES]
-			  forKey:kEnableGist];
+					  forKey:kCommitMessageViewHasVerticalLine];
 	[defaultValues setObject:[NSNumber numberWithBool:YES]
-			  forKey:kEnableGravatar];
+					  forKey:kEnableGist];
 	[defaultValues setObject:[NSNumber numberWithBool:YES]
-			  forKey:kConfirmPublicGists];
+					  forKey:kEnableGravatar];
+	[defaultValues setObject:[NSNumber numberWithBool:YES]
+					  forKey:kConfirmPublicGists];
 	[defaultValues setObject:[NSNumber numberWithBool:NO]
-			  forKey:kPublicGist];
+					  forKey:kPublicGist];
 	[defaultValues setObject:[NSNumber numberWithBool:YES]
-			  forKey:kShowWhitespaceDifferences];
+					  forKey:kShowWhitespaceDifferences];
 	[defaultValues setObject:[NSNumber numberWithBool:YES]
-			  forKey:kOpenCurDirOnLaunch];
+					  forKey:kOpenCurDirOnLaunch];
 	[defaultValues setObject:[NSNumber numberWithBool:YES]
-			  forKey:kShowOpenPanelOnLaunch];
+					  forKey:kShowOpenPanelOnLaunch];
 	[defaultValues setObject:[NSNumber numberWithBool:YES]
 					  forKey:kShouldCheckoutBranch];
 	[defaultValues setObject:[NSNumber numberWithBool:NO]
-                      forKey:kOpenPreviousDocumentsOnLaunch];
+					  forKey:kOpenPreviousDocumentsOnLaunch];
 	[defaultValues setObject:[NSNumber numberWithInteger:PBHistorySearchModeBasic]
-                      forKey:kHistorySearchMode];
+					  forKey:kHistorySearchMode];
 	[defaultValues setObject:[NSNumber numberWithBool:YES]
-                      forKey:kUseRepositoryWatcher];
+					  forKey:kUseRepositoryWatcher];
 	[defaultValues setObject:@"com.apple.Terminal"
 					  forKey:kTerminalHandler];
 	[[NSUserDefaults standardUserDefaults] registerDefaults:defaultValues];
 }
 
-+ (NSInteger) commitMessageViewVerticalLineLength
++ (NSInteger)commitMessageViewVerticalLineLength
 {
 	return [[NSUserDefaults standardUserDefaults] integerForKey:kCommitMessageViewVerticalLineLength];
 }
 
-+ (BOOL) commitMessageViewHasVerticalLine
++ (BOOL)commitMessageViewHasVerticalLine
 {
 	return [[NSUserDefaults standardUserDefaults] boolForKey:kCommitMessageViewHasVerticalLine];
 }
 
-+ (NSInteger) commitMessageViewVerticalBodyLineLength
++ (NSInteger)commitMessageViewVerticalBodyLineLength
 {
 	return [[NSUserDefaults standardUserDefaults] integerForKey:kCommitMessageViewVerticalBodyLineLength];
 }
 
-+ (BOOL) isGistEnabled
++ (BOOL)isGistEnabled
 {
 	return [[NSUserDefaults standardUserDefaults] boolForKey:kEnableGist];
 }
 
-+ (BOOL) isGravatarEnabled
++ (BOOL)isGravatarEnabled
 {
 	return [[NSUserDefaults standardUserDefaults] boolForKey:kEnableGravatar];
 }
 
-+ (BOOL) confirmPublicGists
++ (BOOL)confirmPublicGists
 {
 	return [[NSUserDefaults standardUserDefaults] boolForKey:kConfirmPublicGists];
 }
 
-+ (BOOL) isGistPublic
++ (BOOL)isGistPublic
 {
 	return [[NSUserDefaults standardUserDefaults] boolForKey:kPublicGist];
 }
@@ -120,61 +120,61 @@
 	return [[NSUserDefaults standardUserDefaults] boolForKey:kShowOpenPanelOnLaunch];
 }
 
-+ (BOOL) shouldCheckoutBranch
++ (BOOL)shouldCheckoutBranch
 {
 	return [[NSUserDefaults standardUserDefaults] boolForKey:kShouldCheckoutBranch];
 }
 
-+ (void) setShouldCheckoutBranch:(BOOL)shouldCheckout
++ (void)setShouldCheckoutBranch:(BOOL)shouldCheckout
 {
 	[[NSUserDefaults standardUserDefaults] setBool:shouldCheckout forKey:kShouldCheckoutBranch];
 }
 
-+ (NSString *) recentCloneDestination
++ (NSString *)recentCloneDestination
 {
 	return [[NSUserDefaults standardUserDefaults] stringForKey:kRecentCloneDestination];
 }
 
-+ (void) setRecentCloneDestination:(NSString *)path
++ (void)setRecentCloneDestination:(NSString *)path
 {
 	[[NSUserDefaults standardUserDefaults] setObject:path forKey:kRecentCloneDestination];
 }
 
-+ (BOOL) showStageView
++ (BOOL)showStageView
 {
 	return [[NSUserDefaults standardUserDefaults] boolForKey:kShowStageView];
 }
 
-+ (void) setShowStageView:(BOOL)suppress
++ (void)setShowStageView:(BOOL)suppress
 {
 	return [[NSUserDefaults standardUserDefaults] setBool:suppress forKey:kShowStageView];
 }
 
-+ (BOOL) openPreviousDocumentsOnLaunch
++ (BOOL)openPreviousDocumentsOnLaunch
 {
 	return [[NSUserDefaults standardUserDefaults] boolForKey:kOpenPreviousDocumentsOnLaunch];
 }
 
-+ (void) setPreviousDocumentPaths:(NSArray *)documentPaths
++ (void)setPreviousDocumentPaths:(NSArray *)documentPaths
 {
 	[[NSUserDefaults standardUserDefaults] setObject:documentPaths forKey:kPreviousDocumentPaths];
 }
 
-+ (NSArray *) previousDocumentPaths
++ (NSArray *)previousDocumentPaths
 {
 	return [[NSUserDefaults standardUserDefaults] arrayForKey:kPreviousDocumentPaths];
 }
 
-+ (void) removePreviousDocumentPaths
++ (void)removePreviousDocumentPaths
 {
 	[[NSUserDefaults standardUserDefaults] removeObjectForKey:kPreviousDocumentPaths];
 }
-+ (NSInteger) branchFilter
++ (NSInteger)branchFilter
 {
 	return [[NSUserDefaults standardUserDefaults] integerForKey:kBranchFilterState];
 }
 
-+ (void) setBranchFilter:(NSInteger)state
++ (void)setBranchFilter:(NSInteger)state
 {
 	[[NSUserDefaults standardUserDefaults] setInteger:state forKey:kBranchFilterState];
 }
@@ -188,7 +188,6 @@
 {
 	[[NSUserDefaults standardUserDefaults] setInteger:mode forKey:kHistorySearchMode];
 }
-
 
 
 // Suppressed Dialog Warnings
@@ -224,7 +223,7 @@
 }
 
 
-+ (BOOL) useRepositoryWatcher
++ (BOOL)useRepositoryWatcher
 {
 	return [[NSUserDefaults standardUserDefaults] boolForKey:kUseRepositoryWatcher];
 }

--- a/Classes/git/PBGitGraphLine.h
+++ b/Classes/git/PBGitGraphLine.h
@@ -6,10 +6,9 @@
 //  Copyright 2008 __MyCompanyName__. All rights reserved.
 //
 
-struct PBGitGraphLine
-{
-	int upper      : 1;
-	int from       : 8;
-	int to         : 8;
+struct PBGitGraphLine {
+	int upper : 1;
+	int from : 8;
+	int to : 8;
 	int colorIndex : 8;
 };

--- a/Classes/git/PBGitGrapher.h
+++ b/Classes/git/PBGitGrapher.h
@@ -11,7 +11,7 @@
 
 @interface PBGitGrapher : NSObject
 
-- (id) initWithRepository:(PBGitRepository *)repo;
-- (void) decorateCommit:(PBGitCommit *)commit;
+- (id)initWithRepository:(PBGitRepository *)repo;
+- (void)decorateCommit:(PBGitCommit *)commit;
 
 @end

--- a/Classes/git/PBGitHistoryGrapher.h
+++ b/Classes/git/PBGitHistoryGrapher.h
@@ -22,7 +22,7 @@
 
 
 @interface PBGitHistoryGrapher : NSObject {
-	__weak id <PBGitHistoryGrapherDelegate> delegate;
+	__weak id<PBGitHistoryGrapherDelegate> delegate;
 	NSOperationQueue *currentQueue;
 
 	NSMutableSet *searchOIDs;
@@ -30,7 +30,7 @@
 	BOOL viewAllBranches;
 }
 
-- (instancetype) initWithBaseCommits:(NSSet *)commits viewAllBranches:(BOOL)viewAll queue:(NSOperationQueue *)queue delegate:(id <PBGitHistoryGrapherDelegate>)theDelegate;
-- (void) graphCommits:(NSArray *)revList;
+- (instancetype)initWithBaseCommits:(NSSet *)commits viewAllBranches:(BOOL)viewAll queue:(NSOperationQueue *)queue delegate:(id<PBGitHistoryGrapherDelegate>)theDelegate;
+- (void)graphCommits:(NSArray *)revList;
 
 @end

--- a/Classes/git/PBGitHistoryGrapher.m
+++ b/Classes/git/PBGitHistoryGrapher.m
@@ -13,9 +13,9 @@
 @implementation PBGitHistoryGrapher
 
 
-- (instancetype) initWithBaseCommits:(NSSet *)commits viewAllBranches:(BOOL)viewAll queue:(NSOperationQueue *)queue delegate:(id <PBGitHistoryGrapherDelegate>)theDelegate
+- (instancetype)initWithBaseCommits:(NSSet *)commits viewAllBranches:(BOOL)viewAll queue:(NSOperationQueue *)queue delegate:(id<PBGitHistoryGrapherDelegate>)theDelegate
 {
-    self = [super init];
+	self = [super init];
 	if (!self) return nil;
 
 	delegate = theDelegate;
@@ -31,12 +31,12 @@
 - (void)sendCommits:(NSArray *)commits
 {
 	dispatch_async(dispatch_get_main_queue(), ^{
-		[self->delegate updateCommitsFromGrapher:@{ kCurrentQueueKey: self->currentQueue, kNewCommitsKey: commits }];
+		[self->delegate updateCommitsFromGrapher:@{kCurrentQueueKey : self->currentQueue, kNewCommitsKey : commits}];
 	});
 }
 
 
-- (void) graphCommits:(NSArray *)revList
+- (void)graphCommits:(NSArray *)revList
 {
 	if (!revList || [revList count] == 0)
 		return;

--- a/Classes/git/PBGitHistoryList.h
+++ b/Classes/git/PBGitHistoryList.h
@@ -36,16 +36,16 @@
 	BOOL isUpdating;
 }
 
-- (id) initWithRepository:(PBGitRepository *)repo;
-- (void) forceUpdate;
-- (void) updateHistory;
+- (id)initWithRepository:(PBGitRepository *)repo;
+- (void)forceUpdate;
+- (void)updateHistory;
 - (void)cleanup;
 
-- (void) updateCommitsFromGrapher:(NSDictionary *)commitData;
+- (void)updateCommitsFromGrapher:(NSDictionary *)commitData;
 
 
-@property  PBGitRevList *projectRevList;
-@property  NSMutableArray *commits;
+@property PBGitRevList *projectRevList;
+@property NSMutableArray *commits;
 @property (readonly) NSArray *projectCommits;
 @property (assign) BOOL isUpdating;
 

--- a/Classes/git/PBGitHistoryList.m
+++ b/Classes/git/PBGitHistoryList.m
@@ -16,17 +16,15 @@
 
 @interface PBGitHistoryList () <PBGitHistoryGrapherDelegate>
 
-- (void) resetGraphing;
+- (void)resetGraphing;
 
-- (PBGitHistoryGrapher *) grapher;
-- (NSInvocationOperation *) operationForCommits:(NSArray *)newCommits;
+- (PBGitHistoryGrapher *)grapher;
+- (NSInvocationOperation *)operationForCommits:(NSArray *)newCommits;
 
-- (void) updateProjectHistoryForRev:(PBGitRevSpecifier *)rev;
-- (void) updateHistoryForRev:(PBGitRevSpecifier *)rev;
+- (void)updateProjectHistoryForRev:(PBGitRevSpecifier *)rev;
+- (void)updateHistoryForRev:(PBGitRevSpecifier *)rev;
 
 @end
-
-
 
 
 @implementation PBGitHistoryList
@@ -38,16 +36,15 @@
 @dynamic projectCommits;
 
 
-
 #pragma mark -
 #pragma mark Public
 
-- (id) initWithRepository:(PBGitRepository *)repo
+- (id)initWithRepository:(PBGitRepository *)repo
 {
-    self = [super init];
-    if (!self)
-        return nil;
-    
+	self = [super init];
+	if (!self)
+		return nil;
+
 	commits = [NSMutableArray array];
 	repository = repo;
 	lastBranchFilter = -1;
@@ -58,11 +55,12 @@
 	return self;
 }
 
-- (void)dealloc {
-    [self cleanup];
+- (void)dealloc
+{
+	[self cleanup];
 }
 
-- (void) forceUpdate
+- (void)forceUpdate
 {
 	if ([repository.currentBranch isSimpleRef])
 		shouldReloadProjectHistory = YES;
@@ -71,7 +69,7 @@
 }
 
 
-- (void) updateHistory
+- (void)updateHistory
 {
 	PBGitRevSpecifier *rev = repository.currentBranch;
 	if (!rev)
@@ -92,21 +90,19 @@
 		currentRevList = nil;
 	}
 	[graphQueue cancelAllOperations];
-
 }
 
 
-- (NSArray *) projectCommits
+- (NSArray *)projectCommits
 {
 	return [projectRevList.commits copy];
 }
 
 
-
 #pragma mark -
 #pragma mark History Grapher delegate methods
 
-- (void) addCommitsFromArray:(NSArray *)array
+- (void)addCommitsFromArray:(NSArray *)array
 {
 	if (!array || [array count] == 0)
 		return;
@@ -125,7 +121,7 @@
 }
 
 
-- (void) updateCommitsFromGrapher:(NSDictionary *)commitData
+- (void)updateCommitsFromGrapher:(NSDictionary *)commitData
 {
 	if ([commitData objectForKey:kCurrentQueueKey] != graphQueue)
 		return;
@@ -133,7 +129,7 @@
 	[self addCommitsFromArray:[commitData objectForKey:kNewCommitsKey]];
 }
 
-- (void) finishedGraphing
+- (void)finishedGraphing
 {
 	if (!currentRevList.parsing && ([[graphQueue operations] count] == 0)) {
 		self.isUpdating = NO;
@@ -141,11 +137,10 @@
 }
 
 
-
 #pragma mark -
 #pragma mark Private
 
-- (void) resetGraphing
+- (void)resetGraphing
 {
 	resetCommits = YES;
 	self.isUpdating = YES;
@@ -158,13 +153,13 @@
 }
 
 
-- (NSInvocationOperation *) operationForCommits:(NSArray *)newCommits
+- (NSInvocationOperation *)operationForCommits:(NSArray *)newCommits
 {
 	return [[NSInvocationOperation alloc] initWithTarget:grapher selector:@selector(graphCommits:) object:newCommits];
 }
 
 
-- (NSSet *) baseCommitsForLocalRefs
+- (NSSet *)baseCommitsForLocalRefs
 {
 	NSMutableSet *baseCommitOIDs = [NSMutableSet set];
 	NSDictionary *refs = repository.refs;
@@ -181,7 +176,7 @@
 }
 
 
-- (NSSet *) baseCommitsForRemoteRefs
+- (NSSet *)baseCommitsForRemoteRefs
 {
 	NSMutableSet *baseCommitOIDs = [NSMutableSet set];
 	NSDictionary *refs = repository.refs;
@@ -197,7 +192,7 @@
 }
 
 
-- (NSSet *) baseCommits
+- (NSSet *)baseCommits
 {
 	if ((repository.currentBranchFilter == kGitXSelectedBranchFilter) || (repository.currentBranchFilter == kGitXAllBranchesFilter)) {
 		if (lastOID)
@@ -208,8 +203,7 @@
 			if (OID)
 				return [NSMutableSet setWithObject:OID];
 		}
-	}
-	else if (repository.currentBranchFilter == kGitXLocalRemoteBranchesFilter) {
+	} else if (repository.currentBranchFilter == kGitXLocalRemoteBranchesFilter) {
 		if ([[repository.currentBranch ref] isRemote])
 			return [self baseCommitsForRemoteRefs];
 		else
@@ -220,7 +214,7 @@
 }
 
 
-- (PBGitHistoryGrapher *) grapher
+- (PBGitHistoryGrapher *)grapher
 {
 	BOOL viewAllBranches = (repository.currentBranchFilter == kGitXAllBranchesFilter);
 
@@ -228,7 +222,7 @@
 }
 
 
-- (void) setCurrentRevList:(PBGitRevList *)parser
+- (void)setCurrentRevList:(PBGitRevList *)parser
 {
 	if (currentRevList == parser)
 		return;
@@ -238,26 +232,29 @@
 
 	currentRevList = parser;
 
-	[currentRevList addObserver:self keyPath:@"commits" options:NSKeyValueObservingOptionNew block:^(MAKVONotification *notification) {
-		PBGitHistoryList *observer = notification.observer;
-		if (notification.kind == NSKeyValueChangeInsertion) {
-			NSArray *newCommits = notification.newValue;
-			if ([observer->repository.currentBranch isSimpleRef])
-				[observer->graphQueue addOperation:[observer operationForCommits:newCommits]];
-			else
-				[observer addCommitsFromArray:newCommits];
-		}
-	}];
+	[currentRevList addObserver:self
+						keyPath:@"commits"
+						options:NSKeyValueObservingOptionNew
+						  block:^(MAKVONotification *notification) {
+							  PBGitHistoryList *observer = notification.observer;
+							  if (notification.kind == NSKeyValueChangeInsertion) {
+								  NSArray *newCommits = notification.newValue;
+								  if ([observer->repository.currentBranch isSimpleRef])
+									  [observer->graphQueue addOperation:[observer operationForCommits:newCommits]];
+								  else
+									  [observer addCommitsFromArray:newCommits];
+							  }
+						  }];
 }
 
 
-- (BOOL) isAllBranchesOnlyUpdate
+- (BOOL)isAllBranchesOnlyUpdate
 {
 	return (lastBranchFilter == kGitXAllBranchesFilter) && (repository.currentBranchFilter == kGitXAllBranchesFilter);
 }
 
 
-- (BOOL) isLocalRemoteOnlyUpdate:(PBGitRevSpecifier *)rev
+- (BOOL)isLocalRemoteOnlyUpdate:(PBGitRevSpecifier *)rev
 {
 	if ((lastBranchFilter == kGitXLocalRemoteBranchesFilter) && (repository.currentBranchFilter == kGitXLocalRemoteBranchesFilter)) {
 		if (!lastRemoteRef && ![[rev ref] isRemote])
@@ -271,7 +268,7 @@
 }
 
 
-- (BOOL) selectedBranchNeedsNewGraph:(PBGitRevSpecifier *)rev
+- (BOOL)selectedBranchNeedsNewGraph:(PBGitRevSpecifier *)rev
 {
 	if (![rev isSimpleRef])
 		return YES;
@@ -295,7 +292,7 @@
 }
 
 
-- (BOOL) haveRefsBeenModified
+- (BOOL)haveRefsBeenModified
 {
 	[repository reloadRefs];
 
@@ -309,7 +306,7 @@
 
 #pragma mark updating history
 
-- (void) updateProjectHistoryForRev:(PBGitRevSpecifier *)rev
+- (void)updateProjectHistoryForRev:(PBGitRevSpecifier *)rev
 {
 	[self setCurrentRevList:projectRevList];
 
@@ -338,7 +335,7 @@
 }
 
 
-- (void) updateHistoryForRev:(PBGitRevSpecifier *)rev
+- (void)updateHistoryForRev:(PBGitRevSpecifier *)rev
 {
 	PBGitRevList *otherRevListParser = [[PBGitRevList alloc] initWithRepository:repository rev:rev shouldGraph:YES];
 

--- a/Classes/git/PBGitIndex.h
+++ b/Classes/git/PBGitIndex.h
@@ -38,7 +38,6 @@ extern NSString *PBGitIndexAmendMessageAvailable;
 extern NSString *PBGitIndexOperationFailed;
 
 
-
 // Represents a git index for a given work tree.
 // As a single git repository can have multiple trees,
 // the tree has to be given explicitly, even though
@@ -53,14 +52,14 @@ extern NSString *PBGitIndexOperationFailed;
 // A list of PBChangedFile's with differences between the work tree and the index
 // This method is KVO-aware, so changes when any of the index-modifying methods are called
 // (including -refresh)
-@property (readonly, retain) NSArray <PBChangedFile *> *indexChanges;
+@property (readonly, retain) NSArray<PBChangedFile *> *indexChanges;
 
 - (instancetype)initWithRepository:(PBGitRepository *)repository;
 
 // Refresh the index
 - (void)refresh;
 
-- (void)commitWithMessage:(NSString *)commitMessage andVerify:(BOOL) doVerify;
+- (void)commitWithMessage:(NSString *)commitMessage andVerify:(BOOL)doVerify;
 
 // Inter-file changes:
 - (BOOL)stageFiles:(NSArray<PBChangedFile *> *)stageFiles;

--- a/Classes/git/PBGitLane.h
+++ b/Classes/git/PBGitLane.h
@@ -8,34 +8,34 @@
 
 #import <Cocoa/Cocoa.h>
 
-class PBGitLane {
+class PBGitLane
+{
 	git_oid d_sha;
 	int d_index;
 
-public:
-
+   public:
 	PBGitLane(const git_oid *sha)
 	{
 		d_sha = *sha;
 	}
 
 	PBGitLane(int index, const git_oid *sha)
-	: d_index(index)
+		: d_index(index)
 	{
 		git_oid_cpy(&d_sha, sha);
 	}
-	
+
 	bool isCommit(const git_oid *sha) const
 	{
 		return !git_oid_cmp(&d_sha, sha);
 	}
-	
+
 	void setSha(const git_oid *sha);
-	
+
 	git_oid const *sha() const
 	{
 		return &d_sha;
 	}
-	
+
 	int index() const;
 };

--- a/Classes/git/PBGitRef.h
+++ b/Classes/git/PBGitRef.h
@@ -11,16 +11,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString * const kGitXTagType;
-extern NSString * const kGitXBranchType;
-extern NSString * const kGitXRemoteType;
-extern NSString * const kGitXRemoteBranchType;
-extern NSString * const kGitXStashType;
+extern NSString *const kGitXTagType;
+extern NSString *const kGitXBranchType;
+extern NSString *const kGitXRemoteType;
+extern NSString *const kGitXRemoteBranchType;
+extern NSString *const kGitXStashType;
 
-extern NSString * const kGitXTagRefPrefix;
-extern NSString * const kGitXBranchRefPrefix;
-extern NSString * const kGitXRemoteRefPrefix;
-extern NSString * const kGitXStashRefPrefix;
+extern NSString *const kGitXTagRefPrefix;
+extern NSString *const kGitXBranchRefPrefix;
+extern NSString *const kGitXRemoteRefPrefix;
+extern NSString *const kGitXStashRefPrefix;
 
 @interface PBGitRef : NSObject <PBGitRefish>
 
@@ -45,7 +45,7 @@ extern NSString * const kGitXStashRefPrefix;
 
 - (BOOL)isEqualToRef:(PBGitRef *)otherRef;
 
-@property(nonatomic, strong, readonly) NSString *ref;
+@property (nonatomic, strong, readonly) NSString *ref;
 
 @end
 

--- a/Classes/git/PBGitRef.m
+++ b/Classes/git/PBGitRef.m
@@ -9,16 +9,16 @@
 #import "PBGitRef.h"
 
 
-NSString * const kGitXTagType    = @"tag";
-NSString * const kGitXBranchType = @"branch";
-NSString * const kGitXRemoteType = @"remote";
-NSString * const kGitXRemoteBranchType = @"remote branch";
-NSString * const kGitXStashType  = @"stash";
+NSString *const kGitXTagType = @"tag";
+NSString *const kGitXBranchType = @"branch";
+NSString *const kGitXRemoteType = @"remote";
+NSString *const kGitXRemoteBranchType = @"remote branch";
+NSString *const kGitXStashType = @"stash";
 
-NSString * const kGitXTagRefPrefix    = @"refs/tags/";
-NSString * const kGitXBranchRefPrefix = @"refs/heads/";
-NSString * const kGitXRemoteRefPrefix = @"refs/remotes/";
-NSString * const kGitXStashRefPrefix  = @"refs/stash@";
+NSString *const kGitXTagRefPrefix = @"refs/tags/";
+NSString *const kGitXBranchRefPrefix = @"refs/heads/";
+NSString *const kGitXRemoteRefPrefix = @"refs/remotes/";
+NSString *const kGitXStashRefPrefix = @"refs/stash@";
 
 @interface PBGitRef ()
 
@@ -42,11 +42,12 @@ NSString * const kGitXStashRefPrefix  = @"refs/stash@";
 	return self;
 }
 
-- (NSString *)debugDescription {
+- (NSString *)debugDescription
+{
 	return [NSString stringWithFormat:@"<%@: %p ref: %@", NSStringFromClass([self class]), self, self.ref];
 }
 
-- (NSString *) tagName
+- (NSString *)tagName
 {
 	if (![self isTag])
 		return nil;
@@ -54,7 +55,7 @@ NSString * const kGitXStashRefPrefix  = @"refs/stash@";
 	return [self shortName];
 }
 
-- (NSString *) branchName
+- (NSString *)branchName
 {
 	if (![self isBranch])
 		return nil;
@@ -62,7 +63,7 @@ NSString * const kGitXStashRefPrefix  = @"refs/stash@";
 	return [self shortName];
 }
 
-- (NSString *) remoteName
+- (NSString *)remoteName
 {
 	if (![self isRemote])
 		return nil;
@@ -70,15 +71,16 @@ NSString * const kGitXStashRefPrefix  = @"refs/stash@";
 	return (NSString *)[[self.ref componentsSeparatedByString:@"/"] objectAtIndex:2];
 }
 
-- (NSString *) remoteBranchName
+- (NSString *)remoteBranchName
 {
 	if (![self isRemoteBranch])
 		return nil;
 
-	return [[self shortName] substringFromIndex:[[self remoteName] length] + 1];;
+	return [[self shortName] substringFromIndex:[[self remoteName] length] + 1];
+	;
 }
 
-- (NSString *) type
+- (NSString *)type
 {
 	if ([self isBranch])
 		return @"head";
@@ -91,22 +93,22 @@ NSString * const kGitXStashRefPrefix  = @"refs/stash@";
 	return nil;
 }
 
-- (BOOL) isBranch
+- (BOOL)isBranch
 {
 	return [self.ref hasPrefix:kGitXBranchRefPrefix];
 }
 
-- (BOOL) isTag
+- (BOOL)isTag
 {
 	return [self.ref hasPrefix:kGitXTagRefPrefix];
 }
 
-- (BOOL) isRemote
+- (BOOL)isRemote
 {
 	return [self.ref hasPrefix:kGitXRemoteRefPrefix];
 }
 
-- (BOOL) isRemoteBranch
+- (BOOL)isRemoteBranch
 {
 	if (![self isRemote])
 		return NO;
@@ -114,17 +116,17 @@ NSString * const kGitXStashRefPrefix  = @"refs/stash@";
 	return ([[self.ref componentsSeparatedByString:@"/"] count] > 3);
 }
 
-- (BOOL) isStash
+- (BOOL)isStash
 {
 	return [self.ref hasPrefix:kGitXStashRefPrefix];
 }
 
-- (BOOL) isEqualToRef:(PBGitRef *)otherRef
+- (BOOL)isEqualToRef:(PBGitRef *)otherRef
 {
 	return [self.ref isEqualToString:[otherRef ref]];
 }
 
-- (PBGitRef *) remoteRef
+- (PBGitRef *)remoteRef
 {
 	if (![self isRemote])
 		return nil;
@@ -137,28 +139,29 @@ NSString * const kGitXStashRefPrefix  = @"refs/stash@";
 	return NO;
 }
 
-+ (BOOL)isKeyExcludedFromWebScript:(const char *)name {
++ (BOOL)isKeyExcludedFromWebScript:(const char *)name
+{
 	return NO;
 }
 
 
 #pragma mark <PBGitRefish>
 
-- (NSString *) refishName
+- (NSString *)refishName
 {
 	return self.ref;
 }
 
-- (NSString *) shortName
+- (NSString *)shortName
 {
-    if ([self isStash])
-        return [self.ref substringFromIndex:5];
+	if ([self isStash])
+		return [self.ref substringFromIndex:5];
 	if ([self type])
 		return [self.ref substringFromIndex:[[self type] length] + 7];
 	return self.ref;
 }
 
-- (NSString *) refishType
+- (NSString *)refishType
 {
 	if ([self isBranch])
 		return kGitXBranchType;
@@ -168,8 +171,8 @@ NSString * const kGitXStashRefPrefix  = @"refs/stash@";
 		return kGitXRemoteBranchType;
 	if ([self isRemote])
 		return kGitXRemoteType;
-    if ([self isStash])
-        return kGitXStashType;
+	if ([self isStash])
+		return kGitXStashType;
 	return nil;
 }
 

--- a/Classes/git/PBGitRefish.h
+++ b/Classes/git/PBGitRefish.h
@@ -20,8 +20,8 @@
 
 @protocol PBGitRefish <NSObject>
 
-- (NSString *) refishName;
-- (NSString *) shortName;
-- (NSString *) refishType;
+- (NSString *)refishName;
+- (NSString *)shortName;
+- (NSString *)refishType;
 
 @end

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -20,7 +20,7 @@
 extern NSString *PBGitRepositoryDocumentType;
 
 /** NSError user info key - hook name */
-extern NSString * const PBHookNameErrorKey;
+extern NSString *const PBHookNameErrorKey;
 
 typedef enum branchFilterTypes {
 	kGitXAllBranchesFilter = 0,
@@ -42,51 +42,51 @@ typedef enum branchFilterTypes {
 @property (nonatomic, assign) BOOL hasChanged;
 @property (nonatomic, assign) NSInteger currentBranchFilter;
 
-@property (readonly, getter = getIndexURL) NSURL* indexURL;
+@property (readonly, getter=getIndexURL) NSURL *indexURL;
 
 @property (nonatomic, strong) PBGitHistoryList *revisionList;
-@property (nonatomic, readonly, strong) NSArray <PBGitStash *> *stashes;
-@property (nonatomic, readonly, strong) NSArray <PBGitRevSpecifier *> *branches;
-@property (nonatomic, strong) NSMutableOrderedSet <PBGitRevSpecifier *> *branchesSet;
+@property (nonatomic, readonly, strong) NSArray<PBGitStash *> *stashes;
+@property (nonatomic, readonly, strong) NSArray<PBGitRevSpecifier *> *branches;
+@property (nonatomic, strong) NSMutableOrderedSet<PBGitRevSpecifier *> *branchesSet;
 @property (nonatomic, strong) PBGitRevSpecifier *currentBranch;
-@property (nonatomic, strong) NSMutableDictionary <GTOID *, NSMutableArray <PBGitRef *> *> *refs;
-@property (readonly, strong) GTRepository* gtRepo;
+@property (nonatomic, strong) NSMutableDictionary<GTOID *, NSMutableArray<PBGitRef *> *> *refs;
+@property (readonly, strong) GTRepository *gtRepo;
 @property (nonatomic, readonly) BOOL isShallowRepository;
 
-@property (nonatomic, strong) NSMutableArray<GTSubmodule *>* submodules;
+@property (nonatomic, strong) NSMutableArray<GTSubmodule *> *submodules;
 @property (readonly, strong) PBGitIndex *index;
 
 // Designated initializer
 - (id)initWithURL:(NSURL *)repositoryURL error:(NSError **)error;
 
-- (BOOL) addRemote:(NSString *)remoteName withURL:(NSString *)URLString error:(NSError **)error;
-- (BOOL) fetchRemoteForRef:(PBGitRef *)ref error:(NSError **)error;
-- (BOOL) pullBranch:(PBGitRef *)branchRef fromRemote:(PBGitRef *)remoteRef rebase:(BOOL)rebase error:(NSError **)error;
-- (BOOL) pushBranch:(PBGitRef *)branchRef toRemote:(PBGitRef *)remoteRef error:(NSError **)error;
+- (BOOL)addRemote:(NSString *)remoteName withURL:(NSString *)URLString error:(NSError **)error;
+- (BOOL)fetchRemoteForRef:(PBGitRef *)ref error:(NSError **)error;
+- (BOOL)pullBranch:(PBGitRef *)branchRef fromRemote:(PBGitRef *)remoteRef rebase:(BOOL)rebase error:(NSError **)error;
+- (BOOL)pushBranch:(PBGitRef *)branchRef toRemote:(PBGitRef *)remoteRef error:(NSError **)error;
 
-- (BOOL) checkoutRefish:(id <PBGitRefish>)ref error:(NSError **)error;
-- (BOOL) checkoutFiles:(NSArray *)files fromRefish:(id <PBGitRefish>)ref error:(NSError **)error;
-- (BOOL) mergeWithRefish:(id <PBGitRefish>)ref error:(NSError **)error;
-- (BOOL) cherryPickRefish:(id <PBGitRefish>)ref error:(NSError **)error;
-- (BOOL) resetRefish:(GTRepositoryResetType)mode to:(id <PBGitRefish>)ref error:(NSError **)error;
-- (BOOL) rebaseBranch:(id <PBGitRefish>)branch onRefish:(id <PBGitRefish>)upstream error:(NSError **)error;
-- (BOOL) createBranch:(NSString *)branchName atRefish:(id <PBGitRefish>)ref error:(NSError **)error;
-- (BOOL) createTag:(NSString *)tagName message:(NSString *)message atRefish:(id <PBGitRefish>)commitSHA error:(NSError **)error;
-- (BOOL) deleteRemote:(PBGitRef *)ref error:(NSError **)error;
-- (BOOL) deleteRef:(PBGitRef *)ref error:(NSError **)error;
+- (BOOL)checkoutRefish:(id<PBGitRefish>)ref error:(NSError **)error;
+- (BOOL)checkoutFiles:(NSArray *)files fromRefish:(id<PBGitRefish>)ref error:(NSError **)error;
+- (BOOL)mergeWithRefish:(id<PBGitRefish>)ref error:(NSError **)error;
+- (BOOL)cherryPickRefish:(id<PBGitRefish>)ref error:(NSError **)error;
+- (BOOL)resetRefish:(GTRepositoryResetType)mode to:(id<PBGitRefish>)ref error:(NSError **)error;
+- (BOOL)rebaseBranch:(id<PBGitRefish>)branch onRefish:(id<PBGitRefish>)upstream error:(NSError **)error;
+- (BOOL)createBranch:(NSString *)branchName atRefish:(id<PBGitRefish>)ref error:(NSError **)error;
+- (BOOL)createTag:(NSString *)tagName message:(NSString *)message atRefish:(id<PBGitRefish>)commitSHA error:(NSError **)error;
+- (BOOL)deleteRemote:(PBGitRef *)ref error:(NSError **)error;
+- (BOOL)deleteRef:(PBGitRef *)ref error:(NSError **)error;
 
-- (BOOL) stashPop:(PBGitStash *)stash error:(NSError **)error;
-- (BOOL) stashApply:(PBGitStash *)stash error:(NSError **)error;
-- (BOOL) stashDrop:(PBGitStash *)stash error:(NSError **)error;
-- (BOOL) stashSave:(NSError **)error;
-- (BOOL) stashSaveWithKeepIndex:(BOOL)keepIndex error:(NSError **)error;
+- (BOOL)stashPop:(PBGitStash *)stash error:(NSError **)error;
+- (BOOL)stashApply:(PBGitStash *)stash error:(NSError **)error;
+- (BOOL)stashDrop:(PBGitStash *)stash error:(NSError **)error;
+- (BOOL)stashSave:(NSError **)error;
+- (BOOL)stashSaveWithKeepIndex:(BOOL)keepIndex error:(NSError **)error;
 
 - (BOOL)ignoreFilePaths:(NSArray *)filePaths error:(NSError **)error;
 
 - (BOOL)updateReference:(PBGitRef *)ref toPointAtCommit:(PBGitCommit *)newCommit error:(NSError **)error;
 - (NSString *)performDiff:(PBGitCommit *)startCommit against:(PBGitCommit *)diffCommit forFiles:(NSArray *)filePaths;
 
-- (NSURL *) gitURL ;
+- (NSURL *)gitURL;
 
 - (BOOL)executeHook:(NSString *)name error:(NSError **)error;
 - (BOOL)executeHook:(NSString *)name arguments:(NSArray *)arguments error:(NSError **)error;
@@ -101,9 +101,9 @@ typedef enum branchFilterTypes {
 
 - (BOOL)hasSVNRemote;
 
-- (void) reloadRefs;
-- (void) lazyReload;
-- (PBGitRevSpecifier*)headRef;
+- (void)reloadRefs;
+- (void)lazyReload;
+- (PBGitRevSpecifier *)headRef;
 - (GTOID *)headOID;
 - (PBGitCommit *)headCommit;
 - (GTOID *)OIDForRef:(PBGitRef *)ref;
@@ -117,18 +117,18 @@ typedef enum branchFilterTypes {
 - (BOOL)refExists:(PBGitRef *)ref;
 - (PBGitRef *)refForName:(NSString *)name;
 
-- (NSArray <NSString *> *) remotes;
-- (BOOL) hasRemotes;
-- (PBGitRef *) remoteRefForBranch:(PBGitRef *)branch error:(NSError **)error;
+- (NSArray<NSString *> *)remotes;
+- (BOOL)hasRemotes;
+- (PBGitRef *)remoteRefForBranch:(PBGitRef *)branch error:(NSError **)error;
 
-- (void) readCurrentBranch;
-- (PBGitRevSpecifier*) addBranch: (PBGitRevSpecifier*) rev;
+- (void)readCurrentBranch;
+- (PBGitRevSpecifier *)addBranch:(PBGitRevSpecifier *)rev;
 - (BOOL)removeBranch:(PBGitRevSpecifier *)rev;
 
-- (BOOL) revisionExists:(NSString*) spec;
+- (BOOL)revisionExists:(NSString *)spec;
 
-- (void) forceUpdateRevisions;
-- (NSURL*) getIndexURL;
+- (void)forceUpdateRevisions;
+- (NSURL *)getIndexURL;
 
 - (GTSubmodule *)submoduleAtPath:(NSString *)path error:(NSError **)error;
 

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -30,13 +30,13 @@
 #import "PBGitStash.h"
 #import "PBError.h"
 
-NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
+NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 
 @interface PBGitRepository () {
 	__strong PBGitRepositoryWatcher *watcher;
 	__strong PBGitRevSpecifier *_headRef; // Caching
-	__strong GTOID* _headOID;
-	__strong GTRepository* _gtRepo;
+	__strong GTOID *_headOID;
+	__strong GTRepository *_gtRepo;
 	PBGitIndex *_index;
 }
 
@@ -53,13 +53,13 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 
 - (id)init
 {
-    self = [super init];
-    if (!self) return nil;
+	self = [super init];
+	if (!self) return nil;
 
 	self.branchesSet = [NSMutableOrderedSet orderedSet];
-    self.submodules = [NSMutableArray array];
+	self.submodules = [NSMutableArray array];
 	currentBranchFilter = [PBGitDefaults branchFilter];
-    return self;
+	return self;
 }
 
 - (id)initWithURL:(NSURL *)repositoryURL error:(NSError **)error
@@ -83,13 +83,13 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 
 	[self reloadRefs];
 
-    // Setup the FSEvents watcher to fire notifications when things change
-    watcher = [[PBGitRepositoryWatcher alloc] initWithRepository:self];
+	// Setup the FSEvents watcher to fire notifications when things change
+	watcher = [[PBGitRepositoryWatcher alloc] initWithRepository:self];
 
 	return self;
 }
 
-- (void) dealloc
+- (void)dealloc
 {
 	// NSLog(@"Dealloc of repository");
 	[watcher stop];
@@ -102,23 +102,23 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 {
 	NSError *error = nil;
 	GTIndex *index = [self.gtRepo indexWithError:&error];
-    if (index == nil) {
-        NSLog(@"getIndexURL failed with error %@", error);
-        return nil;
-    }
-	NSURL* result = index.fileURL;
+	if (index == nil) {
+		NSLog(@"getIndexURL failed with error %@", error);
+		return nil;
+	}
+	NSURL *result = index.fileURL;
 	return result;
 }
 
 - (BOOL)isBareRepository
 {
-    return self.gtRepo.isBare;
+	return self.gtRepo.isBare;
 }
 
 - (BOOL)isShallowRepository
 {
 	// Using low-level function because GTRepository does not currently
-    // expose this information itself.
+	// expose this information itself.
 	return (BOOL)git_repository_is_shallow(self.gtRepo.git_repository);
 }
 
@@ -143,17 +143,19 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return [self.hasSVNRepoConfig boolValue];
 }
 
-- (NSURL *)gitURL {
-    return self.gtRepo.gitDirectoryURL;
+- (NSURL *)gitURL
+{
+	return self.gtRepo.gitDirectoryURL;
 }
 
-- (NSURL *)workingDirectoryURL {
-    return self.gtRepo.fileURL;
+- (NSURL *)workingDirectoryURL
+{
+	return self.gtRepo.fileURL;
 }
 
 - (NSString *)workingDirectory
 {
-    return self.workingDirectoryURL.path;
+	return self.workingDirectoryURL.path;
 }
 
 - (void)forceUpdateRevisions
@@ -191,10 +193,10 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 		return;
 	}
 
-	PBGitRef* ref = [[PBGitRef alloc] initWithString:gtRef.name];
-//	NSLog(@"addRef %@ %@ at %@", ref.type, gtRef.name, [sha string]);
-	NSMutableArray* curRefs = refs[sha];
-	if ( curRefs != nil ) {
+	PBGitRef *ref = [[PBGitRef alloc] initWithString:gtRef.name];
+	//	NSLog(@"addRef %@ %@ at %@", ref.type, gtRef.name, [sha string]);
+	NSMutableArray *curRefs = refs[sha];
+	if (curRefs != nil) {
 		if ([curRefs containsObject:ref]) {
 			NSLog(@"Duplicate ref shouldn't be added: %@", ref);
 			return;
@@ -207,39 +209,37 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 
 - (void)loadSubmodules
 {
-    self.submodules = [NSMutableArray array];
+	self.submodules = [NSMutableArray array];
 
-    [self.gtRepo enumerateSubmodulesRecursively:NO usingBlock:^(GTSubmodule *gtSubmodule, NSError *error, BOOL *stop) {
-		[self.submodules addObject:gtSubmodule];
-    }];
+	[self.gtRepo enumerateSubmodulesRecursively:NO
+									 usingBlock:^(GTSubmodule *gtSubmodule, NSError *error, BOOL *stop) {
+										 [self.submodules addObject:gtSubmodule];
+									 }];
 }
 
-- (void) reloadRefs
+- (void)reloadRefs
 {
 	// clear out ref caches
 	_headRef = nil;
 	_headOID = nil;
 	self->refs = [NSMutableDictionary dictionary];
-	
-	NSError* error = nil;
-	NSArray* allRefs = [self.gtRepo referenceNamesWithError:&error];
+
+	NSError *error = nil;
+	NSArray *allRefs = [self.gtRepo referenceNamesWithError:&error];
 
 	if ([self.gtRepo isHEADDetached]) {
 		// Add HEAD when we're detached
 		allRefs = [allRefs arrayByAddingObject:@"HEAD"];
 	}
-	
+
 	// load all named refs
 	NSMutableOrderedSet *oldBranches = [self.branchesSet mutableCopy];
-	for (NSString* referenceName in allRefs)
-	{
-		GTReference* gtRef = [self.gtRepo lookUpReferenceWithName:referenceName error:&error];
-		
-		if (gtRef == nil)
-		{
+	for (NSString *referenceName in allRefs) {
+		GTReference *gtRef = [self.gtRepo lookUpReferenceWithName:referenceName error:&error];
+
+		if (gtRef == nil) {
 			NSLog(@"Reference \"%@\" could not be found in the repository", referenceName);
-			if (error)
-			{
+			if (error) {
 				NSLog(@"Error loading reference was: %@", error);
 			}
 			continue;
@@ -248,27 +248,27 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 			// Hide remote symbolic references like origin/HEAD
 			continue;
 		}
-		PBGitRef* gitRef = [PBGitRef refFromString:referenceName];
-		PBGitRevSpecifier* revSpec = [[PBGitRevSpecifier alloc] initWithRef:gitRef];
+		PBGitRef *gitRef = [PBGitRef refFromString:referenceName];
+		PBGitRevSpecifier *revSpec = [[PBGitRevSpecifier alloc] initWithRef:gitRef];
 		[self addBranch:revSpec];
 		[self addRef:gtRef];
 		[oldBranches removeObject:revSpec];
 	}
-	
+
 	for (PBGitRevSpecifier *branch in oldBranches)
 		if ([branch isSimpleRef] && ![branch isEqual:[self headRef]])
 			[self removeBranch:branch];
 
 
-    [self loadSubmodules];
-    
+	[self loadSubmodules];
+
 	[self willChangeValueForKey:@"refs"];
 	[self willChangeValueForKey:@"stashes"];
 	[self didChangeValueForKey:@"refs"];
 	[self didChangeValueForKey:@"stashes"];
 }
 
-- (void) lazyReload
+- (void)lazyReload
 {
 	if (!hasChanged)
 		return;
@@ -305,7 +305,7 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 
 - (GTOID *)headOID
 {
-	if (! _headOID)
+	if (!_headOID)
 		[self headRef];
 
 	return _headOID;
@@ -320,24 +320,20 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 {
 	if (!ref)
 		return nil;
-	
-	for (GTOID *sha in refs)
-	{
+
+	for (GTOID *sha in refs) {
 		NSMutableArray *refsForSha = [refs objectForKey:sha];
-		for (PBGitRef *existingRef in refsForSha)
-		{
-			if ([existingRef isEqualToRef:ref])
-			{
+		for (PBGitRef *existingRef in refsForSha) {
+			if ([existingRef isEqualToRef:ref]) {
 				return sha;
 			}
 		}
-    }
-    
-	
-	NSError* error = nil;
+	}
+
+
+	NSError *error = nil;
 	GTReference *gtRef = [self.gtRepo lookUpReferenceWithName:ref.ref error:&error];
-	if (!gtRef)
-	{
+	if (!gtRef) {
 		NSLog(@"Error looking up ref for %@", ref.ref);
 		return nil;
 	}
@@ -358,10 +354,10 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 		return nil;
 	NSArray *revList = revisionList.projectCommits;
 
-    if (!revList) {
-        [revisionList forceUpdate];
-        revList = revisionList.projectCommits;
-    }
+	if (!revList) {
+		[revisionList forceUpdate];
+		revList = revisionList.projectCommits;
+	}
 	for (PBGitCommit *commit in revList)
 		if ([commit.OID isEqual:sha])
 			return commit;
@@ -388,8 +384,7 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 				return YES;
 			[searchOIDs removeObject:commitOID];
 			[searchOIDs addObjectsFromArray:commit.parents];
-		}
-		else if ([testOID isEqual:commitOID])
+		} else if ([testOID isEqual:commitOID])
 			return NO;
 	}
 
@@ -417,13 +412,13 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return [self isOIDOnHeadBranch:[self OIDForRef:testRef]];
 }
 
-- (BOOL) checkRefFormat:(NSString *)refName
+- (BOOL)checkRefFormat:(NSString *)refName
 {
 	BOOL result = [GTReference isValidReferenceName:refName];
 	return result;
 }
 
-- (BOOL) refExists:(PBGitRef *)ref
+- (BOOL)refExists:(PBGitRef *)ref
 {
 	NSError *gtError = nil;
 	GTReference *gtRef = [self.gtRepo lookUpReferenceWithName:ref.ref error:&gtError];
@@ -442,7 +437,7 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 		return nil;
 
 	NSError *taskError = nil;
-	NSString *output = [self outputOfTaskWithArguments:@[@"show-ref", name] error:&taskError];
+	NSString *output = [self outputOfTaskWithArguments:@[ @"show-ref", name ] error:&taskError];
 
 	// the output is in the format: <SHA-1 ID> <space> <reference name>
 	// with potentially multiple lines if there are multiple matching refs (ex: refs/remotes/origin/master)
@@ -454,61 +449,64 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return [PBGitRef refFromString:refName];
 }
 
-- (NSArray <PBGitRevSpecifier *> *)branches
+- (NSArray<PBGitRevSpecifier *> *)branches
 {
-    return [self.branchesSet array];
+	return [self.branchesSet array];
 }
-		
+
 // Returns either this object, or an existing, equal object
-- (PBGitRevSpecifier*) addBranch:(PBGitRevSpecifier*)branch
+- (PBGitRevSpecifier *)addBranch:(PBGitRevSpecifier *)branch
 {
 	if ([[branch parameters] count] == 0)
 		branch = [self headRef];
 
 	// First check if the branch doesn't exist already
-    if ([self.branchesSet containsObject:branch]) {
-        return branch;
-    }
+	if ([self.branchesSet containsObject:branch]) {
+		return branch;
+	}
 
 	NSIndexSet *newIndex = [NSIndexSet indexSetWithIndex:[self.branches count]];
 	[self willChange:NSKeyValueChangeInsertion valuesAtIndexes:newIndex forKey:@"branches"];
 
-    [self.branchesSet addObject:branch];
+	[self.branchesSet addObject:branch];
 
 	[self didChange:NSKeyValueChangeInsertion valuesAtIndexes:newIndex forKey:@"branches"];
 	return branch;
 }
 
-- (BOOL) removeBranch:(PBGitRevSpecifier *)branch
+- (BOOL)removeBranch:(PBGitRevSpecifier *)branch
 {
-    if ([self.branchesSet containsObject:branch]) {
-        NSIndexSet *oldIndex = [NSIndexSet indexSetWithIndex:[self.branches indexOfObject:branch]];
-        [self willChange:NSKeyValueChangeRemoval valuesAtIndexes:oldIndex forKey:@"branches"];
+	if ([self.branchesSet containsObject:branch]) {
+		NSIndexSet *oldIndex = [NSIndexSet indexSetWithIndex:[self.branches indexOfObject:branch]];
+		[self willChange:NSKeyValueChangeRemoval valuesAtIndexes:oldIndex forKey:@"branches"];
 
-        [self.branchesSet removeObject:branch];
+		[self.branchesSet removeObject:branch];
 
-        [self didChange:NSKeyValueChangeRemoval valuesAtIndexes:oldIndex forKey:@"branches"];
-        return YES;
-    }
+		[self didChange:NSKeyValueChangeRemoval valuesAtIndexes:oldIndex forKey:@"branches"];
+		return YES;
+	}
 	return NO;
 }
-	
-- (void) readCurrentBranch
+
+- (void)readCurrentBranch
 {
-		self.currentBranch = [self addBranch: [self headRef]];
+	self.currentBranch = [self addBranch:[self headRef]];
 }
 
-- (void) setCurrentBranch:(PBGitRevSpecifier *)newCurrentBranch {
+- (void)setCurrentBranch:(PBGitRevSpecifier *)newCurrentBranch
+{
 	currentBranch = newCurrentBranch;
 	[revisionList updateHistory];
 }
 
-- (void) setCurrentBranchFilter:(NSInteger)newCurrentBranchFilter {
+- (void)setCurrentBranchFilter:(NSInteger)newCurrentBranchFilter
+{
 	currentBranchFilter = newCurrentBranchFilter;
 	[revisionList updateHistory];
 }
 
-- (void) setHasChanged:(BOOL)newHasChanged {
+- (void)setHasChanged:(BOOL)newHasChanged
+{
 	hasChanged = newHasChanged;
 	[revisionList forceUpdate];
 }
@@ -516,80 +514,81 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 
 #pragma mark Stashes
 
-- (NSArray <PBGitStash *> *)stashes
+- (NSArray<PBGitStash *> *)stashes
 {
 	NSMutableArray *stashes = [NSMutableArray array];
 	[self.gtRepo enumerateStashesUsingBlock:^(NSUInteger index, NSString *message, GTOID *oid, BOOL *stop) {
 		PBGitStash *stash = [[PBGitStash alloc] initWithRepository:self stashOID:oid index:index message:message];
 		[stashes addObject:stash];
 	}];
-    return [NSArray arrayWithArray:stashes];
+	return [NSArray arrayWithArray:stashes];
 }
 
-- (PBGitStash *)stashForRef:(PBGitRef *)ref {
-    __block PBGitStash * found = nil;
+- (PBGitStash *)stashForRef:(PBGitRef *)ref
+{
+	__block PBGitStash *found = nil;
 
 	[self.gtRepo enumerateStashesUsingBlock:^(NSUInteger index, NSString *message, GTOID *oid, BOOL *stop) {
 		PBGitStash *stash = [[PBGitStash alloc] initWithRepository:self stashOID:oid index:index message:message];
-        if ([stash.ref isEqualToRef:ref]) {
-            found = stash;
-            *stop = YES;
-        }
+		if ([stash.ref isEqualToRef:ref]) {
+			found = stash;
+			*stop = YES;
+		}
 	}];
-    return found;
+	return found;
 }
 
 - (BOOL)stashRunCommand:(NSString *)command withStash:(PBGitStash *)stash error:(NSError **)error
 {
 	NSError *gitError = nil;
-    NSArray *arguments = @[@"stash", command, stash.ref.refishName];
+	NSArray *arguments = @[ @"stash", command, stash.ref.refishName ];
 	NSString *output = [self outputOfTaskWithArguments:arguments error:&gitError];
-    [self willChangeValueForKey:@"stashes"];
+	[self willChangeValueForKey:@"stashes"];
 	[self didChangeValueForKey:@"stashes"];
 	if (!output) {
 		NSString *title = [NSString stringWithFormat:@"Stash %@ failed!", command];
 		NSString *message = [NSString stringWithFormat:@"There was an error!"];
 
-		return PBReturnErrorWithUserInfo(error, title, message, @{NSUnderlyingErrorKey: gitError});
-    }
-    return YES;
+		return PBReturnErrorWithUserInfo(error, title, message, @{NSUnderlyingErrorKey : gitError});
+	}
+	return YES;
 }
 
 - (BOOL)stashPop:(PBGitStash *)stash error:(NSError **)error
 {
-    return [self stashRunCommand:@"pop" withStash:stash error:error];
+	return [self stashRunCommand:@"pop" withStash:stash error:error];
 }
 
 - (BOOL)stashApply:(PBGitStash *)stash error:(NSError **)error
 {
-    return [self stashRunCommand:@"apply" withStash:stash error:error];
+	return [self stashRunCommand:@"apply" withStash:stash error:error];
 }
 
 - (BOOL)stashDrop:(PBGitStash *)stash error:(NSError **)error
 {
-    return [self stashRunCommand:@"drop" withStash:stash error:error];
+	return [self stashRunCommand:@"drop" withStash:stash error:error];
 }
 
 - (BOOL)stashSave:(NSError **)error
 {
-    return [self stashSaveWithKeepIndex:NO error:error];
+	return [self stashSaveWithKeepIndex:NO error:error];
 }
 
 - (BOOL)stashSaveWithKeepIndex:(BOOL)keepIndex error:(NSError **)error
 {
 	NSError *gitError = nil;
-    NSArray * arguments = @[@"stash", @"save", keepIndex?@"--keep-index":@"--no-keep-index"];
+	NSArray *arguments = @[ @"stash", @"save", keepIndex ? @"--keep-index" : @"--no-keep-index" ];
 
 	NSString *output = [self outputOfTaskWithArguments:arguments error:&gitError];
-    [self willChangeValueForKey:@"stashes"];
+	[self willChangeValueForKey:@"stashes"];
 	[self didChangeValueForKey:@"stashes"];
-    if (!output) {
+	if (!output) {
 		NSString *title = [NSString stringWithFormat:@"Stash save failed!"];
 		NSString *message = [NSString stringWithFormat:@"There was an error!"];
 
-		return PBReturnErrorWithUserInfo(error, title, message, @{NSUnderlyingErrorKey: gitError});
-    }
-    return YES;
+		return PBReturnErrorWithUserInfo(error, title, message, @{NSUnderlyingErrorKey : gitError});
+	}
+	return YES;
 }
 
 - (BOOL)ignoreFilePaths:(NSArray *)filePaths error:(NSError **)error
@@ -629,7 +628,7 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 
 #pragma mark Remotes
 
-- (NSArray <NSString *> *)remotes
+- (NSArray<NSString *> *)remotes
 {
 	NSError *error = nil;
 	NSArray *remotes = [self.gtRepo remoteNamesWithError:&error];
@@ -640,12 +639,12 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return remotes;
 }
 
-- (BOOL) hasRemotes
+- (BOOL)hasRemotes
 {
 	return ([self remotes] != nil);
 }
 
-- (PBGitRef *) remoteRefForBranch:(PBGitRef *)branch error:(NSError **)error
+- (PBGitRef *)remoteRefForBranch:(PBGitRef *)branch error:(NSError **)error
 {
 	if ([branch isRemote]) {
 		return [branch remoteRef];
@@ -679,9 +678,9 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 			NSString *recovery = NSLocalizedString(@"Please select a branch from the popup menu, which has a corresponding remote tracking branch set up.\n\nYou can also use a contextual menu to choose a branch by right clicking on its label in the commit history list.", @"");
 
 			return [NSError pb_errorWithDescription:NSLocalizedString(@"No remote configured for branch", @"")
-										failureReason:info
-									  underlyingError:gtError
-											 userInfo:@{NSLocalizedRecoverySuggestionErrorKey: recovery}];
+									  failureReason:info
+									underlyingError:gtError
+										   userInfo:@{NSLocalizedRecoverySuggestionErrorKey : recovery}];
 		});
 		return nil;
 	}
@@ -695,7 +694,7 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 
 - (BOOL)addRemote:(NSString *)remoteName withURL:(NSString *)URLString error:(NSError **)error
 {
-	PBTask *task = [self taskWithArguments:@[@"remote", @"add", @"-f", remoteName, URLString]];
+	PBTask *task = [self taskWithArguments:@[ @"remote", @"add", @"-f", remoteName, URLString ]];
 	return [task launchTask:error];
 }
 
@@ -712,7 +711,7 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 		fetchArg = ref.remoteName;
 	}
 
-	PBTask *task = [self taskWithArguments:@[@"fetch", fetchArg]];
+	PBTask *task = [self taskWithArguments:@[ @"fetch", fetchArg ]];
 	NSError *taskError = nil;
 	BOOL success = [task launchTask:&taskError];
 	if (!success) {
@@ -805,7 +804,7 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return success;
 }
 
-- (BOOL) checkoutRefish:(id <PBGitRefish>)ref error:(NSError **)error
+- (BOOL)checkoutRefish:(id<PBGitRefish>)ref error:(NSError **)error
 {
 	NSString *refName = nil;
 	if ([ref refishType] == kGitXBranchType)
@@ -814,7 +813,7 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 		refName = [ref refishName];
 
 	NSError *gitError = nil;
-	NSArray *arguments = @[@"checkout", refName];
+	NSArray *arguments = @[ @"checkout", refName ];
 	NSString *output = [self outputOfTaskWithArguments:arguments error:&gitError];
 	if (!output) {
 		NSString *title = @"Checkout failed";
@@ -828,7 +827,7 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return YES;
 }
 
-- (BOOL) checkoutFiles:(NSArray *)files fromRefish:(id <PBGitRefish>)ref error:(NSError **)error
+- (BOOL)checkoutFiles:(NSArray *)files fromRefish:(id<PBGitRefish>)ref error:(NSError **)error
 {
 	if (!files || ([files count] == 0))
 		return NO;
@@ -839,7 +838,7 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	else
 		refName = [ref refishName];
 
-	NSArray *arguments = @[@"checkout", refName, @"--"];
+	NSArray *arguments = @[ @"checkout", refName, @"--" ];
 	arguments = [arguments arrayByAddingObjectsFromArray:files];
 
 	NSError *gitError = nil;
@@ -855,12 +854,12 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 }
 
 
-- (BOOL) mergeWithRefish:(id <PBGitRefish>)ref error:(NSError **)error
+- (BOOL)mergeWithRefish:(id<PBGitRefish>)ref error:(NSError **)error
 {
 	NSString *refName = [ref refishName];
 
 	NSError *gitError = nil;
-	NSArray *arguments = @[@"merge", refName];
+	NSArray *arguments = @[ @"merge", refName ];
 	NSString *output = [self outputOfTaskWithArguments:arguments error:&gitError];
 	if (!output) {
 		NSString *title = @"Merge failed!";
@@ -875,7 +874,7 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return YES;
 }
 
-- (BOOL) cherryPickRefish:(id <PBGitRefish>)ref error:(NSError **)error
+- (BOOL)cherryPickRefish:(id<PBGitRefish>)ref error:(NSError **)error
 {
 	if (!ref)
 		return NO;
@@ -883,7 +882,7 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	NSString *refName = [ref refishName];
 
 	NSError *gitError = nil;
-	NSArray *arguments = @[@"cherry-pick", refName];
+	NSArray *arguments = @[ @"cherry-pick", refName ];
 	NSString *output = [self outputOfTaskWithArguments:arguments error:&gitError];
 	if (!output) {
 		NSString *title = @"Cherry pick failed!";
@@ -897,13 +896,13 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return YES;
 }
 
-- (BOOL) resetRefish:(GTRepositoryResetType)mode to:(id <PBGitRefish>)ref error:(NSError **)error
+- (BOOL)resetRefish:(GTRepositoryResetType)mode to:(id<PBGitRefish>)ref error:(NSError **)error
 {
 	if (!ref)
 		return NO;
-	
+
 	NSString *refName = [ref refishName];
-	
+
 	NSString *modeParam;
 	switch (mode) {
 		case GTRepositoryResetTypeSoft:
@@ -918,27 +917,27 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	}
 
 	NSError *gitError = nil;
-	NSArray *arguments = @[@"reset", modeParam, refName];
-	
+	NSArray *arguments = @[ @"reset", modeParam, refName ];
+
 	NSString *output = [self outputOfTaskWithArguments:arguments error:&gitError];
 	if (!output) {
 		NSString *title = @"Reset failed!";
 		NSString *message = [NSString stringWithFormat:@"There was an error resetting to %@ '%@'.", [ref refishType], [ref shortName]];
-		
+
 		return PBReturnError(error, title, message, gitError);
 	}
-	
+
 	[self reloadRefs];
 	[self readCurrentBranch];
 	return YES;
 }
 
 
-- (BOOL) rebaseBranch:(id <PBGitRefish>)branch onRefish:(id <PBGitRefish>)upstream error:(NSError **)error
+- (BOOL)rebaseBranch:(id<PBGitRefish>)branch onRefish:(id<PBGitRefish>)upstream error:(NSError **)error
 {
 	NSParameterAssert(upstream != nil);
 
-	NSArray *arguments = @[@"rebase", upstream.refishName];
+	NSArray *arguments = @[ @"rebase", upstream.refishName ];
 
 	if (branch)
 		arguments = [arguments arrayByAddingObject:branch.refishName];
@@ -960,26 +959,26 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return YES;
 }
 
-- (BOOL) createBranch:(NSString *)branchName atRefish:(id <PBGitRefish>)ref error:(NSError **)error
+- (BOOL)createBranch:(NSString *)branchName atRefish:(id<PBGitRefish>)ref error:(NSError **)error
 {
 	if (!branchName || !ref)
 		return NO;
 
 	NSError *gitError = nil;
-	NSArray *arguments = @[@"branch", branchName, ref.refishName];
+	NSArray *arguments = @[ @"branch", branchName, ref.refishName ];
 	NSString *output = [self outputOfTaskWithArguments:arguments error:&gitError];
 	if (!output) {
 		NSString *title = @"Create Branch failed!";
 		NSString *message = [NSString stringWithFormat:@"There was an error creating the branch '%@' at %@ '%@'.", branchName, [ref refishType], [ref shortName]];
 
-		return PBReturnErrorWithUserInfo(error, title, message, @{NSUnderlyingErrorKey: gitError});
+		return PBReturnErrorWithUserInfo(error, title, message, @{NSUnderlyingErrorKey : gitError});
 	}
 
 	[self reloadRefs];
 	return YES;
 }
 
-- (BOOL) createTag:(NSString *)tagName message:(NSString *)message atRefish:(id <PBGitRefish>)target error:(NSError **)error
+- (BOOL)createTag:(NSString *)tagName message:(NSString *)message atRefish:(id<PBGitRefish>)target error:(NSError **)error
 {
 	if (!tagName)
 		return NO;
@@ -1000,18 +999,18 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return YES;
 }
 
-- (BOOL) deleteRemote:(PBGitRef *)ref error:(NSError **)error
+- (BOOL)deleteRemote:(PBGitRef *)ref error:(NSError **)error
 {
 	if (!ref || ([ref refishType] != kGitXRemoteType))
 		return NO;
 
 	NSError *gitError = nil;
-	NSArray *arguments = @[@"remote", @"rm", ref.remoteName];
+	NSArray *arguments = @[ @"remote", @"rm", ref.remoteName ];
 	NSString *output = [self outputOfTaskWithArguments:arguments error:&gitError];
 	if (!output) {
 		NSString *title = @"Delete remote failed!";
 		NSString *message = [NSString stringWithFormat:@"There was an error deleting the remote: %@\n\n", [ref remoteName]];
-		return PBReturnErrorWithUserInfo(error, title, message, @{NSUnderlyingErrorKey: gitError});
+		return PBReturnErrorWithUserInfo(error, title, message, @{NSUnderlyingErrorKey : gitError});
 	}
 
 	// remove the remote's branches
@@ -1029,7 +1028,8 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return YES;
 }
 
-- (NSString *)performDiff:(PBGitCommit *)startCommit against:(PBGitCommit *)diffCommit forFiles:(NSArray *)filePaths {
+- (NSString *)performDiff:(PBGitCommit *)startCommit against:(PBGitCommit *)diffCommit forFiles:(NSArray *)filePaths
+{
 	NSParameterAssert(startCommit);
 	NSAssert(startCommit.repository == self, @"Different repo");
 
@@ -1059,7 +1059,7 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return diff;
 }
 
-- (BOOL) deleteRef:(PBGitRef *)ref error:(NSError **)error
+- (BOOL)deleteRef:(PBGitRef *)ref error:(NSError **)error
 {
 	if (!ref)
 		return NO;
@@ -1068,13 +1068,13 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 		return [self deleteRemote:ref error:error];
 
 	NSError *gitError = nil;
-	NSArray *arguments = @[@"update-ref", @"-d", ref.ref];
+	NSArray *arguments = @[ @"update-ref", @"-d", ref.ref ];
 	NSString *output = [self outputOfTaskWithArguments:arguments error:&gitError];
 	if (!output) {
 		NSString *title = @"Delete ref failed!";
 		NSString *message = [NSString stringWithFormat:@"There was an error deleting the ref: %@\n\n", [ref shortName]];
 
-		return PBReturnErrorWithUserInfo(error, title, message, @{NSUnderlyingErrorKey: gitError});
+		return PBReturnErrorWithUserInfo(error, title, message, @{NSUnderlyingErrorKey : gitError});
 	}
 
 	[self removeBranch:[[PBGitRevSpecifier alloc] initWithRef:ref]];
@@ -1085,9 +1085,10 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return YES;
 }
 
-- (BOOL)updateReference:(PBGitRef *)ref toPointAtCommit:(PBGitCommit *)newCommit error:(NSError **)error {
+- (BOOL)updateReference:(PBGitRef *)ref toPointAtCommit:(PBGitCommit *)newCommit error:(NSError **)error
+{
 	NSError *gitError = nil;
-	BOOL success = [self launchTaskWithArguments:@[@"update-ref", @"-mUpdate from GitX", ref.ref, newCommit.SHA] error:&gitError];
+	BOOL success = [self launchTaskWithArguments:@[ @"update-ref", @"-mUpdate from GitX", ref.ref, newCommit.SHA ] error:&gitError];
 	if (!success) {
 		NSString *title = NSLocalizedString(@"Reference update failed", @"Reference update failure - error title");
 		NSString *message = NSLocalizedString(@"The reference %@ couldn't be update", @"Reference update failure - error message");
@@ -1116,15 +1117,18 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 
 #pragma mark Hooks
 
-- (BOOL)executeHook:(NSString *)name error:(NSError **)error {
+- (BOOL)executeHook:(NSString *)name error:(NSError **)error
+{
 	return [self executeHook:name arguments:@[] error:error];
 }
 
-- (BOOL)executeHook:(NSString *)name arguments:(NSArray *)arguments error:(NSError **)error {
+- (BOOL)executeHook:(NSString *)name arguments:(NSArray *)arguments error:(NSError **)error
+{
 	return [self executeHook:name arguments:arguments output:NULL error:error];
 }
 
-- (BOOL)executeHook:(NSString *)name arguments:(NSArray *)arguments output:(NSString **)outputPtr error:(NSError **)error {
+- (BOOL)executeHook:(NSString *)name arguments:(NSArray *)arguments output:(NSString **)outputPtr error:(NSError **)error
+{
 	NSParameterAssert(name != nil);
 
 	NSString *hookPath = [[[[self gitURL] path] stringByAppendingPathComponent:@"hooks"] stringByAppendingPathComponent:name];
@@ -1135,9 +1139,9 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 
 	PBTask *task = [PBTask taskWithLaunchPath:hookPath arguments:arguments inDirectory:self.workingDirectory];
 	task.additionalEnvironment = @{
-								   @"GIT_DIR": self.gitURL.path,
-								   @"GIT_INDEX_FILE": [self.gitURL.path stringByAppendingPathComponent:@"index"],
-								   };
+		@"GIT_DIR" : self.gitURL.path,
+		@"GIT_INDEX_FILE" : [self.gitURL.path stringByAppendingPathComponent:@"index"],
+	};
 
 	NSError *taskError = nil;
 	BOOL success = [task launchTask:&taskError];
@@ -1152,7 +1156,7 @@ NSString * const PBHookNameErrorKey = @"PBHookNameErrorKey";
 			} else {
 				failureReason = [NSString localizedStringWithFormat:NSLocalizedString(@"The %@ hook reported an error and returned the following:\n%@", @"Hook execution error - failure reason (with output)"), name, output];
 			}
-			return [NSError pb_errorWithDescription:desc failureReason:failureReason underlyingError:taskError userInfo:@{PBHookNameErrorKey:name}];
+			return [NSError pb_errorWithDescription:desc failureReason:failureReason underlyingError:taskError userInfo:@{PBHookNameErrorKey : name}];
 		});
 	}
 

--- a/Classes/git/PBGitRepositoryWatcher.h
+++ b/Classes/git/PBGitRepositoryWatcher.h
@@ -29,9 +29,9 @@ extern NSString *kPBGitRepositoryEventPathsUserInfoKey;
 
 @property (readonly, weak) PBGitRepository *repository;
 
-- (instancetype) initWithRepository:(PBGitRepository *)repository;
-- (void) start;
-- (void) stop;
+- (instancetype)initWithRepository:(PBGitRepository *)repository;
+- (void)start;
+- (void)stop;
 
 @end
 

--- a/Classes/git/PBGitRepositoryWatcher.m
+++ b/Classes/git/PBGitRepositoryWatcher.m
@@ -39,8 +39,8 @@ typedef void (^PBGitRepositoryWatcherCallbackBlock)(NSArray *changedFiles);
 
 @property (nonatomic, strong) NSMutableDictionary *statusCache;
 
-- (void) handleGitDirEventCallback:(NSArray *)eventPaths;
-- (void) handleWorkDirEventCallback:(NSArray *)eventPaths;
+- (void)handleGitDirEventCallback:(NSArray *)eventPaths;
+- (void)handleWorkDirEventCallback:(NSArray *)eventPaths;
 
 @end
 
@@ -49,12 +49,13 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 									size_t numEvents,
 									void *_eventPaths,
 									const FSEventStreamEventFlags eventFlags[],
-									const FSEventStreamEventId eventIds[]){
+									const FSEventStreamEventId eventIds[])
+{
 	PBGitRepositoryWatcher *watcher = (__bridge PBGitRepositoryWatcher *)clientCallBackInfo;
 
 	NSMutableArray *gitDirEvents = [NSMutableArray array];
 	NSMutableArray *workDirEvents = [NSMutableArray array];
-	NSArray *eventPaths = (__bridge NSArray*)_eventPaths;
+	NSArray *eventPaths = (__bridge NSArray *)_eventPaths;
 	for (int i = 0; i < numEvents; ++i) {
 		NSString *path = [eventPaths objectAtIndex:i];
 		PBGitRepositoryWatcherEventPath *ep = [[PBGitRepositoryWatcherEventPath alloc] init];
@@ -83,23 +84,25 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 
 @implementation PBGitRepositoryWatcher
 
-- (instancetype) initWithRepository:(PBGitRepository *)theRepository {
+- (instancetype)initWithRepository:(PBGitRepository *)theRepository
+{
 	NSParameterAssert(theRepository != nil);
 
-    self = [super init];
-    if (!self) {
-        return nil;
+	self = [super init];
+	if (!self) {
+		return nil;
 	}
 
 	_repository = theRepository;
 	_statusCache = [NSMutableDictionary new];
-	
+
 	if ([PBGitDefaults useRepositoryWatcher])
 		[self start];
 	return self;
 }
 
-- (void)dealloc {
+- (void)dealloc
+{
 	if (eventStream) {
 		FSEventStreamStop(eventStream);
 		FSEventStreamInvalidate(eventStream);
@@ -107,24 +110,25 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 	}
 }
 
-- (NSDate *) fileModificationDateAtPath:(NSString *)path {
-	NSError* error;
-    NSDictionary *attrs = [[NSFileManager defaultManager] attributesOfItemAtPath:path
+- (NSDate *)fileModificationDateAtPath:(NSString *)path
+{
+	NSError *error;
+	NSDictionary *attrs = [[NSFileManager defaultManager] attributesOfItemAtPath:path
 																		   error:&error];
-	if (error)
-	{
+	if (error) {
 		NSLog(@"Unable to get attributes of \"%@\"", path);
 		return nil;
 	}
 	return [attrs objectForKey:NSFileModificationDate];
 }
 
-- (BOOL) indexChanged {
+- (BOOL)indexChanged
+{
 	if (self.repository.isBareRepository) {
 		return NO;
 	}
-	
-    NSDate *newTouchDate = [self fileModificationDateAtPath:[self.gitDir stringByAppendingPathComponent:@"index"]];
+
+	NSDate *newTouchDate = [self fileModificationDateAtPath:[self.gitDir stringByAppendingPathComponent:@"index"]];
 	if (![newTouchDate isEqual:indexTouchDate]) {
 		indexTouchDate = newTouchDate;
 		return YES;
@@ -133,15 +137,14 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 	return NO;
 }
 
-- (BOOL) gitDirectoryChanged {
-
-	NSArray *properties = @[NSURLIsDirectoryKey, NSURLContentModificationDateKey];
-	NSArray <NSURL *> *urls = [[NSFileManager defaultManager] contentsOfDirectoryAtURL:self.repository.gitURL
-															 includingPropertiesForKeys:properties
-																				options:0
-																				  error:nil];
-	for (NSURL *fileURL in urls)
-	{
+- (BOOL)gitDirectoryChanged
+{
+	NSArray *properties = @[ NSURLIsDirectoryKey, NSURLContentModificationDateKey ];
+	NSArray<NSURL *> *urls = [[NSFileManager defaultManager] contentsOfDirectoryAtURL:self.repository.gitURL
+														   includingPropertiesForKeys:properties
+																			  options:0
+																				error:nil];
+	for (NSURL *fileURL in urls) {
 		NSNumber *number = nil;
 		if (![fileURL getResourceValue:&number forKey:NSURLIsDirectoryKey error:nil] || [number boolValue]) {
 			continue;
@@ -150,34 +153,33 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 		NSDate *modTime = nil;
 		if (![fileURL getResourceValue:&modTime forKey:NSURLContentModificationDateKey error:nil])
 			continue;
-		
-		if (gitDirTouchDate == nil || [modTime compare:gitDirTouchDate] == NSOrderedDescending)
-		{
-			NSDate* newModTime = [modTime laterDate:gitDirTouchDate];
-			
+
+		if (gitDirTouchDate == nil || [modTime compare:gitDirTouchDate] == NSOrderedDescending) {
+			NSDate *newModTime = [modTime laterDate:gitDirTouchDate];
+
 			gitDirTouchDate = newModTime;
 			return YES;
 		}
 	}
-    return NO;
+	return NO;
 }
 
-- (void) handleGitDirEventCallback:(NSArray *)eventPaths
+- (void)handleGitDirEventCallback:(NSArray *)eventPaths
 {
 	PBGitRepositoryWatcherEventType event = 0x0;
-	
+
 	if ([self indexChanged]) {
 		event |= PBGitRepositoryWatcherEventTypeIndex;
 	}
 
 
-    NSMutableArray *paths = [NSMutableArray array];
+	NSMutableArray *paths = [NSMutableArray array];
 	for (PBGitRepositoryWatcherEventPath *eventPath in eventPaths) {
 		// .git dir
 		if ([eventPath.path isEqualToString:self.gitDir]) {
 			if ([self gitDirectoryChanged] || eventPath.flag != kFSEventStreamEventFlagNone) {
 				event |= PBGitRepositoryWatcherEventTypeGitDirectory;
-                [paths addObject:eventPath.path];
+				[paths addObject:eventPath.path];
 			}
 		}
 		// ignore objects dir  ... ?
@@ -191,13 +193,13 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 		// subdirs of .git dir
 		else if ([eventPath.path rangeOfString:self.gitDir].location != NSNotFound) {
 			event |= PBGitRepositoryWatcherEventTypeGitDirectory;
-            [paths addObject:eventPath.path];
+			[paths addObject:eventPath.path];
 		}
 	}
-	
-	if(event != 0x0){
-		NSDictionary *eventInfo = @{kPBGitRepositoryEventTypeUserInfoKey:@(event),
-							  kPBGitRepositoryEventPathsUserInfoKey:paths};
+
+	if (event != 0x0) {
+		NSDictionary *eventInfo = @{kPBGitRepositoryEventTypeUserInfoKey : @(event),
+									kPBGitRepositoryEventPathsUserInfoKey : paths};
 
 		[[NSNotificationCenter defaultCenter] postNotificationName:PBGitRepositoryEventNotification object:self.repository userInfo:eventInfo];
 	}
@@ -207,7 +209,7 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 {
 	PBGitRepositoryWatcherEventType event = 0x0;
 
-    NSMutableArray *paths = [NSMutableArray array];
+	NSMutableArray *paths = [NSMutableArray array];
 	for (PBGitRepositoryWatcherEventPath *eventPath in eventPaths) {
 		unsigned int fileStatus = 0;
 		if (![eventPath.path hasPrefix:self.workDir]) {
@@ -239,23 +241,26 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 		}
 	}
 
-	if(event != 0x0){
-		NSDictionary *eventInfo = @{kPBGitRepositoryEventTypeUserInfoKey:@(event),
-							  kPBGitRepositoryEventPathsUserInfoKey:paths};
+	if (event != 0x0) {
+		NSDictionary *eventInfo = @{kPBGitRepositoryEventTypeUserInfoKey : @(event),
+									kPBGitRepositoryEventPathsUserInfoKey : paths};
 
 		[[NSNotificationCenter defaultCenter] postNotificationName:PBGitRepositoryEventNotification object:self.repository userInfo:eventInfo];
 	}
 }
 
-- (NSString *)gitDir {
+- (NSString *)gitDir
+{
 	return [self.repository.gtRepo.gitDirectoryURL.path stringByStandardizingPath];
 }
 
-- (NSString *)workDir {
+- (NSString *)workDir
+{
 	return !self.repository.gtRepo.isBare ? [self.repository.gtRepo.fileURL.path stringByStandardizingPath] : nil;
 }
 
-- (void) _initializeStream {
+- (void)_initializeStream
+{
 	if (eventStream) return;
 
 	NSMutableArray *array = [NSMutableArray array];
@@ -266,15 +271,16 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 
 	FSEventStreamContext gitDirWatcherContext = {0, (__bridge void *)(self), NULL, NULL, NULL};
 	eventStream = FSEventStreamCreate(kCFAllocatorDefault, PBGitRepositoryWatcherCallback, &gitDirWatcherContext,
-											(__bridge CFArrayRef)array,
-											kFSEventStreamEventIdSinceNow, 1.0,
-											kFSEventStreamCreateFlagUseCFTypes |
-											kFSEventStreamCreateFlagIgnoreSelf |
-											kFSEventStreamCreateFlagFileEvents);
+									  (__bridge CFArrayRef)array,
+									  kFSEventStreamEventIdSinceNow, 1.0,
+									  kFSEventStreamCreateFlagUseCFTypes |
+										  kFSEventStreamCreateFlagIgnoreSelf |
+										  kFSEventStreamCreateFlagFileEvents);
 }
 
-- (void) start {
-    if (_running)
+- (void)start
+{
+	if (_running)
 		return;
 
 	// set initial state
@@ -290,8 +296,9 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 	_running = YES;
 }
 
-- (void) stop {
-    if (!_running)
+- (void)stop
+{
+	if (!_running)
 		return;
 
 	if (eventStream) {

--- a/Classes/git/PBGitRepository_PBGitBinarySupport.m
+++ b/Classes/git/PBGitRepository_PBGitBinarySupport.m
@@ -15,7 +15,7 @@
 
 - (PBTask *)taskWithArguments:(NSArray *)arguments
 {
-	NSArray *realArgs = @[[@"--git-dir=" stringByAppendingString:self.gitURL.path]];
+	NSArray *realArgs = @[ [@"--git-dir=" stringByAppendingString:self.gitURL.path] ];
 
 	// Prepend a --git-dir argument in case we're running against a bare repository
 	realArgs = [realArgs arrayByAddingObjectsFromArray:arguments];
@@ -59,39 +59,39 @@
 
 @implementation PBGitRepository (PBGitBinarySupportDeprecated)
 
-- (NSString*) outputForCommand:(NSString *)cmd
+- (NSString *)outputForCommand:(NSString *)cmd
 {
-	NSArray* arguments = [cmd componentsSeparatedByString:@" "];
+	NSArray *arguments = [cmd componentsSeparatedByString:@" "];
 	return [self outputForArguments:arguments inputString:nil byExtendingEnvironment:nil retValue:NULL];
 }
 
-- (NSString*) outputForCommand:(NSString *)str retValue:(int *)ret;
+- (NSString *)outputForCommand:(NSString *)str retValue:(int *)ret;
 {
-	NSArray* arguments = [str componentsSeparatedByString:@" "];
+	NSArray *arguments = [str componentsSeparatedByString:@" "];
 	return [self outputForArguments:arguments inputString:nil byExtendingEnvironment:nil retValue:ret];
 }
 
-- (NSString*) outputForArguments:(NSArray*) arguments
-{
-	return [self outputForArguments:arguments inputString:nil byExtendingEnvironment:nil retValue:NULL];
-}
-
-- (NSString*) outputInWorkdirForArguments:(NSArray*) arguments
+- (NSString *)outputForArguments:(NSArray *)arguments
 {
 	return [self outputForArguments:arguments inputString:nil byExtendingEnvironment:nil retValue:NULL];
 }
 
-- (NSString*) outputInWorkdirForArguments:(NSArray *)arguments retValue:(int *)ret
+- (NSString *)outputInWorkdirForArguments:(NSArray *)arguments
+{
+	return [self outputForArguments:arguments inputString:nil byExtendingEnvironment:nil retValue:NULL];
+}
+
+- (NSString *)outputInWorkdirForArguments:(NSArray *)arguments retValue:(int *)ret
 {
 	return [self outputForArguments:arguments inputString:nil byExtendingEnvironment:nil retValue:ret];
 }
 
-- (NSString*) outputForArguments:(NSArray *)arguments retValue:(int *)ret
+- (NSString *)outputForArguments:(NSArray *)arguments retValue:(int *)ret
 {
 	return [self outputForArguments:arguments inputString:nil byExtendingEnvironment:nil retValue:ret];
 }
 
-- (NSString*) outputForArguments:(NSArray *)arguments inputString:(NSString *)input retValue:(int *)ret
+- (NSString *)outputForArguments:(NSArray *)arguments inputString:(NSString *)input retValue:(int *)ret
 {
 	return [self outputForArguments:arguments inputString:input byExtendingEnvironment:nil retValue:ret];
 }

--- a/Classes/git/PBGitRevList.h
+++ b/Classes/git/PBGitRevList.h
@@ -17,8 +17,8 @@
 @property (nonatomic, assign, getter=isParsing, readonly) BOOL parsing;
 @property (nonatomic, strong) NSMutableArray<PBGitCommit *> *commits;
 
-- (id) initWithRepository:(PBGitRepository *)repo rev:(PBGitRevSpecifier *)rev shouldGraph:(BOOL)graph;
-- (void)loadRevisionsWithCompletionBlock:(void(^)(void))completionBlock;
+- (id)initWithRepository:(PBGitRepository *)repo rev:(PBGitRevSpecifier *)rev shouldGraph:(BOOL)graph;
+- (void)loadRevisionsWithCompletionBlock:(void (^)(void))completionBlock;
 - (void)cancel;
 
 @end

--- a/Classes/git/PBGitRevSpecifier.h
+++ b/Classes/git/PBGitRevSpecifier.h
@@ -9,32 +9,32 @@
 #import <Cocoa/Cocoa.h>
 @class PBGitRef;
 
-@interface PBGitRevSpecifier : NSObject  <NSCopying> {
+@interface PBGitRevSpecifier : NSObject <NSCopying> {
 	NSString *description;
 	NSArray *parameters;
 	NSURL *workingDirectory;
 	BOOL isSimpleRef;
 }
 
-- (id) initWithParameters:(NSArray *)params description:(NSString *)descrip;
-- (id) initWithParameters:(NSArray*) params;
-- (id) initWithRef: (PBGitRef*) ref;
+- (id)initWithParameters:(NSArray *)params description:(NSString *)descrip;
+- (id)initWithParameters:(NSArray *)params;
+- (id)initWithRef:(PBGitRef *)ref;
 
-- (NSString*) simpleRef;
-- (PBGitRef *) ref;
-- (BOOL) hasPathLimiter;
-- (NSString *) title;
+- (NSString *)simpleRef;
+- (PBGitRef *)ref;
+- (BOOL)hasPathLimiter;
+- (NSString *)title;
 
-- (BOOL) isEqual: (PBGitRevSpecifier*) other;
-- (BOOL) isAllBranchesRev;
-- (BOOL) isLocalBranchesRev;
+- (BOOL)isEqual:(PBGitRevSpecifier *)other;
+- (BOOL)isAllBranchesRev;
+- (BOOL)isLocalBranchesRev;
 
 + (PBGitRevSpecifier *)allBranchesRevSpec;
 + (PBGitRevSpecifier *)localBranchesRevSpec;
 
-@property(retain)   NSString *description;
-@property(readonly) NSArray *parameters;
-@property(retain)   NSURL *workingDirectory;
-@property(readonly) BOOL isSimpleRef;
+@property (retain) NSString *description;
+@property (readonly) NSArray *parameters;
+@property (retain) NSURL *workingDirectory;
+@property (readonly) BOOL isSimpleRef;
 
 @end

--- a/Classes/git/PBGitRevSpecifier.m
+++ b/Classes/git/PBGitRevSpecifier.m
@@ -26,7 +26,7 @@ NS_INLINE BOOL ContainsComplexRefCharSequence(NSString *refString)
 }
 
 // internal designated init
-- (id) initWithParameters:(NSArray *)params description:(NSString *)descrip
+- (id)initWithParameters:(NSArray *)params description:(NSString *)descrip
 {
 	NSParameterAssert(params != nil);
 
@@ -40,40 +40,40 @@ NS_INLINE BOOL ContainsComplexRefCharSequence(NSString *refString)
 	return self;
 }
 
-- (id) initWithParameters:(NSArray *)params
+- (id)initWithParameters:(NSArray *)params
 {
 	return [self initWithParameters:params description:nil];
 }
 
-- (id) initWithRef:(PBGitRef *)ref
+- (id)initWithRef:(PBGitRef *)ref
 {
 	return [self initWithParameters:[NSArray arrayWithObject:ref.ref] description:ref.shortName];
 }
 
-- (id) initWithCoder:(NSCoder *)coder
+- (id)initWithCoder:(NSCoder *)coder
 {
 	return [self initWithParameters:[coder decodeObjectForKey:@"Parameters"] description:[coder decodeObjectForKey:@"Description"]];
 }
 
 + (PBGitRevSpecifier *)allBranchesRevSpec
 {
-    // Using --all here would include refs like refs/notes/commits, which probably isn't what we want.
-	return [[PBGitRevSpecifier alloc] initWithParameters:@[@"--branches", @"--remotes", @"--tags", @"--glob=refs/stash*", @"HEAD"] description:@"All branches"];
+	// Using --all here would include refs like refs/notes/commits, which probably isn't what we want.
+	return [[PBGitRevSpecifier alloc] initWithParameters:@[ @"--branches", @"--remotes", @"--tags", @"--glob=refs/stash*", @"HEAD" ] description:@"All branches"];
 }
 
 + (PBGitRevSpecifier *)localBranchesRevSpec
 {
-	return [[PBGitRevSpecifier alloc] initWithParameters:@[@"--branches", @"HEAD"] description:@"Local branches"];
+	return [[PBGitRevSpecifier alloc] initWithParameters:@[ @"--branches", @"HEAD" ] description:@"Local branches"];
 }
 
-- (NSString*) simpleRef
+- (NSString *)simpleRef
 {
 	if (![self isSimpleRef])
 		return nil;
 	return [parameters objectAtIndex:0];
 }
 
-- (PBGitRef *) ref
+- (PBGitRef *)ref
 {
 	if (![self isSimpleRef])
 		return nil;
@@ -81,7 +81,7 @@ NS_INLINE BOOL ContainsComplexRefCharSequence(NSString *refString)
 	return [PBGitRef refFromString:[self simpleRef]];
 }
 
-- (NSString *) description
+- (NSString *)description
 {
 	if (!description)
 		return [parameters componentsJoinedByString:@" "];
@@ -89,16 +89,16 @@ NS_INLINE BOOL ContainsComplexRefCharSequence(NSString *refString)
 	return description;
 }
 
-- (void) setDescription:(NSString *)newDescription
+- (void)setDescription:(NSString *)newDescription
 {
 	description = newDescription;
 }
 
 
-- (NSString *) title
+- (NSString *)title
 {
 	NSString *title = nil;
-	
+
 	if ([self.description isEqualToString:@"HEAD"])
 		title = @"detached HEAD";
 	else if ([self isSimpleRef])
@@ -111,30 +111,30 @@ NS_INLINE BOOL ContainsComplexRefCharSequence(NSString *refString)
 		title = [self.description substringFromIndex:[@"-- " length]];
 	else
 		title = self.description;
-	
+
 	return [NSString stringWithFormat:@"“%@”", title];
 }
 
-- (BOOL) hasPathLimiter;
+- (BOOL)hasPathLimiter;
 {
-	for (NSString* param in parameters)
+	for (NSString *param in parameters)
 		if ([param isEqualToString:@"--"])
 			return YES;
 	return NO;
 }
 
-- (BOOL) isEqual:(PBGitRevSpecifier *)other
+- (BOOL)isEqual:(PBGitRevSpecifier *)other
 {
 	if ([self isSimpleRef] ^ [other isSimpleRef])
 		return NO;
-	
+
 	if ([self isSimpleRef])
 		return [[[self parameters] objectAtIndex:0] isEqualToString:[other.parameters objectAtIndex:0]];
 
 	return [self.description isEqualToString:other.description];
 }
 
-- (NSUInteger) hash
+- (NSUInteger)hash
 {
 	if ([self isSimpleRef])
 		return [[[self parameters] objectAtIndex:0] hash];
@@ -142,17 +142,17 @@ NS_INLINE BOOL ContainsComplexRefCharSequence(NSString *refString)
 	return [self.description hash];
 }
 
-- (BOOL) isAllBranchesRev
+- (BOOL)isAllBranchesRev
 {
 	return [self isEqual:[PBGitRevSpecifier allBranchesRevSpec]];
 }
 
-- (BOOL) isLocalBranchesRev
+- (BOOL)isLocalBranchesRev
 {
 	return [self isEqual:[PBGitRevSpecifier localBranchesRevSpec]];
 }
 
-- (void) encodeWithCoder:(NSCoder *)coder
+- (void)encodeWithCoder:(NSCoder *)coder
 {
 	[coder encodeObject:description forKey:@"Description"];
 	[coder encodeObject:parameters forKey:@"Parameters"];
@@ -160,11 +160,11 @@ NS_INLINE BOOL ContainsComplexRefCharSequence(NSString *refString)
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    PBGitRevSpecifier *copy = [[[self class] allocWithZone:zone] initWithParameters:[self.parameters copy]];
-    copy.description = [self.description copy];
+	PBGitRevSpecifier *copy = [[[self class] allocWithZone:zone] initWithParameters:[self.parameters copy]];
+	copy.description = [self.description copy];
 	copy.workingDirectory = [self.workingDirectory copy];
 
-    return copy;
+	return copy;
 }
 
 @end

--- a/Classes/git/PBGitSVBranchItem.m
+++ b/Classes/git/PBGitSVBranchItem.m
@@ -18,7 +18,7 @@
 
 - (NSString *)iconName
 {
-    return @"BranchTemplate";
+	return @"BranchTemplate";
 }
 
 @end

--- a/Classes/git/PBGitSVFolderItem.m
+++ b/Classes/git/PBGitSVFolderItem.m
@@ -18,7 +18,7 @@
 
 - (NSString *)iconName
 {
-    return self.isExpanded ? @"FolderTemplate" : @"FolderClosedTemplate";
+	return self.isExpanded ? @"FolderTemplate" : @"FolderClosedTemplate";
 }
 
 @end

--- a/Classes/git/PBGitSVOtherRevItem.m
+++ b/Classes/git/PBGitSVOtherRevItem.m
@@ -19,7 +19,7 @@
 
 - (NSString *)iconName
 {
-    return @"BranchTemplate";
+	return @"BranchTemplate";
 }
 
 @end

--- a/Classes/git/PBGitSVRemoteBranchItem.m
+++ b/Classes/git/PBGitSVRemoteBranchItem.m
@@ -18,7 +18,7 @@
 
 - (NSString *)iconName
 {
-    return @"RemoteBranchTemplate";
+	return @"RemoteBranchTemplate";
 }
 
 @end

--- a/Classes/git/PBGitSVRemoteItem.m
+++ b/Classes/git/PBGitSVRemoteItem.m
@@ -19,7 +19,7 @@
 
 - (NSString *)iconName
 {
-    return @"RemoteTemplate";
+	return @"RemoteTemplate";
 }
 
 - (PBGitRef *)ref

--- a/Classes/git/PBGitSVStageItem.m
+++ b/Classes/git/PBGitSVStageItem.m
@@ -18,7 +18,7 @@
 
 - (NSString *)iconName
 {
-    return @"StageTemplate";
+	return @"StageTemplate";
 }
 
 @end

--- a/Classes/git/PBGitSVStashItem.m
+++ b/Classes/git/PBGitSVStashItem.m
@@ -33,8 +33,9 @@
 	return self;
 }
 
-- (PBGitRef *)ref {
-    return self.stash.ref;
+- (PBGitRef *)ref
+{
+	return self.stash.ref;
 }
 
 @end

--- a/Classes/git/PBGitSVSubmoduleItem.m
+++ b/Classes/git/PBGitSVSubmoduleItem.m
@@ -16,19 +16,19 @@
 
 @implementation PBSourceViewGitSubmoduleItem
 
-+ (instancetype) itemWithSubmodule:(GTSubmodule *)submodule
++ (instancetype)itemWithSubmodule:(GTSubmodule *)submodule
 {
 	return [[self alloc] initWithSubmodule:submodule];
 }
 
 - (instancetype)initWithSubmodule:(GTSubmodule *)submodule
 {
-    self = [self initWithTitle:submodule.name revSpecifier:nil];
+	self = [self initWithTitle:submodule.name revSpecifier:nil];
 	if (!self) return nil;
 
 	_submodule = submodule;
 
-    return self;
+	return self;
 }
 
 - (NSString *)title

--- a/Classes/git/PBGitSVTagItem.m
+++ b/Classes/git/PBGitSVTagItem.m
@@ -18,7 +18,7 @@
 
 - (NSString *)iconName
 {
-    return @"TagTemplate";
+	return @"TagTemplate";
 }
 
 @end

--- a/Classes/git/PBGitStash.m
+++ b/Classes/git/PBGitStash.m
@@ -13,37 +13,37 @@
 
 @implementation PBGitStash
 
--(id)initWithRepository:(PBGitRepository *)repo stashOID:(GTOID *)stashOID index:(NSInteger)index message:(NSString *)message
+- (id)initWithRepository:(PBGitRepository *)repo stashOID:(GTOID *)stashOID index:(NSInteger)index message:(NSString *)message
 {
 	self = [self init];
 	if (!self) return nil;
 
-    _index = index;
-    _message = message;
-    
-    GTRepository * gtRepo = repo.gtRepo;
-    NSError * error = nil;
-    GTCommit * gtCommit = (GTCommit *)[gtRepo lookUpObjectByOID:stashOID objectType:GTObjectTypeCommit error:&error];
-    NSArray * parents = [gtCommit parents];
-    GTCommit * gtIndexCommit = [parents objectAtIndex:1];
-    GTCommit * gtAncestorCommit = [parents objectAtIndex:0];
+	_index = index;
+	_message = message;
 
-    _commit = [[PBGitCommit alloc] initWithRepository:repo andCommit:gtCommit];
-    _indexCommit = [[PBGitCommit alloc] initWithRepository:repo andCommit:gtIndexCommit];
-    _ancestorCommit = [[PBGitCommit alloc] initWithRepository:repo andCommit:gtAncestorCommit];
+	GTRepository *gtRepo = repo.gtRepo;
+	NSError *error = nil;
+	GTCommit *gtCommit = (GTCommit *)[gtRepo lookUpObjectByOID:stashOID objectType:GTObjectTypeCommit error:&error];
+	NSArray *parents = [gtCommit parents];
+	GTCommit *gtIndexCommit = [parents objectAtIndex:1];
+	GTCommit *gtAncestorCommit = [parents objectAtIndex:0];
 
-    return self;
+	_commit = [[PBGitCommit alloc] initWithRepository:repo andCommit:gtCommit];
+	_indexCommit = [[PBGitCommit alloc] initWithRepository:repo andCommit:gtIndexCommit];
+	_ancestorCommit = [[PBGitCommit alloc] initWithRepository:repo andCommit:gtAncestorCommit];
+
+	return self;
 }
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"stash@{%zd}: %@", _index, _message];
+	return [NSString stringWithFormat:@"stash@{%zd}: %@", _index, _message];
 }
 
 - (PBGitRef *)ref
 {
-    NSString * refStr = [NSString stringWithFormat:@"refs/stash@{%zd}", _index];
-    return [[PBGitRef alloc] initWithString:refStr];
+	NSString *refStr = [NSString stringWithFormat:@"refs/stash@{%zd}", _index];
+	return [[PBGitRef alloc] initWithString:refStr];
 }
 
 @end

--- a/Classes/git/PBGitTree.h
+++ b/Classes/git/PBGitTree.h
@@ -13,33 +13,33 @@
 @interface PBGitTree : NSObject {
 	long long _fileSize;
 
-	NSString* sha;
-	NSString* path;
-	NSArray* children;
+	NSString *sha;
+	NSString *path;
+	NSArray *children;
 	BOOL leaf;
 
-	NSString* localFileName;
-	NSDate* localMtime;
+	NSString *localFileName;
+	NSDate *localMtime;
 }
 
-+ (PBGitTree*) rootForCommit: (id) commit;
-+ (PBGitTree*) treeForTree: (PBGitTree*) tree andPath: (NSString*) path;
-- (void) saveToFolder: (NSString *) directory;
++ (PBGitTree *)rootForCommit:(id)commit;
++ (PBGitTree *)treeForTree:(PBGitTree *)tree andPath:(NSString *)path;
+- (void)saveToFolder:(NSString *)directory;
 - (NSString *)textContents;
 - (NSString *)blame;
-- (NSString *) log:(NSString *)format;
+- (NSString *)log:(NSString *)format;
 
-- (NSString*) tmpFileNameForContents;
+- (NSString *)tmpFileNameForContents;
 - (long long)fileSize;
 
-@property(copy) NSString* sha;
-@property(copy) NSString* path;
-@property(assign) BOOL leaf;
-@property(nonatomic, weak) PBGitRepository* repository;
-@property(nonatomic, weak) PBGitTree* parent;
+@property (copy) NSString *sha;
+@property (copy) NSString *path;
+@property (assign) BOOL leaf;
+@property (nonatomic, weak) PBGitRepository *repository;
+@property (nonatomic, weak) PBGitTree *parent;
 
-@property(readonly) NSArray* children;
-@property(readonly) NSString* fullPath;
-@property(readonly) NSString* contents;
+@property (readonly) NSArray *children;
+@property (readonly) NSString *fullPath;
+@property (readonly) NSString *contents;
 
 @end

--- a/Classes/git/PBGitXProtocol.h
+++ b/Classes/git/PBGitXProtocol.h
@@ -19,4 +19,3 @@
 @interface NSMutableURLRequest (PBGitXProtocol)
 @property (nonatomic, strong) PBGitRepository *repository;
 @end
-

--- a/Classes/git/PBGitXProtocol.m
+++ b/Classes/git/PBGitXProtocol.m
@@ -17,7 +17,7 @@
 
 @implementation PBGitXProtocol
 
-+ (BOOL) canInitWithRequest:(NSURLRequest *)request
++ (BOOL)canInitWithRequest:(NSURLRequest *)request
 {
 	NSString *URLScheme = request.URL.scheme;
 	if ([[URLScheme lowercaseString] isEqualToString:@"gitx"])
@@ -28,21 +28,21 @@
 
 + (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request
 {
-    return request;
+	return request;
 }
 
--(void)startLoading
+- (void)startLoading
 {
-    NSURL *url = [[self request] URL];
+	NSURL *url = [[self request] URL];
 	PBGitRepository *repo = [[self request] repository];
 
 	if (!repo) {
 		[[self client] URLProtocol:self didFailWithError:[NSError errorWithDomain:NSURLErrorDomain code:0 userInfo:nil]];
 		return;
-    }
+	}
 
 	NSString *specifier = [NSString stringWithFormat:@"%@:%@", [url host], [[url path] substringFromIndex:1]];
-	_task = [repo taskWithArguments:@[@"cat-file", @"blob", specifier]];
+	_task = [repo taskWithArguments:@[ @"cat-file", @"blob", specifier ]];
 	[_task performTaskWithCompletionHandler:^(NSData *readData, NSError *error) {
 		if (error) {
 			[[self client] URLProtocol:self didFailWithError:error];
@@ -53,17 +53,17 @@
 		[[self client] URLProtocolDidFinishLoading:self];
 	}];
 
-    NSURLResponse *response = [[NSURLResponse alloc] initWithURL:[[self request] URL]
+	NSURLResponse *response = [[NSURLResponse alloc] initWithURL:[[self request] URL]
 														MIMEType:nil
 										   expectedContentLength:-1
 												textEncodingName:nil];
 
-    [[self client] URLProtocol:self
+	[[self client] URLProtocol:self
 			didReceiveResponse:response
 			cacheStoragePolicy:NSURLCacheStorageNotAllowed];
 }
 
-- (void) stopLoading
+- (void)stopLoading
 {
 	[_task terminate];
 }
@@ -73,7 +73,7 @@
 @implementation NSURLRequest (PBGitXProtocol)
 @dynamic repository;
 
-- (PBGitRepository *) repository
+- (PBGitRepository *)repository
 {
 	return [NSURLProtocol propertyForKey:@"PBGitRepository" inRequest:self];
 }
@@ -82,7 +82,7 @@
 @implementation NSMutableURLRequest (PBGitXProtocol)
 @dynamic repository;
 
-- (void) setRepository:(PBGitRepository *)repository
+- (void)setRepository:(PBGitRepository *)repository
 {
 	[NSURLProtocol setProperty:repository forKey:@"PBGitRepository" inRequest:self];
 }

--- a/Classes/git/PBRepositoryFinder.h
+++ b/Classes/git/PBRepositoryFinder.h
@@ -11,7 +11,7 @@
 @interface PBRepositoryFinder : NSObject
 
 + (NSURL *)fileURLForURL:(NSURL *)inputURL;
-+ (NSURL*)workDirForURL:(NSURL*)fileURL;
-+ (NSURL*)gitDirForURL:(NSURL*)fileURL;
++ (NSURL *)workDirForURL:(NSURL *)fileURL;
++ (NSURL *)gitDirForURL:(NSURL *)fileURL;
 
 @end

--- a/Classes/git/PBRepositoryFinder.m
+++ b/Classes/git/PBRepositoryFinder.m
@@ -12,72 +12,71 @@
 
 + (NSURL *)workDirForURL:(NSURL *)fileURL;
 {
-  if (!fileURL.isFileURL) {
-    return nil;
-  }
+	if (!fileURL.isFileURL) {
+		return nil;
+	}
 
-  git_repository *repo = NULL;
-  git_repository_open_ext(&repo, fileURL.path.UTF8String, GIT_REPOSITORY_OPEN_CROSS_FS, NULL);
-  if (!repo) {
-    return NULL;
-  }
+	git_repository *repo = NULL;
+	git_repository_open_ext(&repo, fileURL.path.UTF8String, GIT_REPOSITORY_OPEN_CROSS_FS, NULL);
+	if (!repo) {
+		return NULL;
+	}
 
-  const char *workdir = git_repository_workdir(repo);
-  NSURL *result = nil;
-  if (workdir) {
-    result = [NSURL fileURLWithPath:[NSString stringWithUTF8String:workdir]];
-  }
+	const char *workdir = git_repository_workdir(repo);
+	NSURL *result = nil;
+	if (workdir) {
+		result = [NSURL fileURLWithPath:[NSString stringWithUTF8String:workdir]];
+	}
 
-  git_repository_free(repo); repo = nil;
-  return result;
+	git_repository_free(repo);
+	repo = nil;
+	return result;
 }
 
 + (NSURL *)gitDirForURL:(NSURL *)fileURL
 {
-  if (!fileURL.isFileURL)
-  {
-    return nil;
-  }
-  git_buf path_buffer = {NULL, 0, 0};
-  int gitResult = git_repository_discover(&path_buffer,
-                                          [fileURL.path UTF8String],
-                                          GIT_REPOSITORY_OPEN_CROSS_FS,
-                                          nil);
+	if (!fileURL.isFileURL) {
+		return nil;
+	}
+	git_buf path_buffer = {NULL, 0, 0};
+	int gitResult = git_repository_discover(&path_buffer,
+											[fileURL.path UTF8String],
+											GIT_REPOSITORY_OPEN_CROSS_FS,
+											nil);
 
-  NSData *repoPathBuffer = nil;
-  if (path_buffer.ptr) {
-    repoPathBuffer = [NSData dataWithBytes:path_buffer.ptr length:path_buffer.asize];
-    git_buf_free(&path_buffer);
-  }
+	NSData *repoPathBuffer = nil;
+	if (path_buffer.ptr) {
+		repoPathBuffer = [NSData dataWithBytes:path_buffer.ptr length:path_buffer.asize];
+		git_buf_free(&path_buffer);
+	}
 
-  if (gitResult == GIT_OK && repoPathBuffer.length)
-  {
-    NSString* repoPath = [NSString stringWithUTF8String:repoPathBuffer.bytes];
-    BOOL isDirectory;
-    if ([[NSFileManager defaultManager] fileExistsAtPath:repoPath
-                                             isDirectory:&isDirectory] && isDirectory)
-    {
-      NSURL* result = [NSURL fileURLWithPath:repoPath
-                                 isDirectory:isDirectory];
-      return result;
-    }
-  }
-  return nil;
+	if (gitResult == GIT_OK && repoPathBuffer.length) {
+		NSString *repoPath = [NSString stringWithUTF8String:repoPathBuffer.bytes];
+		BOOL isDirectory;
+		if ([[NSFileManager defaultManager] fileExistsAtPath:repoPath
+												 isDirectory:&isDirectory] &&
+			isDirectory) {
+			NSURL *result = [NSURL fileURLWithPath:repoPath
+									   isDirectory:isDirectory];
+			return result;
+		}
+	}
+	return nil;
 }
 
 + (NSURL *)fileURLForURL:(NSURL *)inputURL
 {
-  NSURL* gitDir = [self gitDirForURL:inputURL];
-  if (!gitDir) {
-    return nil; // not a Git directory at all
-  }
+	NSURL *gitDir = [self gitDirForURL:inputURL];
+	if (!gitDir) {
+		return nil; // not a Git directory at all
+	}
 
-  NSURL *workDir = [self workDirForURL:inputURL];
-  if (workDir) {
-    return workDir; // root of this working copy or deepest submodule
-  }
+	NSURL *workDir = [self workDirForURL:inputURL];
+	if (workDir) {
+		return workDir; // root of this working copy or deepest submodule
+	}
 
-  return gitDir; // bare repo
+	return gitDir; // bare repo
 }
 
 @end

--- a/Classes/git/PBSourceViewFolderItem.m
+++ b/Classes/git/PBSourceViewFolderItem.m
@@ -18,7 +18,7 @@
 
 - (NSString *)iconName
 {
-    return self.isExpanded ? @"FolderTemplate" : @"FolderClosedTemplate";
+	return self.isExpanded ? @"FolderTemplate" : @"FolderClosedTemplate";
 }
 
 @end

--- a/Classes/git/PBSourceViewGitBranchItem.m
+++ b/Classes/git/PBSourceViewGitBranchItem.m
@@ -18,7 +18,7 @@
 
 - (NSString *)iconName
 {
-    return @"BranchTemplate";
+	return @"BranchTemplate";
 }
 
 @end

--- a/Classes/git/PBSourceViewGitRemoteBranchItem.m
+++ b/Classes/git/PBSourceViewGitRemoteBranchItem.m
@@ -18,7 +18,7 @@
 
 - (NSString *)iconName
 {
-    return @"RemoteBranchTemplate";
+	return @"RemoteBranchTemplate";
 }
 
 @end

--- a/Classes/git/PBSourceViewGitRemoteItem.m
+++ b/Classes/git/PBSourceViewGitRemoteItem.m
@@ -19,7 +19,7 @@
 
 - (NSString *)iconName
 {
-    return @"RemoteTemplate";
+	return @"RemoteTemplate";
 }
 
 - (PBGitRef *)ref

--- a/Classes/git/PBSourceViewGitStashItem.m
+++ b/Classes/git/PBSourceViewGitStashItem.m
@@ -34,8 +34,9 @@
 	return self;
 }
 
-- (PBGitRef *)ref {
-    return self.stash.ref;
+- (PBGitRef *)ref
+{
+	return self.stash.ref;
 }
 
 @end

--- a/Classes/git/PBSourceViewGitSubmoduleItem.m
+++ b/Classes/git/PBSourceViewGitSubmoduleItem.m
@@ -16,19 +16,19 @@
 
 @implementation PBSourceViewGitSubmoduleItem
 
-+ (instancetype) itemWithSubmodule:(GTSubmodule *)submodule
++ (instancetype)itemWithSubmodule:(GTSubmodule *)submodule
 {
 	return [[self alloc] initWithSubmodule:submodule];
 }
 
 - (instancetype)initWithSubmodule:(GTSubmodule *)submodule
 {
-    self = [self initWithTitle:submodule.name revSpecifier:nil];
+	self = [self initWithTitle:submodule.name revSpecifier:nil];
 	if (!self) return nil;
 
 	_submodule = submodule;
 
-    return self;
+	return self;
 }
 
 - (NSString *)title

--- a/Classes/git/PBSourceViewGitTagItem.m
+++ b/Classes/git/PBSourceViewGitTagItem.m
@@ -18,7 +18,7 @@
 
 - (NSString *)iconName
 {
-    return @"TagTemplate";
+	return @"TagTemplate";
 }
 
 @end

--- a/Classes/git/PBSourceViewOtherRevItem.m
+++ b/Classes/git/PBSourceViewOtherRevItem.m
@@ -19,7 +19,7 @@
 
 - (NSString *)iconName
 {
-    return @"BranchTemplate";
+	return @"BranchTemplate";
 }
 
 @end

--- a/Classes/git/PBSourceViewStageItem.m
+++ b/Classes/git/PBSourceViewStageItem.m
@@ -17,7 +17,7 @@
 
 - (NSString *)iconName
 {
-    return @"StageTemplate";
+	return @"StageTemplate";
 }
 
 @end

--- a/Classes/gitx.m
+++ b/Classes/gitx.m
@@ -16,7 +16,6 @@
 
 void usage(char const *programName)
 {
-
 	printf("Usage: %s (--help|--version|--git-path)\n", programName);
 	printf("   or: %s (--commit)\n", programName);
 	printf("   or: %s (--all|--local|--branch) [branch/tag]\n", programName);
@@ -85,7 +84,7 @@ void usage(char const *programName)
 
 void version_info()
 {
-    NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey];
+	NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey];
 	printf("GitX version %s\n", [version UTF8String]);
 	exit(1);
 }
@@ -119,11 +118,11 @@ void handleDiffWithArguments(NSURL *repositoryURL, NSArray *arguments)
 
 void handleOpenRepository(NSURL *repositoryURL, NSArray *arguments)
 {
-    GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
+	GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
 	[gitXApp setSendMode:kAENoReply];
-    [gitXApp open:repositoryURL withOptions:arguments];
+	[gitXApp open:repositoryURL withOptions:arguments];
 	[gitXApp activate];
-    return;
+	return;
 }
 
 void handleInit(NSURL *repositoryURL)
@@ -147,8 +146,7 @@ void handleClone(NSURL *repositoryURL, NSMutableArray *arguments)
 
 		GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
 		[gitXApp cloneRepository:repository to:repositoryURL isBare:NO];
-	}
-	else {
+	} else {
 		printf("Error: --clone needs the URL of the repository to clone.\n");
 		exit(2);
 	}
@@ -190,11 +188,9 @@ PBHistorySearchMode searchModeForCommandLineArgument(NSString *argument)
 
 GitXDocument *documentForURL(SBElementArray *documents, NSURL *theURL)
 {
-	for (GitXDocument *document in documents)
-	{
-		NSURL* docURL = [document file];
-		if ([docURL isEqualTo:theURL])
-		{
+	for (GitXDocument *document in documents) {
+		NSURL *docURL = [document file];
+		if ([docURL isEqualTo:theURL]) {
 			return document;
 		}
 	}
@@ -317,7 +313,7 @@ NSURL *workingDirectoryURL(NSMutableArray *arguments)
 	return [PBRepositoryFinder fileURLForURL:[NSURL fileURLWithPath:workingDirectory]];
 }
 
-int main(int argc, const char** argv)
+int main(int argc, const char **argv)
 {
 	@autoreleasepool {
 		if (argc >= 2 && (!strcmp(argv[1], "--help") || !strcmp(argv[1], "-h")))
@@ -325,9 +321,9 @@ int main(int argc, const char** argv)
 		if (argc >= 2 && (!strcmp(argv[1], "--version") || !strcmp(argv[1], "-v")))
 			version_info();
 		if (argc >= 2 && !strcmp(argv[1], "--git-path")) {
-            printf("gitx now uses libgit2 to work.");
-            exit(1);
-        }
+			printf("gitx now uses libgit2 to work.");
+			exit(1);
+		}
 
 		// gitx can be used to pipe diff output to be displayed in GitX
 		if (!isatty(STDIN_FILENO) && fdopen(STDIN_FILENO, "r"))
@@ -339,25 +335,24 @@ int main(int argc, const char** argv)
 
 		// From this point, we require a working directory and the arguments
 		NSURL *wdURL = workingDirectoryURL(arguments);
-		if (!wdURL)
-		{
+		if (!wdURL) {
 			printf("Could not find a git working directory.\n");
 			exit(0);
 		}
-		
+
 		if ([arguments count]) {
 			NSString *firstArgument = [arguments objectAtIndex:0];
-			
+
 			if ([firstArgument isEqualToString:@"--diff"] || [firstArgument isEqualToString:@"-d"]) {
 				[arguments removeObjectAtIndex:0];
 				handleDiffWithArguments(wdURL, arguments);
 			}
-			
+
 			if ([firstArgument isEqualToString:@"--init"]) {
 				[arguments removeObjectAtIndex:0];
 				handleInit(wdURL);
 			}
-			
+
 			if ([firstArgument isEqualToString:@"--clone"]) {
 				[arguments removeObjectAtIndex:0];
 				handleClone(wdURL, arguments);
@@ -373,10 +368,10 @@ int main(int argc, const char** argv)
 				handleGitXSearch(wdURL, PBHistorySearchModePath, arguments);
 			}
 		}
-		
+
 		// No commands handled by gitx, open the current dir in GitX with the arguments
 		handleOpenRepository(wdURL, arguments);
-		
+
 		return 0;
 	}
 }

--- a/Classes/gitx_askpasswd_main.m
+++ b/Classes/gitx_askpasswd_main.m
@@ -10,25 +10,24 @@
 #include <ApplicationServices/ApplicationServices.h>
 #import <AppKit/AppKit.h>
 
-#define OKBUTTONWIDTH			100.0
-#define OKBUTTONHEIGHT			24.0
-#define CANCELBUTTONWIDTH		100.0
-#define CANCELBUTTONHEIGHT		24.0
-#define	PASSHEIGHT				22.0
-#define	PASSLABELHEIGHT			16.0
-#define WINDOWAUTOSAVENAME		@"GitXAskPasswordWindowFrame"
+#define OKBUTTONWIDTH 100.0
+#define OKBUTTONHEIGHT 24.0
+#define CANCELBUTTONWIDTH 100.0
+#define CANCELBUTTONHEIGHT 24.0
+#define PASSHEIGHT 22.0
+#define PASSLABELHEIGHT 16.0
+#define WINDOWAUTOSAVENAME @"GitXAskPasswordWindowFrame"
 
 
-@interface GAPAppDelegate : NSObject<NSApplicationDelegate>
-{
-	NSPanel*			mPasswordPanel;
-	NSSecureTextField*	mPasswordField;
+@interface GAPAppDelegate : NSObject <NSApplicationDelegate> {
+	NSPanel *mPasswordPanel;
+	NSSecureTextField *mPasswordField;
 }
 
--(NSPanel*)		passwordPanel;
+- (NSPanel *)passwordPanel;
 
--(IBAction)	doOKButton: (id)sender;
--(IBAction)	doCancelButton: (id)sender;
+- (IBAction)doOKButton:(id)sender;
+- (IBAction)doCancelButton:(id)sender;
 
 @end
 
@@ -39,104 +38,104 @@ static const NSInteger kReturnCodeOK = 0;
 static const NSInteger kReturnCodeCancel = 1;
 
 
--(NSPanel*)	passwordPanel
+- (NSPanel *)passwordPanel
 {
-	if( !mPasswordPanel )
-	{
-		NSRect box = NSMakeRect( 100, 100, 400, 134 );
-		mPasswordPanel = [[NSPanel alloc] initWithContentRect: box
-													styleMask: NSTitledWindowMask
-													  backing: NSBackingStoreBuffered defer: NO];
-		[mPasswordPanel setHidesOnDeactivate: NO];
-		[mPasswordPanel setLevel: NSFloatingWindowLevel];
-		[mPasswordPanel setTitle: NSLocalizedString(@"GitX SSH Remote Login", @"Title for password panel in command line tool")];
-        if (![mPasswordPanel setFrameUsingName: WINDOWAUTOSAVENAME]) {
-            [mPasswordPanel center];
-            [mPasswordPanel setFrameAutosaveName: WINDOWAUTOSAVENAME];
-        }
-		
-		box.origin = NSZeroPoint;	// Only need local coords from now on.
-		
+	if (!mPasswordPanel) {
+		NSRect box = NSMakeRect(100, 100, 400, 134);
+		mPasswordPanel = [[NSPanel alloc] initWithContentRect:box
+													styleMask:NSTitledWindowMask
+													  backing:NSBackingStoreBuffered
+														defer:NO];
+		[mPasswordPanel setHidesOnDeactivate:NO];
+		[mPasswordPanel setLevel:NSFloatingWindowLevel];
+		[mPasswordPanel setTitle:NSLocalizedString(@"GitX SSH Remote Login", @"Title for password panel in command line tool")];
+		if (![mPasswordPanel setFrameUsingName:WINDOWAUTOSAVENAME]) {
+			[mPasswordPanel center];
+			[mPasswordPanel setFrameAutosaveName:WINDOWAUTOSAVENAME];
+		}
+
+		box.origin = NSZeroPoint; // Only need local coords from now on.
+
 		// OK:
 		NSRect okBox = box;
-		okBox.origin.x = NSMaxX( box ) -OKBUTTONWIDTH -20;
+		okBox.origin.x = NSMaxX(box) - OKBUTTONWIDTH - 20;
 		okBox.size.width = OKBUTTONWIDTH;
 		okBox.origin.y += 20;
 		okBox.size.height = OKBUTTONHEIGHT;
-		NSButton *okButton = [[NSButton alloc] initWithFrame: okBox];
-		[okButton setTarget: self];
-		[okButton setAction: @selector(doOKButton:)];
-		[okButton setTitle: NSLocalizedString(@"OK", @"OK button for password panel in command line tool")];
-		[okButton setKeyEquivalent: @"\r"];
-		[okButton setBordered: YES];
-		[okButton setBezelStyle: NSRoundedBezelStyle];
-		[[mPasswordPanel contentView] addSubview: okButton];
+		NSButton *okButton = [[NSButton alloc] initWithFrame:okBox];
+		[okButton setTarget:self];
+		[okButton setAction:@selector(doOKButton:)];
+		[okButton setTitle:NSLocalizedString(@"OK", @"OK button for password panel in command line tool")];
+		[okButton setKeyEquivalent:@"\r"];
+		[okButton setBordered:YES];
+		[okButton setBezelStyle:NSRoundedBezelStyle];
+		[[mPasswordPanel contentView] addSubview:okButton];
 
 		// Cancel:
-		NSRect	cancelBox = box;
-		cancelBox.origin.x = NSMinX( okBox ) -CANCELBUTTONWIDTH -6;
+		NSRect cancelBox = box;
+		cancelBox.origin.x = NSMinX(okBox) - CANCELBUTTONWIDTH - 6;
 		cancelBox.size.width = CANCELBUTTONWIDTH;
 		cancelBox.origin.y += 20;
 		cancelBox.size.height = CANCELBUTTONHEIGHT;
-		NSButton *cancleButton = [[NSButton alloc] initWithFrame: cancelBox];
-		[cancleButton setTarget: self];
-		[cancleButton setAction: @selector(doCancelButton:)];
-		[cancleButton setTitle: NSLocalizedString(@"Cancel", @"Cancel button for password panel in command line tool")];
-		[cancleButton setBordered: YES];
-		[cancleButton setBezelStyle: NSRoundedBezelStyle];
-		[[mPasswordPanel contentView] addSubview: cancleButton];
-		
+		NSButton *cancleButton = [[NSButton alloc] initWithFrame:cancelBox];
+		[cancleButton setTarget:self];
+		[cancleButton setAction:@selector(doCancelButton:)];
+		[cancleButton setTitle:NSLocalizedString(@"Cancel", @"Cancel button for password panel in command line tool")];
+		[cancleButton setBordered:YES];
+		[cancleButton setBezelStyle:NSRoundedBezelStyle];
+		[[mPasswordPanel contentView] addSubview:cancleButton];
+
 		// Password field:
 		NSRect passBox = box;
 		passBox.origin.y = NSMaxY(okBox) + 24;
 		passBox.size.height = PASSHEIGHT;
 		passBox.origin.x += 104;
 		passBox.size.width -= 104 + 20;
-		mPasswordField = [[NSSecureTextField alloc] initWithFrame: passBox];
-		[mPasswordField setSelectable: YES];
-		[mPasswordField setEditable: YES];
-		[mPasswordField setBordered: YES];
-		[mPasswordField setBezeled: YES];
-		[mPasswordField setBezelStyle: NSTextFieldSquareBezel];
-		[mPasswordField selectText: self];
-		[[mPasswordPanel contentView] addSubview: mPasswordField];
-		
+		mPasswordField = [[NSSecureTextField alloc] initWithFrame:passBox];
+		[mPasswordField setSelectable:YES];
+		[mPasswordField setEditable:YES];
+		[mPasswordField setBordered:YES];
+		[mPasswordField setBezeled:YES];
+		[mPasswordField setBezelStyle:NSTextFieldSquareBezel];
+		[mPasswordField selectText:self];
+		[[mPasswordPanel contentView] addSubview:mPasswordField];
+
 		// Password label:
 		NSRect passLabelBox = box;
 		passLabelBox.origin.y = NSMaxY(passBox) + 8;
 		passLabelBox.size.height = PASSLABELHEIGHT;
 		passLabelBox.origin.x += 100;
 		passLabelBox.size.width -= 100 + 20;
-		NSTextField *passwordLabel = [[NSTextField alloc] initWithFrame: passLabelBox];
-		[passwordLabel setSelectable: YES];
-		[passwordLabel setEditable: NO];
-		[passwordLabel setBordered: NO];
-		[passwordLabel setBezeled: NO];
-		[passwordLabel setDrawsBackground: NO];
-		[passwordLabel setStringValue: NSLocalizedString(@"Please enter your password:", @"Label for password field in password panel in command line tool")];
-		[[mPasswordPanel contentView] addSubview: passwordLabel];
-		
+		NSTextField *passwordLabel = [[NSTextField alloc] initWithFrame:passLabelBox];
+		[passwordLabel setSelectable:YES];
+		[passwordLabel setEditable:NO];
+		[passwordLabel setBordered:NO];
+		[passwordLabel setBezeled:NO];
+		[passwordLabel setDrawsBackground:NO];
+		[passwordLabel setStringValue:NSLocalizedString(@"Please enter your password:", @"Label for password field in password panel in command line tool")];
+		[[mPasswordPanel contentView] addSubview:passwordLabel];
+
 		// GitX icon:
 		NSRect gitxIconBox = box;
 		gitxIconBox.origin.y = NSMaxY(box) - 78;
 		gitxIconBox.size.height = 64;
 		gitxIconBox.origin.x += 20;
 		gitxIconBox.size.width = 64;
-		NSImageView *gitxIconView = [[NSImageView alloc] initWithFrame: gitxIconBox];
-		[gitxIconView setEditable: NO];
-		NSString *gitxIconPath = [[[NSBundle mainBundle] bundlePath] stringByAppendingPathComponent: @"gitx.icns"];
-		NSImage *gitxIcon = [[NSImage alloc] initWithContentsOfFile: gitxIconPath];
-		[gitxIconView setImage: gitxIcon];
-		[[mPasswordPanel contentView] addSubview: gitxIconView];
+		NSImageView *gitxIconView = [[NSImageView alloc] initWithFrame:gitxIconBox];
+		[gitxIconView setEditable:NO];
+		NSString *gitxIconPath = [[[NSBundle mainBundle] bundlePath] stringByAppendingPathComponent:@"gitx.icns"];
+		NSImage *gitxIcon = [[NSImage alloc] initWithContentsOfFile:gitxIconPath];
+		[gitxIconView setImage:gitxIcon];
+		[[mPasswordPanel contentView] addSubview:gitxIconView];
 	}
-	
+
 	return mPasswordPanel;
 }
 
 
--(IBAction)	doOKButton: (id)sender
+- (IBAction)doOKButton:(id)sender
 {
-	printf( "%s\n", [[mPasswordField stringValue] UTF8String] );
+	printf("%s\n", [[mPasswordField stringValue] UTF8String]);
 	[[NSApplication sharedApplication] stopModalWithCode:kReturnCodeOK];
 }
 
@@ -144,7 +143,7 @@ static const NSInteger kReturnCodeCancel = 1;
 // TODO: Need to find out how to get SSH to cancel.
 //       When the user cancels the window it is opened again for however
 //       many times the remote server allows failed attempts.
--(IBAction)	doCancelButton: (id)sender
+- (IBAction)doCancelButton:(id)sender
 {
 	[[NSApplication sharedApplication] stopModalWithCode:kReturnCodeCancel];
 }
@@ -152,30 +151,28 @@ static const NSInteger kReturnCodeCancel = 1;
 @end
 
 
-
-int	main( int argc, const char** argv )
+int main(int argc, const char **argv)
 {
 	@autoreleasepool {
 		// close stderr to stop cocoa log messages from being picked up by GitX
 		close(STDERR_FILENO);
-		
+
 		NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-		
-		ProcessSerialNumber	myPSN = { 0, kCurrentProcess };
-		TransformProcessType( &myPSN, kProcessTransformToForegroundApplication );
-		
+
+		ProcessSerialNumber myPSN = {0, kCurrentProcess};
+		TransformProcessType(&myPSN, kProcessTransformToForegroundApplication);
+
 		NSApplication *app = [NSApplication sharedApplication];
 		GAPAppDelegate *appDel = [[GAPAppDelegate alloc] init];
-		[app setDelegate: appDel];
+		[app setDelegate:appDel];
 		NSWindow *passPanel = [appDel passwordPanel];
-		
-		[app activateIgnoringOtherApps: YES];
-		[passPanel makeKeyAndOrderFront: nil];
-		NSInteger code = [app runModalForWindow: passPanel];
-		
+
+		[app activateIgnoringOtherApps:YES];
+		[passPanel makeKeyAndOrderFront:nil];
+		NSInteger code = [app runModalForWindow:passPanel];
+
 		[defaults synchronize];
 
 		return code == kReturnCodeOK ? EXIT_SUCCESS : EXIT_FAILURE;
 	}
 }
-

--- a/Classes/iTerm2GeneratedScriptingBridge.h
+++ b/Classes/iTerm2GeneratedScriptingBridge.h
@@ -17,29 +17,28 @@ typedef enum iTerm2SaveOptions iTerm2SaveOptions;
 
 @protocol iTerm2GenericMethods
 
-- (void) delete;  // Delete an object.
-- (void) duplicateTo:(SBObject *)to withProperties:(NSDictionary *)withProperties;  // Copy object(s) and put the copies at a new location.
-- (BOOL) exists;  // Verify if an object exists.
-- (void) moveTo:(SBObject *)to;  // Move object(s) to a new location.
-- (void) close;  // Close a document.
-- (iTerm2Tab *) createTabWithProfile:(NSString *)withProfile command:(NSString *)command;  // Create a new tab
-- (iTerm2Tab *) createTabWithDefaultProfileCommand:(NSString *)command;  // Create a new tab with the default profile
-- (void) writeContentsOfFile:(NSURL *)contentsOfFile text:(NSString *)text newline:(BOOL)newline;  // Send text as though it was typed.
-- (void) select;  // Make receiver visible and selected.
-- (iTerm2Session *) splitVerticallyWithProfile:(NSString *)withProfile command:(NSString *)command;  // Split a session vertically.
-- (iTerm2Session *) splitVerticallyWithDefaultProfileCommand:(NSString *)command;  // Split a session vertically, using the default profile for the new session
-- (iTerm2Session *) splitVerticallyWithSameProfileCommand:(NSString *)command;  // Split a session vertically, using the original session's profile for the new session
-- (iTerm2Session *) splitHorizontallyWithProfile:(NSString *)withProfile command:(NSString *)command;  // Split a session horizontally.
-- (iTerm2Session *) splitHorizontallyWithDefaultProfileCommand:(NSString *)command;  // Split a session horizontally, using the default profile for the new session
-- (iTerm2Session *) splitHorizontallyWithSameProfileCommand:(NSString *)command;  // Split a session horizontally, using the original session's profile for the new session
-- (NSString *) variableNamed:(NSString *)named;  // Returns the value of a session variable with the given name
-- (NSString *) setVariableNamed:(NSString *)named to:(NSString *)to;  // Sets the value of a session variable
-- (void) revealHotkeyWindow;  // Reveals a hotkey window. Only to be called on windows that are hotkey windows.
-- (void) hideHotkeyWindow;  // Hides a hotkey window. Only to be called on windows that are hotkey windows.
-- (void) toggleHotkeyWindow;  // Toggles the visibility of a hotkey window. Only to be called on windows that are hotkey windows.
+- (void)delete;																						 // Delete an object.
+- (void)duplicateTo:(SBObject *)to withProperties:(NSDictionary *)withProperties;					 // Copy object(s) and put the copies at a new location.
+- (BOOL)exists;																						 // Verify if an object exists.
+- (void)moveTo:(SBObject *)to;																		 // Move object(s) to a new location.
+- (void)close;																						 // Close a document.
+- (iTerm2Tab *)createTabWithProfile:(NSString *)withProfile command:(NSString *)command;			 // Create a new tab
+- (iTerm2Tab *)createTabWithDefaultProfileCommand:(NSString *)command;								 // Create a new tab with the default profile
+- (void)writeContentsOfFile:(NSURL *)contentsOfFile text:(NSString *)text newline:(BOOL)newline;	 // Send text as though it was typed.
+- (void)select;																						 // Make receiver visible and selected.
+- (iTerm2Session *)splitVerticallyWithProfile:(NSString *)withProfile command:(NSString *)command;	 // Split a session vertically.
+- (iTerm2Session *)splitVerticallyWithDefaultProfileCommand:(NSString *)command;					 // Split a session vertically, using the default profile for the new session
+- (iTerm2Session *)splitVerticallyWithSameProfileCommand:(NSString *)command;						 // Split a session vertically, using the original session's profile for the new session
+- (iTerm2Session *)splitHorizontallyWithProfile:(NSString *)withProfile command:(NSString *)command; // Split a session horizontally.
+- (iTerm2Session *)splitHorizontallyWithDefaultProfileCommand:(NSString *)command;					 // Split a session horizontally, using the default profile for the new session
+- (iTerm2Session *)splitHorizontallyWithSameProfileCommand:(NSString *)command;						 // Split a session horizontally, using the original session's profile for the new session
+- (NSString *)variableNamed:(NSString *)named;														 // Returns the value of a session variable with the given name
+- (NSString *)setVariableNamed:(NSString *)named to:(NSString *)to;									 // Sets the value of a session variable
+- (void)revealHotkeyWindow;																			 // Reveals a hotkey window. Only to be called on windows that are hotkey windows.
+- (void)hideHotkeyWindow;																			 // Hides a hotkey window. Only to be called on windows that are hotkey windows.
+- (void)toggleHotkeyWindow;																			 // Toggles the visibility of a hotkey window. Only to be called on windows that are hotkey windows.
 
 @end
-
 
 
 /*
@@ -49,49 +48,48 @@ typedef enum iTerm2SaveOptions iTerm2SaveOptions;
 // The application's top-level scripting object.
 @interface iTerm2Application : SBApplication
 
-- (SBElementArray<iTerm2Window *> *) windows;
+- (SBElementArray<iTerm2Window *> *)windows;
 
-@property (copy) iTerm2Window *currentWindow;  // The frontmost window
-@property (copy, readonly) NSString *name;  // The name of the application.
-@property (readonly) BOOL frontmost;  // Is this the frontmost (active) application?
-@property (copy, readonly) NSString *version;  // The version of the application.
+@property (copy) iTerm2Window *currentWindow; // The frontmost window
+@property (copy, readonly) NSString *name;	  // The name of the application.
+@property (readonly) BOOL frontmost;		  // Is this the frontmost (active) application?
+@property (copy, readonly) NSString *version; // The version of the application.
 
-- (iTerm2Window *) createWindowWithProfile:(NSString *)x command:(NSString *)command;  // Create a new window
-- (iTerm2Window *) createHotkeyWindowWithProfile:(NSString *)x;  // Create a hotkey window
-- (iTerm2Window *) createWindowWithDefaultProfileCommand:(NSString *)command;  // Create a new window with the default profile
+- (iTerm2Window *)createWindowWithProfile:(NSString *)x command:(NSString *)command; // Create a new window
+- (iTerm2Window *)createHotkeyWindowWithProfile:(NSString *)x;						 // Create a hotkey window
+- (iTerm2Window *)createWindowWithDefaultProfileCommand:(NSString *)command;		 // Create a new window with the default profile
 
 @end
 
 // A window.
 @interface iTerm2Window : SBObject <iTerm2GenericMethods>
 
-- (SBElementArray<iTerm2Tab *> *) tabs;
+- (SBElementArray<iTerm2Tab *> *)tabs;
 
-- (NSInteger) id;  // The unique identifier of the session.
-@property (copy, readonly) NSString *alternateIdentifier;  // The alternate unique identifier of the session.
-@property (copy, readonly) NSString *name;  // The full title of the window.
-@property NSInteger index;  // The index of the window, ordered front to back.
-@property NSRect bounds;  // The bounding rectangle of the window.
-@property (readonly) BOOL closeable;  // Whether the window has a close box.
-@property (readonly) BOOL miniaturizable;  // Whether the window can be minimized.
-@property BOOL miniaturized;  // Whether the window is currently minimized.
-@property (readonly) BOOL resizable;  // Whether the window can be resized.
-@property BOOL visible;  // Whether the window is currently visible.
-@property (readonly) BOOL zoomable;  // Whether the window can be zoomed.
-@property BOOL zoomed;  // Whether the window is currently zoomed.
-@property BOOL frontmost;  // Whether the window is currently the frontmost window.
-@property (copy) iTerm2Tab *currentTab;  // The currently selected tab
-@property (copy) iTerm2Session *currentSession;  // The current session in a window
-@property BOOL isHotkeyWindow;  // Whether the window is a hotkey window.
-@property (copy) NSString *hotkeyWindowProfile;  // If the window is a hotkey window, this gives the name of the profile that created the window. 
-@property NSPoint position;  // The position of the window, relative to the upper left corner of the screen.
-@property NSPoint origin;  // The position of the window, relative to the lower left corner of the screen.
-@property NSPoint size;  // The width and height of the window
-@property NSRect frame;  // The bounding rectangle, relative to the lower left corner of the screen.
+- (NSInteger)id;										  // The unique identifier of the session.
+@property (copy, readonly) NSString *alternateIdentifier; // The alternate unique identifier of the session.
+@property (copy, readonly) NSString *name;				  // The full title of the window.
+@property NSInteger index;								  // The index of the window, ordered front to back.
+@property NSRect bounds;								  // The bounding rectangle of the window.
+@property (readonly) BOOL closeable;					  // Whether the window has a close box.
+@property (readonly) BOOL miniaturizable;				  // Whether the window can be minimized.
+@property BOOL miniaturized;							  // Whether the window is currently minimized.
+@property (readonly) BOOL resizable;					  // Whether the window can be resized.
+@property BOOL visible;									  // Whether the window is currently visible.
+@property (readonly) BOOL zoomable;						  // Whether the window can be zoomed.
+@property BOOL zoomed;									  // Whether the window is currently zoomed.
+@property BOOL frontmost;								  // Whether the window is currently the frontmost window.
+@property (copy) iTerm2Tab *currentTab;					  // The currently selected tab
+@property (copy) iTerm2Session *currentSession;			  // The current session in a window
+@property BOOL isHotkeyWindow;							  // Whether the window is a hotkey window.
+@property (copy) NSString *hotkeyWindowProfile;			  // If the window is a hotkey window, this gives the name of the profile that created the window.
+@property NSPoint position;								  // The position of the window, relative to the upper left corner of the screen.
+@property NSPoint origin;								  // The position of the window, relative to the lower left corner of the screen.
+@property NSPoint size;									  // The width and height of the window
+@property NSRect frame;									  // The bounding rectangle, relative to the lower left corner of the screen.
 
 
 @end
-
 
 
 /*
@@ -101,10 +99,10 @@ typedef enum iTerm2SaveOptions iTerm2SaveOptions;
 // A terminal tab
 @interface iTerm2Tab : SBObject <iTerm2GenericMethods>
 
-- (SBElementArray<iTerm2Session *> *) sessions;
+- (SBElementArray<iTerm2Session *> *)sessions;
 
-@property (copy) iTerm2Session *currentSession;  // The current session in a tab
-@property NSInteger index;  // Index of tab in parent tab view control
+@property (copy) iTerm2Session *currentSession; // The current session in a tab
+@property NSInteger index;						// Index of tab in parent tab view control
 
 
 @end
@@ -112,14 +110,14 @@ typedef enum iTerm2SaveOptions iTerm2SaveOptions;
 // A terminal session
 @interface iTerm2Session : SBObject <iTerm2GenericMethods>
 
-- (NSString *) id;  // The unique identifier of the session.
-@property BOOL isProcessing;  // The session has received output recently.
-@property BOOL isAtShellPrompt;  // The terminal is at the shell prompt. Requires shell integration.
+- (NSString *)id;				// The unique identifier of the session.
+@property BOOL isProcessing;	// The session has received output recently.
+@property BOOL isAtShellPrompt; // The terminal is at the shell prompt. Requires shell integration.
 @property NSInteger columns;
 @property NSInteger rows;
 @property (copy, readonly) NSString *tty;
-@property (copy) NSString *contents;  // The currently visible contents of the session.
-@property (copy, readonly) NSString *text;  // The currently visible contents of the session.
+@property (copy) NSString *contents;	   // The currently visible contents of the session.
+@property (copy, readonly) NSString *text; // The currently visible contents of the session.
 @property (copy) NSString *colorPreset;
 @property (copy) NSColor *backgroundColor;
 @property (copy) NSColor *boldColor;
@@ -145,14 +143,13 @@ typedef enum iTerm2SaveOptions iTerm2SaveOptions;
 @property (copy) NSColor *ANSIBrightCyanColor;
 @property (copy) NSColor *ANSIBrightWhiteColor;
 @property (copy) NSColor *underlineColor;
-@property BOOL useUnderlineColor;  // Whether the use a dedicated color for underlining.
+@property BOOL useUnderlineColor; // Whether the use a dedicated color for underlining.
 @property (copy) NSString *backgroundImage;
 @property (copy) NSString *name;
 @property double transparency;
 @property (copy, readonly) NSString *uniqueID;
-@property (copy, readonly) NSString *profileName;  // The session's profile name
-@property (copy) NSString *answerbackString;  // ENQ Answerback string
+@property (copy, readonly) NSString *profileName; // The session's profile name
+@property (copy) NSString *answerbackString;	  // ENQ Answerback string
 
 
 @end
-

--- a/Scripts/clang-format.rb
+++ b/Scripts/clang-format.rb
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+
+Dir.glob('Classes/**/*.[chm]') do |file|
+  `clang-format -i #{file}`
+  puts "failed to format file #{file}" if $? != 0
+end


### PR DESCRIPTION
This is an attempt at configuring clang-format in some way that is not too "intrusive" :wink:.

For reference, I wrote a script (which I'll gist) to check what were the current "preferences", with the following results :
```
{:file_count=>200,
 :line_count=>18783,
 :space_indent=>811,
 :tab_indent=>7496,
 :brace_prototype_inline=>86,
 :brace_prototype_wrap=>1444,
 :brace_control_inline=>528,
 :brace_control_wrap=>49,
 :method_prototype_space_after_return_type=>717,
 :method_prototype_no_space_after_return_type=>808}
```

I don't plan on merging that yet, because of a metric ton of commits I have locally, which wouldn't like being reindented. This is just to get the ball rolling.