### PR TITLE
Sped up how quickly gitx CLI terminates when opening an already open repository

### DIFF
--- a/Classes/gitx.m
+++ b/Classes/gitx.m
@@ -101,6 +101,7 @@ void handleSTDINDiff()
 
 	if (diff && [diff length] > 0) {
 		GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
+		[gitXApp setSendMode:kAENoReply];
 		[gitXApp activate];
 		[gitXApp showDiff:diff];
 		exit(0);
@@ -110,6 +111,7 @@ void handleSTDINDiff()
 void handleDiffWithArguments(NSURL *repositoryURL, NSArray *arguments)
 {
 	GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
+	[gitXApp setSendMode:kAENoReply];
 	[gitXApp activate];
 	[gitXApp performDiffIn:repositoryURL withOptions:arguments];
 	exit(0);
@@ -118,6 +120,7 @@ void handleDiffWithArguments(NSURL *repositoryURL, NSArray *arguments)
 void handleOpenRepository(NSURL *repositoryURL, NSArray *arguments)
 {
     GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
+	[gitXApp setSendMode:kAENoReply];
 	[gitXApp activate];
     [gitXApp open:repositoryURL withOptions:arguments];
     return;


### PR DESCRIPTION
Set the SBApplication instance's sendMode to kAENoReply to speed up how quickly gitx terminates

Without this it was waiting for the Apple Event to respond, which could result in the gitx command line app staying open for a few seconds as it waits for the reply. This happened frequently when trying to open a repository that was already open.