### PR TITLE
Staging or unstaging chunks updates the index for just the modified file

### DIFF
--- a/Classes/Controllers/PBWebChangesController.m
+++ b/Classes/Controllers/PBWebChangesController.m
@@ -93,7 +93,7 @@
 
 - (void)stageHunk:(NSString *)hunk reverse:(BOOL)reverse
 {
-	[controller.index applyPatch:hunk stage:YES reverse:reverse];
+	[controller.index applyPatch:hunk forFile:selectedFile stage:YES reverse:reverse];
 	// FIXME: Don't need a hard refresh
 
 	[self refresh];
@@ -101,7 +101,7 @@
 
 - (void) discardHunk:(NSString *)hunk
 {
-    [controller.index applyPatch:hunk stage:NO reverse:YES];
+    [controller.index applyPatch:hunk forFile:selectedFile stage:NO reverse:YES];
     [self refresh];
 }
 

--- a/Classes/git/PBGitIndex.h
+++ b/Classes/git/PBGitIndex.h
@@ -66,7 +66,7 @@ extern NSString *PBGitIndexOperationFailed;
 - (void)discardChangesForFiles:(NSArray<PBChangedFile *> *)discardFiles;
 
 // Intra-file changes
-- (BOOL)applyPatch:(NSString *)hunk stage:(BOOL)stage reverse:(BOOL)reverse;
+- (BOOL)applyPatch:(NSString *)hunk forFile:(PBChangedFile *)file stage:(BOOL)stage reverse:(BOOL)reverse;
 - (NSString *)diffForFile:(PBChangedFile *)file staged:(BOOL)staged contextLines:(NSUInteger)context;
 
 @end


### PR DESCRIPTION
Fixes a UI problem where staging the last line or last chunk of a modified file doesn't remove the file from the list of unstaged files.
This also avoids performing a full index refresh when staging a single line or chunk, which can make the UI a lot more responsive when there are lots of modifications.