### PR TITLE
Change Amend Commit menu item to use an action instead of bindings

### DIFF
--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -253,6 +253,11 @@
     [self commitWithVerification:NO];
 }
 
+- (IBAction)toggleAmendCommit:(id)sender
+{
+	[[[self repository] index] setAmend:![[[self repository] index] isAmend]];
+}
+
 - (NSArray <PBChangedFile *> *)selectedFilesForSender:(id)sender
 {
 	NSParameterAssert(sender != nil);
@@ -691,6 +696,9 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray <PBChangedFile *> *files)
 			menuItem.hidden = !active;
 		}
 		return active;
+	}
+	else if (menuItem.action == @selector(toggleAmendCommit:)) {
+		menuItem.state = [[[self repository] index] isAmend] ? NSOnState : NSOffState;
 	}
 
 	return menuItem.enabled;

--- a/Resources/English.lproj/MainMenu.xib
+++ b/Resources/English.lproj/MainMenu.xib
@@ -528,7 +528,7 @@ DQ
                             <menuItem title="Amend Commit" keyEquivalent="a" id="W5p-JV-xeS">
                                 <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>
-                                    <binding destination="oqX-ct-wMx" name="value" keyPath="currentDocument.windowController.repository.index.amend" id="qcF-1I-xfx"/>
+                                    <action selector="toggleAmendCommit:" target="-1" id="sQs-hs-7cR"/>
                                 </connections>
                             </menuItem>
                         </items>


### PR DESCRIPTION
Bindings can make the menu item behavior act erratically because the binding state is shared across the app, not per-document.
This also adds a checkmark to the menu item when amending is active.

Steps to reproduce a problem like this:
- Open a repository
- Select Amend Commit to start amending
- Close the repository
- Open the same repository
- Select Amend Commit to start amending again
- This time the menu item sets amend to NO instead of YES, so nothing happens the first time you select the menu item