### PR TITLE
Added menu item to Stage menu that can run prepare-commit-msg hook

### DIFF
--- a/Classes/Controllers/PBGitCommitController.h
+++ b/Classes/Controllers/PBGitCommitController.h
@@ -14,6 +14,7 @@
 @interface PBGitCommitController : PBViewController
 
 - (IBAction)refresh:(id)sender;
+- (IBAction)prepareCommitMessage:(id)sender;
 - (IBAction)commit:(id)sender;
 - (IBAction)forceCommit:(id)sender;
 - (IBAction)signOff:(id)sender;

--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -13,6 +13,7 @@
 #import "PBGitIndex.h"
 #import "PBGitRepositoryWatcher.h"
 #import "PBCommitMessageView.h"
+#import "PBTask.h"
 #import "NSSplitView+GitX.h"
 
 #import <ObjectiveGit/GTRepository.h>
@@ -247,6 +248,58 @@
 
 	// Reload refs (in case HEAD changed)
 	[repository reloadRefs];
+}
+
+- (IBAction)prepareCommitMessage:(id)sender
+{
+	NSError *error;
+	NSString *messagePath = [NSTemporaryDirectory() stringByAppendingPathComponent:[@"commit-" stringByAppendingString:[[NSUUID UUID] UUIDString]]];
+	NSMutableArray<NSString *> *arguments = [NSMutableArray arrayWithObject:messagePath];
+
+	if ([[[self repository] index] isAmend]) {
+		// git itself seems to pass HEAD when doing a plain 'git commit --amend', but git's documentation says the third argument can be a commit hash
+		[arguments addObject:@"commit"];
+		[arguments addObject:self.repository.headOID.SHA];
+
+		// Write the message of the commit we're amending to a file so we can run the prepare-commit-msg hook on it
+		GTReference *headRef = [self.repository.gtRepo headReferenceWithError:NULL];
+		GTCommit *commit = [headRef resolvedTarget];
+
+		[commit.message writeToFile:messagePath atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+	}
+
+	self.isBusy = YES;
+
+	if ([repository executeHook:@"prepare-commit-msg" arguments:arguments error:&error]) {
+		NSString *string = [NSString stringWithContentsOfFile:messagePath usedEncoding:NULL error:&error];
+
+		// Trim the last newline from the string (to make this match how git presents the results)
+		if ([string length] > 0 && [string characterAtIndex:[string length] - 1] == '\n') {
+			string = [string substringToIndex:[string length] - 1];
+		}
+
+		if (string) {
+			NSRange replacementRange = NSMakeRange(0, [[commitMessageView string] length]);
+
+			if ([commitMessageView shouldChangeTextInRange:replacementRange replacementString:string]) {
+				[commitMessageView replaceCharactersInRange:replacementRange withString:string];
+			}
+		}
+
+		[[NSFileManager defaultManager] removeItemAtPath:messagePath error:NULL];
+	} else {
+		NSError *taskError = error.userInfo[NSUnderlyingErrorKey];
+		NSString *hookOutput = taskError.userInfo[PBTaskTerminationOutputKey];
+		NSString *hookFailureMessage = [NSString stringWithFormat:@"prepare-commit-msg hook failed%@%@",
+										hookOutput && [hookOutput length] > 0 ? @":\n" : @"",
+										hookOutput];
+
+		[[NSNotificationCenter defaultCenter] postNotificationName:PBGitIndexCommitHookFailed
+															object:self
+														  userInfo:[NSDictionary dictionaryWithObject:hookFailureMessage forKey:@"description"]];
+	}
+
+	self.isBusy = NO;
 }
 
 - (IBAction)commit:(id)sender
@@ -629,6 +682,9 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray<PBChangedFile *> *files)
 	} else if (menuItem.action == @selector(toggleAmendCommit:)) {
 		menuItem.state = [[[self repository] index] isAmend] ? NSOnState : NSOffState;
 		return YES;
+	}
+	else if (menuItem.action == @selector(prepareCommitMessage:)) {
+		return [self.repository hookExists:@"prepare-commit-msg"];
 	}
 
 	return menuItem.enabled;

--- a/Classes/git/PBGitIndex.h
+++ b/Classes/git/PBGitIndex.h
@@ -59,6 +59,9 @@ extern NSString *PBGitIndexOperationFailed;
 // Refresh the index
 - (void)refresh;
 
+// Run the prepare-git-msg hook and return the result
+- (nullable NSString *)createPrepareCommitMessage;
+
 - (void)commitWithMessage:(NSString *)commitMessage andVerify:(BOOL)doVerify;
 
 // Inter-file changes:

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -91,6 +91,7 @@ typedef enum branchFilterTypes {
 - (BOOL)executeHook:(NSString *)name error:(NSError **)error;
 - (BOOL)executeHook:(NSString *)name arguments:(NSArray *)arguments error:(NSError **)error;
 - (BOOL)executeHook:(NSString *)name arguments:(NSArray *)arguments output:(NSString **)outputPtr error:(NSError **)error;
+- (BOOL)hookExists:(NSString *)name;
 
 - (NSString *)workingDirectory;
 - (NSURL *)workingDirectoryURL;

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -1131,12 +1131,12 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 {
 	NSParameterAssert(name != nil);
 
-	NSString *hookPath = [[[[self gitURL] path] stringByAppendingPathComponent:@"hooks"] stringByAppendingPathComponent:name];
-	if (![[NSFileManager defaultManager] isExecutableFileAtPath:hookPath]) {
+	if (![self hookExists:name]) {
 		// XXX: Maybe return error ?
 		return YES;
 	}
 
+	NSString *hookPath = [[[[self gitURL] path] stringByAppendingPathComponent:@"hooks"] stringByAppendingPathComponent:name];
 	PBTask *task = [PBTask taskWithLaunchPath:hookPath arguments:arguments inDirectory:self.workingDirectory];
 	task.additionalEnvironment = @{
 		@"GIT_DIR" : self.gitURL.path,
@@ -1163,6 +1163,14 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	if (outputPtr) *outputPtr = task.standardOutputString;
 
 	return YES;
+}
+
+- (BOOL)hookExists:(NSString *)name
+{
+	NSURL *hookURL = [[[self gitURL] URLByAppendingPathComponent:@"hooks"] URLByAppendingPathComponent:name];
+	NSNumber *executable;
+
+	return [hookURL getResourceValue:&executable forKey:NSURLIsExecutableKey error:NULL] && [executable boolValue];
 }
 
 - (BOOL)revisionExists:(NSString *)spec

--- a/Resources/en.lproj/MainMenu.xib
+++ b/Resources/en.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12120"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="ApplicationController"/>
@@ -502,6 +502,12 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="YAj-JN-RZ1"/>
+                            <menuItem title="Prepare Commit Message" keyEquivalent="p" id="LE6-ZD-UdB">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="prepareCommitMessage:" target="-1" id="upC-SY-iPJ"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Commit" id="6Eq-je-Hbg">
                                 <string key="keyEquivalent" base64-UTF8="YES">
 DQ


### PR DESCRIPTION
This adds a menu item to run the `prepare-commit-msg` hook.

Another option would be to run the hook automatically, but since staging and writing the message don't happen in an explicit order that would get pretty complex (or slow if `prepare-commit-msg` takes a while to run).