### PR TITLE
Little fixes to the diff viewer

### DIFF
--- a/Classes/Controllers/PBWebController.m
+++ b/Classes/Controllers/PBWebController.m
@@ -86,8 +86,7 @@
 	if (!self.repository)
 		return request;
 
-	// TODO: Change this to canInitWithRequest
-	if ([[[[request URL] scheme] lowercaseString] isEqualToString:@"gitx"]) {
+	if ([PBGitXProtocol canInitWithRequest:request]) {
 		NSMutableURLRequest *newRequest = [request mutableCopy];
 		[newRequest setRepository:self.repository];
 		return newRequest;

--- a/Classes/git/PBGitXProtocol.m
+++ b/Classes/git/PBGitXProtocol.m
@@ -13,7 +13,11 @@
 
 + (BOOL) canInitWithRequest:(NSURLRequest *)request
 {
-	return [[[[request URL] scheme] lowercaseString] isEqualToString:@"gitx"];
+	NSString *URLScheme = request.URL.scheme;
+	if ([[URLScheme lowercaseString] isEqualToString:@"gitx"])
+		return YES;
+
+	return NO;
 }
 
 + (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request

--- a/Resources/html/lib/diffHighlighter.js
+++ b/Resources/html/lib/diffHighlighter.js
@@ -118,18 +118,25 @@ var highlightDiff = function(diff, element, callbacks) {
 
 		var firstChar = l.charAt(0);
 
-		if (firstChar == "d" && l.charAt(1) == "i") {			// "diff", i.e. new file, we have to reset everything
-			header = true;						// diff always starts with a header
+		if (firstChar == "d" && l.charAt(1) == "i") {
+			// "diff", i.e. new file, we have to reset everything
 
-			finishContent(); // Finish last file
+			// diff always starts with a header
+			header = true;
+
+			// Finish last file
+			finishContent();
 
 			binary = false;
 			mode_change = false;
 
-			if(match = l.match(/^diff --git (a\/)+(.*) (b\/)+(.*)$/)) {	// there are cases when we need to capture filenames from
-				startname = match[2];					// the diff line, like with mode-changes.
-				endname = match[4];					// this can get overwritten later if there is a diff or if
-			}								// the file is binary
+			// there are cases when we need to capture filenames from the diff
+			// line, like with mode-changes. this can get overridden later if
+			// there is a diff or if the file is binary
+			if (match = l.match(/^diff --git ([a-z]\/)+(.*) ([a-z]\/)+(.*)$/)) {
+				startname = match[2];
+				endname = match[4];
+			}
 
 			continue;
 		}
@@ -159,12 +166,12 @@ var highlightDiff = function(diff, element, callbacks) {
 				continue;
 			}
 			if (firstChar == "-") {
-				if (match = l.match(/^--- (a\/)?(.*)$/))
+				if (match = l.match(/^--- ([a-z]\/)?(.*)$/))
 					startname = match[2];
 				continue;
 			}
 			if (firstChar == "+") {
-				if (match = l.match(/^\+\+\+ (b\/)?(.*)$/))
+				if (match = l.match(/^\+\+\+ ([a-z]\/)?(.*)$/))
 					endname = match[2];
 				continue;
 			}
@@ -187,7 +194,7 @@ var highlightDiff = function(diff, element, callbacks) {
 				// We might not have a diff from the binary file if it's new.
 				// So, we use a regex to figure that out
 
-				if (match = l.match(/^Binary files (a\/)?(.*) and (b\/)?(.*) differ$/))
+				if (match = l.match(/^Binary files ([a-z]\/)?(.*) and ([a-z]\/)?(.*) differ$/))
 				{
 					startname = match[2];
 					endname = match[4];

--- a/Resources/html/lib/diffHighlighter.js
+++ b/Resources/html/lib/diffHighlighter.js
@@ -84,39 +84,27 @@ var highlightDiff = function(diff, element, callbacks) {
 		else if (startname != endname)
 			title = startname + " renamed to " + endname;
 		
-		if (binary && endname == "/dev/null") {	// in cases of a deleted binary file, there is no diff/file to display
-			line1 = "";
-			line2 = "";
-			diffContent = "";
-			file_index++;
-			startname = "";
-			endname = "";
-			return;				// so printing the filename in the file-list is enough
-		}
+		// Show file list header
+		finalContent += '<div class="file" id="file_index_' + (file_index - 1) + '">';
+		finalContent += '<div id="title_' + title + '" class="expanded fileHeader"><a href="javascript:toggleDiff(\'' + title + '\');">' + title + '</a></div>';
 
-		if (diffContent != "" || binary) {
-			finalContent += '<div class="file" id="file_index_' + (file_index - 1) + '">' +
-				'<div id="title_' + title + '" class="expanded fileHeader"><a href="javascript:toggleDiff(\'' + title + '\');">' + title + '</a></div>';
-		}
-
-		if (!binary && (diffContent != ""))  {
-			finalContent +=		'<div id="content_' + title + '" class="diffContent">' +
-								'<div class="lineno">' + line1 + "</div>" +
-								'<div class="lineno">' + line2 + "</div>" +
-								'<div class="lines">' + postProcessDiffContents(diffContent).replace(/\t/g, "    ") + "</div>" +
-							'</div>';
-		}
-		else {
-			if (binary) {
-				if (callbacks["binaryFile"])
-					finalContent += callbacks["binaryFile"](binaryname);
-				else
-					finalContent += '<div id="content_' + title + '">Binary file differs</div>';
+		if (binary) {
+			// diffContent is assumed to be empty for binary files
+			if (callbacks["binaryFile"]) {
+				finalContent += callbacks["binaryFile"](binaryname);
+			} else {
+				finalContent += '<div id="content_' + title + '">Binary file differs</div>';
 			}
+		} else if (diffContent != "") {
+			finalContent += '<div id="content_' + title + '" class="diffContent">' +
+				'<div class="lineno">' + line1 + '</div>' +
+				'<div class="lineno">' + line2 + '</div>' +
+				'<div class="lines">' + postProcessDiffContents(diffContent).replace(/\t/g, "    ") + '</div>' +
+			'</div>';
 		}
 
-		if (diffContent != "" || binary)
-			finalContent += '</div>' + linkToTop;
+		// Close div.file
+		finalContent += '</div>' + linkToTop;
 
 		line1 = "";
 		line2 = "";


### PR DESCRIPTION
I found a few issues with the diff viewer, like inline images not working, and some "missing" files info.

The first was that I'm running with diff.mnemonicprefix set, which the diff parser didn't expect.

The second is that files with no diff at all (like simple renames) were skipped when building the HTML.