### PR TITLE
Fixed bug with reading from pipe.

### DIFF
--- a/Classes/Util/PBEasyPipe.m
+++ b/Classes/Util/PBEasyPipe.m
@@ -59,8 +59,6 @@ NSString *const PBEasyPipeUnderlyingExceptionKey = @"PBEasyPipeUnderlyingExcepti
 	NSParameterAssert(command != nil);
 
 	NSTask *task = [self taskForCommand:command arguments:arguments inDirectory:directory];
-	NSPipe *pipe = task.standardOutput;
-	pipe.dataOutput = [NSMutableData data];
 
 	task.terminationHandler = ^(NSTask *task) {
 		dispatch_async(dispatch_get_main_queue(), ^{
@@ -94,9 +92,10 @@ NSString *const PBEasyPipeUnderlyingExceptionKey = @"PBEasyPipeUnderlyingExcepti
 			return;
 		}
 
-		[pipe clear];
+		NSFileHandle * read = [pipe fileHandleForReading];
+		NSData * dataRead = [read readDataToEndOfFile];
 
-		completionHandler(task, pipe.dataOutput, nil);
+		completionHandler(task, dataRead, nil);
 	}];
 }
 


### PR DESCRIPTION
Fixed #106 

Synopsis: Current implementation of PBEasyPipe reads only 4K bytes (probably, depends on some unix defaults) from NSTask reply. In case when we have more than 30 entries in staged/unstaged files, PBGitIndex.m linesFromData fires an assert and we have an incomplete reply.

Fixed: Read all data from NSTask reply.