### PR TITLE
Fixed missing General preferences icon

### DIFF
--- a/Classes/Controllers/PBPrefsWindowController.m
+++ b/Classes/Controllers/PBPrefsWindowController.m
@@ -19,7 +19,7 @@
 - (void)setupToolbar
 {
 	// GENERAL
-	[self addView:generalPrefsView label:@"General" image:[NSImage imageNamed:@"gitx"]];
+	[self addView:generalPrefsView label:@"General" image:[NSImage imageNamed:NSImageNameApplicationIcon]];
 	// INTERGRATION
 	[self addView:integrationPrefsView label:@"Integration" image:[NSImage imageNamed:NSImageNameNetwork]];
 	// UPDATES


### PR DESCRIPTION
The general icon went missing when gitx.icns was removed.