### PR TITLE
Fix and mitigate code injection (XSS) in HTML views

### DIFF
--- a/Classes/Views/GLFileView.h
+++ b/Classes/Views/GLFileView.h
@@ -25,7 +25,7 @@
 - (void)showFile;
 - (void)didLoad;
 - (NSString *)parseBlame:(NSString *)txt;
-- (NSString *)parseHTML:(NSString *)txt;
+- (NSString *)escapeHTML:(NSString *)txt;
 
 @property NSMutableArray *groups;
 @property NSString *logFormat;

--- a/Classes/Views/GLFileView.h
+++ b/Classes/Views/GLFileView.h
@@ -17,7 +17,6 @@
 	__weak IBOutlet PBGitHistoryController* historyController;
 	__weak IBOutlet MGScopeBar *typeBar;
 	NSMutableArray *groups;
-	NSString *logFormat;
 	__weak IBOutlet NSView *accessoryView;
 	__weak IBOutlet NSSplitView *fileListSplitView;
 }
@@ -28,6 +27,5 @@
 - (NSString *)escapeHTML:(NSString *)txt;
 
 @property NSMutableArray *groups;
-@property NSString *logFormat;
 
 @end

--- a/Resources/html/css/GitX.css
+++ b/Resources/html/css/GitX.css
@@ -31,3 +31,7 @@ table {
 	font-family: Menlo, Monaco, monospace;
 	text-decoration: none;
 }
+
+.hidden {
+	display: none;
+}

--- a/Resources/html/lib/GitX.js
+++ b/Resources/html/lib/GitX.js
@@ -35,25 +35,26 @@ Array.prototype.indexOf = function(item, i) {
 
 var notify = function(html, state) {
 	var n = $("notification");
-	n.style.display = "";
+	n.classList.remove("hidden");
 	$("notification_message").innerHTML = html;
 	
 	// Change color
 	if (!state) { // Busy
-		$("spinner").style.display = "";
-		n.setAttribute("class", "");
+		$("spinner").classList.remove("hidden");
+		n.classList.remove("success");
+		n.classList.remove("fail");
 	}
 	else if (state == 1) { // Success
-		$("spinner").style.display = "none";
-		n.setAttribute("class", "success");
+		$("spinner").classList.add("hidden");
+		n.classList.add("success");
 	} else if (state == -1) {// Fail
-		$("spinner").style.display = "none";
-		n.setAttribute("class", "fail");
+		$("spinner").classList.add("hidden");
+		n.classList.add("fail");
 	}
 }
 
 var hideNotification = function() {
-	$("notification").style.display = "none";
+	$("notification").classList.add("hidden");
 }
 
 var bindCommitSelectionLinks = function(el) {

--- a/Resources/html/lib/GitX.js
+++ b/Resources/html/lib/GitX.js
@@ -9,13 +9,13 @@ function $(element) {
 	return document.getElementById(element);
 }
 
-String.prototype.escapeHTML = function() {
-  return this.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-};
-
-String.prototype.unEscapeHTML = function() {
-  return this.replace(/&amp;/g,'&').replace(/&lt;/g,'<').replace(/&gt;/g,'>');
-};
+String.prototype.escapeHTML = (function() {
+    var div = document.createElement("div");
+    return function() {
+        div.textContent = this;
+        return div.innerHTML;
+    };
+})();
 
 Element.prototype.toggleDisplay = function() {
 	if (this.style.display != "")
@@ -33,10 +33,10 @@ Array.prototype.indexOf = function(item, i) {
   return -1;
 };
 
-var notify = function(text, state) {
+var notify = function(html, state) {
 	var n = $("notification");
 	n.style.display = "";
-	$("notification_message").innerHTML = text;
+	$("notification_message").innerHTML = html;
 	
 	// Change color
 	if (!state) { // Busy
@@ -55,3 +55,13 @@ var notify = function(text, state) {
 var hideNotification = function() {
 	$("notification").style.display = "none";
 }
+
+var bindCommitSelectionLinks = function(el) {
+	var links = el.getElementsByClassName("commit-link");
+	for (var i = 0, n = links.length; i < n; ++i) {
+		links[i].addEventListener("click", function(e) {
+			e.preventDefault();
+			selectCommit(this.dataset.commitId || this.innerHTML);
+		}, false);
+	}
+};

--- a/Resources/html/lib/GitX.js
+++ b/Resources/html/lib/GitX.js
@@ -10,11 +10,11 @@ function $(element) {
 }
 
 String.prototype.escapeHTML = (function() {
-    var div = document.createElement("div");
-    return function() {
-        div.textContent = this;
-        return div.innerHTML;
-    };
+	var div = document.createElement("div");
+	return function() {
+		div.textContent = this;
+		return div.innerHTML;
+	};
 })();
 
 Element.prototype.toggleDisplay = function() {

--- a/Resources/html/lib/diffHighlighter.js
+++ b/Resources/html/lib/diffHighlighter.js
@@ -86,12 +86,12 @@ var highlightDiff = function(diff, element, callbacks) {
 		
 		// Show file list header
 		finalContent += '<div class="file" id="file_index_' + (file_index - 1) + '">';
-		finalContent += '<div id="title_' + title + '" class="expanded fileHeader"><a href="javascript:toggleDiff(\'' + title + '\');">' + title + '</a></div>';
+		finalContent += '<div id="title_' + title + '" class="expanded fileHeader"><a href="">' + title + '</a></div>';
 
 		if (binary) {
 			// diffContent is assumed to be empty for binary files
-			if (callbacks["binaryFile"]) {
-				finalContent += callbacks["binaryFile"](binaryname);
+			if (callbacks.binaryFileHTML) {
+				finalContent += callbacks.binaryFileHTML(binaryname);
 			} else {
 				finalContent += '<div id="content_' + title + '">Binary file differs</div>';
 			}
@@ -254,6 +254,20 @@ var highlightDiff = function(diff, element, callbacks) {
 	// This takes about 7ms
 	element.innerHTML = finalContent;
 
+	var fileHeaders = element.querySelectorAll(".fileHeader a");
+	for (var i = 0, n = fileHeaders.length; i < n; ++i) {
+		fileHeaders[i].addEventListener("click", function(e) {
+			e.preventDefault();
+			toggleDiff(this.innerHTML);
+		});
+	}
+	if (callbacks.binaryFileClass && callbacks.binaryFileOnClick) {
+		var binaryFiles = element.getElementsByClassName(callbacks.binaryFileClass);
+		for (var i = 0, n = binaryFiles.length; i < n; ++i) {
+			binaryFiles[i].addEventListener("click", callbacks.binaryFileOnClick);
+		}
+	}
+
 	// TODO: Replace this with a performance pref call
 	if (false)
 		Controller.log_("Total time:" + (new Date().getTime() - start));
@@ -360,12 +374,7 @@ var inlinediff = (function () {
   };
 
   function escape(s) {
-      var n = s;
-      n = n.replace(/&/g, "&amp;");
-      n = n.replace(/</g, "&lt;");
-      n = n.replace(/>/g, "&gt;");
-      n = n.replace(/"/g, "&quot;");
-      return n;
+      return s.escapeHTML();
   }
 
   function diffString( o, n ) {

--- a/Resources/html/views/blame/blame.js
+++ b/Resources/html/views/blame/blame.js
@@ -1,6 +1,8 @@
-var showFile = function(txt) {
-	$("txt").style.display = "";
-	$("txt").innerHTML="<pre>"+txt+"</pre>";
+var showFile = function(html) {
+	var el = $("txt");
+	el.style.display = "";
+	el.innerHTML = "<pre>" + html + "</pre>";
+	bindCommitSelectionLinks(el);
 	
 	SyntaxHighlighter.defaults['toolbar'] = false;
 

--- a/Resources/html/views/blame/index.html
+++ b/Resources/html/views/blame/index.html
@@ -1,5 +1,7 @@
 <html>
 	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self';">
 		<script src="../../lib/GitX.js" type="text/javascript" charset="utf-8"></script>
 		<script src="../../lib/syntaxhighlighter/scripts/shCore.js" type="text/javascript" charset="utf-8"></script>
 		<script src="../../lib/syntaxhighlighter/scripts/shBrushObjC.js" type="text/javascript" charset="utf-8"></script>

--- a/Resources/html/views/commit/commit.js
+++ b/Resources/html/views/commit/commit.js
@@ -5,16 +5,18 @@ var contextLines = 0;
 
 var showNewFile = function(file)
 {
-	setTitle("New file: " + file.path.escapeHTML());
+	setTitle("New file: " + file.path);
+    diff.innerHTML = "";
 
 	var contents = Index.diffForFile_staged_contextLines_(file, false, contextLines);
 	if (!contents) {
 		notify("Can not display changes (Binary file?)", -1);
-		diff.innerHTML = "";
 		return;
 	}
 
-	diff.innerHTML = "<pre>" + contents.escapeHTML() + "</pre>";
+    var pre = document.createElement("pre");
+    pre.textContent = contents;
+    diff.appendChild(pre);
 	diff.style.display = '';
 }
 
@@ -27,11 +29,11 @@ var setState = function(state) {
 	hideNotification();
 	$("state").style.display = "";
 	$("diff").style.display = "none";
-	$("state").innerHTML = state.escapeHTML();
+	$("state").textContent = state;
 }
 
 var setTitle = function(status) {
-	$("status").innerHTML = status;
+	$("status").textContent = status;
 	$("contextSize").style.display = "none";
 	$("contextTitle").style.display = "none";
 }
@@ -59,7 +61,7 @@ var showFileChanges = function(file, cached) {
 	if (file.status == 0) // New file?
 		return showNewFile(file);
 
-	setTitle((cached ? "Staged": "Unstaged") + " changes for " + file.path.escapeHTML());
+	setTitle((cached ? "Staged" : "Unstaged") + " changes for " + file.path);
 	displayContext();
 	var changes = Index.diffForFile_staged_contextLines_(file, cached, contextLines);
 	

--- a/Resources/html/views/commit/commit.js
+++ b/Resources/html/views/commit/commit.js
@@ -112,8 +112,8 @@ var setSelectHandlers = function()
 			if (file.id = "selected")
 				file = file.parentNode;
 			var start = target;
-			var elem_class = start.getAttribute("class");
-			if(!elem_class || !(elem_class == "addline" | elem_class == "delline")) 
+			var elemClasses = start.classList;
+			if (!(elemClasses.contains("addline") || elemClasses.contains("delline")))
 				return false;
 			deselect();
 			var bounds = findsubhunk(start);
@@ -122,11 +122,11 @@ var setSelectHandlers = function()
 		};
 
 		file.onmousedown = function(event) {
-			if (event.which != 1) 
+			if (event.which != 1)
 				return false;
-			var elem_class = event.target.getAttribute("class")
+			var elemClasses = event.target.classList;
 			event.stopPropagation();
-			if (elem_class == "hunkheader" || elem_class == "hunkbutton")
+			if (elemClasses.contains("hunkheader") || elemClasses.contains("hunkbutton"))
 				return false;
 
 			var target = findParentElementByTag(event.target, "div");
@@ -202,11 +202,26 @@ var displayDiff = function(diff, cached)
 
 	for (i = 0; i < hunkHeaders.length; ++i) {
 		var header = hunkHeaders[i];
-		if (cached)
-			header.innerHTML = "<a href='#' class='hunkbutton' onclick='addHunk(this, true); return false'>Unstage</a>" + header.innerHTML;
+		if (cached) {
+			header.innerHTML = "<a href='#' class='hunkbutton unstage-button'>Unstage</a>" + header.innerHTML;
+			header.getElementsByClassName('unstage-button')[0].addEventListener("click", function(e) {
+				e.preventDefault();
+				addHunk(this, true);
+			});
+		}
 		else {
-			header.innerHTML = "<a href='#' class='hunkbutton' onclick='discardHunk(this, event); return false'>Discard</a>" + header.innerHTML;
-			header.innerHTML = "<a href='#' class='hunkbutton' onclick='addHunk(this, false); return false'>Stage</a>" + header.innerHTML;
+			header.innerHTML =
+				"<a href='#' class='hunkbutton add-hunk-button'>Stage</a>" +
+				"<a href='#' class='hunkbutton discard-hunk-button'>Discard</a>" +
+				header.innerHTML;
+			header.getElementsByClassName("add-hunk-button")[0].addEventListener("click", function(e) {
+				e.preventDefault();
+				addHunk(this, false);
+			});
+			header.getElementsByClassName("discard-hunk-button")[0].addEventListener("click", function(e) {
+				e.preventDefault();
+				discardHunk(this, event);
+			});
 		}
 	}
 	setSelectHandlers();
@@ -275,19 +290,19 @@ var discardHunk = function(hunk, event)
 
 /* Find all contiguous add/del lines. A quick way to select "just this
  * chunk". */
-var findsubhunk = function(start) { 
-        var findBound = function(direction) { 
+var findsubhunk = function(start) {
+	var findBound = function(direction) {
 		var element=start;
-                for (var next = element[direction]; next; next = next[direction]) { 
-                        var elem_class = next.getAttribute("class"); 
-                        if (elem_class == "hunkheader" || elem_class == "noopline") 
-                                break; 
+		for (var next = element[direction]; next; next = next[direction]) {
+			var elemClasses = next.classList;
+			if (elemClasses.contains("hunkheader") || elemClasses.contains("noopline"))
+				break;
 			element=next;
 		}
-		return element; 
-        }
-        return [findBound("previousSibling"), findBound("nextSibling")]; 
-} 
+		return element;
+	}
+	return [findBound("previousSibling"), findBound("nextSibling")];
+}
 
 /* Remove existing selection */
 var deselect = function() {
@@ -306,11 +321,10 @@ var stageLines = function(reverse) {
 	if(!selection) return false;
 	currentSelection = false;
 	var hunkHeader = false;
-	var preselect = 0,elem_class;
+	var preselect = 0;
 
 	for(var next = selection.previousSibling; next; next = next.previousSibling) {
-		elem_class = next.getAttribute("class");
-		if(elem_class == "hunkheader") {
+		if (next.classList.contains("hunkheader")) {
 			hunkHeader = next.lastChild.data;
 			break;
 		}
@@ -395,13 +409,13 @@ var computeSelection = function(list, from, to)
 			insel = true;
 		}
 
-		var elem_class = elem.getAttribute("class");
-		if(elem_class) {
-			if(elem_class == "hunkheader") {
+		var elemClasses = elem.classList;
+		if (elem.className) {
+			if (elemClasses.contains("hunkheader")) {
 				elem = last;
 				break; // Stay inside this hunk
 			}
-			if(!good && (elem_class == "addline" || elem_class == "delline"))
+			if (!good && (elemClasses.contains("addline") || elemClasses.contains("delline")))
 				good = true; // A good selection
 		}
 		if (elem == to) break;
@@ -489,10 +503,14 @@ var showSelection = function(file, from, to, trust)
 	buttons_div.appendChild(copy_button);
 
 	if (sel.good) {
-		button.setAttribute('onclick','stageLines('+
-				    (originalCached?'true':'false')+
-				    '); return false;');
-		copy_button.setAttribute('onclick','copy(); return false;');
+		button.addEventListener("click", function(e) {
+			e.preventDefault();
+			stageLines(originalCached);
+		});
+		copy_button.addEventListener("click", function(e) {
+			e.preventDefault();
+			copy();
+		});
 	} else {
 		button.setAttribute("class","disabled");
 		copy_button.setAttribute("class","disabled");

--- a/Resources/html/views/commit/commit.js
+++ b/Resources/html/views/commit/commit.js
@@ -6,7 +6,7 @@ var contextLines = 0;
 var showNewFile = function(file)
 {
 	setTitle("New file: " + file.path);
-    diff.innerHTML = "";
+	diff.innerHTML = "";
 
 	var contents = Index.diffForFile_staged_contextLines_(file, false, contextLines);
 	if (!contents) {
@@ -14,9 +14,9 @@ var showNewFile = function(file)
 		return;
 	}
 
-    var pre = document.createElement("pre");
-    pre.textContent = contents;
-    diff.appendChild(pre);
+	var pre = document.createElement("pre");
+	pre.textContent = contents;
+	diff.appendChild(pre);
 	diff.style.display = '';
 }
 

--- a/Resources/html/views/commit/index.html
+++ b/Resources/html/views/commit/index.html
@@ -1,5 +1,7 @@
 <html>
 <head>
+	<meta charset="utf-8">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self';">
 	<title>Diff for file</title>
 	<link rel="stylesheet" href="../../css/GitX.css" type="text/css" media="screen" title="no title" charset="utf-8">
 	<script src="../../lib/jquery-2.0.2.min.js" type="text/javascript" charset="utf-8"></script>
@@ -21,7 +23,7 @@
 
 	</h1>
 
-	<div id="notification" style="display:none">
+	<div id="notification" class="hidden">
 		<img src="../../images/spinner.gif" alt="Spinner" id="spinner"></img>
 		<div id="notification_message"></div>
 	</div>

--- a/Resources/html/views/commit/multipleSelection.js
+++ b/Resources/html/views/commit/multipleSelection.js
@@ -4,18 +4,18 @@ var showMultipleFilesSelection = function(files)
 	setTitle("");
 
 	var div = $("diff");
-    div.style.display = "";
+	div.style.display = "";
 	div.innerHTML = '<div id="multiselect">' +
 		'<div class="title">Multiple Selection</div>' +
-        '<ul></ul>' +
-        '</div>';
+		'<ul></ul>' +
+		'</div>';
 
-    var ul = div.getElementsByTagName("ul")[0];
+	var ul = div.getElementsByTagName("ul")[0];
 	for (var i = 0; i < files.length; ++i)
 	{
 		var file = files[i];
-        var li = document.createElement("li");
-        li.textContent = file.path;
-        ul.appendChild(li);
+		var li = document.createElement("li");
+		li.textContent = file.path;
+		ul.appendChild(li);
 	}
 }

--- a/Resources/html/views/commit/multipleSelection.js
+++ b/Resources/html/views/commit/multipleSelection.js
@@ -4,19 +4,18 @@ var showMultipleFilesSelection = function(files)
 	setTitle("");
 
 	var div = $("diff");
+    div.style.display = "";
+	div.innerHTML = '<div id="multiselect">' +
+		'<div class="title">Multiple Selection</div>' +
+        '<ul></ul>' +
+        '</div>';
 
-	var contents = '<div id="multiselect">' +
-		'<div class="title">Multiple Selection</div>';
-
-	contents += "<ul>";
-
+    var ul = div.getElementsByTagName("ul")[0];
 	for (var i = 0; i < files.length; ++i)
 	{
 		var file = files[i];
-		contents += "<li>" + file.path + "</li>";
+        var li = document.createElement("li");
+        li.textContent = file.path;
+        ul.appendChild(li);
 	}
-	contents += "</ul></div>";
-
-	div.innerHTML = contents;
-	div.style.display = "";
 }

--- a/Resources/html/views/commit/test.html
+++ b/Resources/html/views/commit/test.html
@@ -18,7 +18,7 @@
 
 	</h1>
 
-	<div id="notification" style="display:none">
+	<div id="notification" class="hidden">
 		<img src="../../images/spinner.gif" alt="Spinner" id="spinner">
 		<div id="notification_message"></div>
 	</div>

--- a/Resources/html/views/diff/diffWindow.js
+++ b/Resources/html/views/diff/diffWindow.js
@@ -1,7 +1,11 @@
 // for diffs shown in the PBDiffWindow
 
+var showDiff = function(diff) {
+	highlightDiff(diff, $("diff"));
+};
+
 var setMessage = function(message) {
-	$("message").style.display = "";
+	$("message").classList.remove("hidden");
 	$("message").textContent = message;
 	$("diff").style.display = "none";
 };

--- a/Resources/html/views/diff/diffWindow.js
+++ b/Resources/html/views/diff/diffWindow.js
@@ -2,7 +2,6 @@
 
 var setMessage = function(message) {
 	$("message").style.display = "";
-	$("message").innerHTML = message.escapeHTML();
+	$("message").textContent = message;
 	$("diff").style.display = "none";
-}
-
+};

--- a/Resources/html/views/diff/index.html
+++ b/Resources/html/views/diff/index.html
@@ -1,5 +1,7 @@
 <html>
 <head>
+	<meta charset="utf-8">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self';">
 	<title>Details for commit</title>
 	<link rel="stylesheet" href="../../css/GitX.css" type="text/css" media="screen" title="no title" charset="utf-8">
 	<script src="../../lib/jquery-2.0.2.min.js" type="text/javascript" charset="utf-8"></script>
@@ -10,16 +12,10 @@
 
 	<link rel="stylesheet" href="diffWindow.css" type="text/css" media="screen" title="no title" charset="utf-8">
 	<script src="diffWindow.js" type="text/javascript" charset="utf-8"></script>
-
-	<script type="text/javascript" charset="utf-8">
-		var showDiff = function(diff) {
-			highlightDiff(diff, $("diff"));
-		}
-	</script>
 </head>
 
 <body>
-	<div id="message" style="display:none">
+	<div id="message" class="hidden">
 		There are no differences
 	</div>
 	<div id='diff'></div>

--- a/Resources/html/views/fileview/index.html
+++ b/Resources/html/views/fileview/index.html
@@ -1,5 +1,8 @@
+<!DOCTYPE html>
 <html>
 	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self';">
 		<script src="../../lib/GitX.js" type="text/javascript" charset="utf-8"></script>
 		<script src="../../lib/syntaxhighlighter/scripts/shCore.js" type="text/javascript" charset="utf-8"></script>
 		<script src="../../lib/syntaxhighlighter/scripts/shAutoloader.js" type="text/javascript" charset="utf-8"></script>
@@ -38,4 +41,4 @@
 	<body>
 		<div id="source"></div>
 	</body>
-</html> 
+</html>

--- a/Resources/html/views/fileview/index_test.html
+++ b/Resources/html/views/fileview/index_test.html
@@ -1,5 +1,8 @@
+<!DOCTYPE html>
 <html>
 	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self';">
 		<script src="../../lib/GitX.js" type="text/javascript" charset="utf-8"></script>
 		<script src="../../lib/syntaxhighlighter/scripts/shCore.js" type="text/javascript" charset="utf-8"></script>
 		<script src="../../lib/syntaxhighlighter/scripts/shBrushObjC.js" type="text/javascript" charset="utf-8"></script>

--- a/Resources/html/views/history/history.css
+++ b/Resources/html/views/history/history.css
@@ -1,3 +1,8 @@
+body {
+	padding: 0px;
+	border: 0px;
+}
+
 #commit_header {
 	width: auto;
 	font-size: 12px;
@@ -68,6 +73,9 @@ a.servicebutton:hover {
 	font-weight: bold;
 }
 
+#subjectID {
+	font-weight: bold;
+}
 
 #message_files {
 	margin: 5px;
@@ -302,3 +310,11 @@ div.renamed
 	// No colour needed right now.
 }
 */
+
+#notification_message .cancel {
+	color: red;
+}
+
+#notification_message .confirm {
+	color: green;
+}

--- a/Resources/html/views/history/index.html
+++ b/Resources/html/views/history/index.html
@@ -1,5 +1,7 @@
 <html>
 <head>
+	<meta charset="utf-8">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src 'self' GitX: https://www.gravatar.com; script-src 'self'; style-src 'self';">
 	<title>Details for commit</title>
 	<link rel="stylesheet" href="../../css/GitX.css" type="text/css" media="screen" title="no title" charset="utf-8">
 	<script src="../../lib/jquery-2.0.2.min.js" type="text/javascript" charset="utf-8"></script>
@@ -10,60 +12,31 @@
 
 	<link rel="stylesheet" href="history.css" type="text/css" media="screen" title="no title" charset="utf-8">
 	<script src="history.js" type="text/javascript" charset="utf-8"></script>
-	<script type="text/javascript">
-	Array.prototype.contains = function(obj) {
-	  var i = this.length;
-	  while (i--) {
-	    if (this[i] === obj) {
-	      return true;
-	    }
-	  }
-	  return false;
-	}
-	function expandDiffstatDetails(obj) {
-	  var children = obj.parentNode.childNodes;
-	  for (i in children) {
-	    var c = children[i];
-	    if (c.className && c.className.split(" ").contains("details"))
-	      c.style.display = "";
-	  }
-	  return true;
-	}
-	function collapseDiffstatDetails(obj) {
-	  var children = obj.parentNode.childNodes;
-	  for (i in children) {
-	    var c = children[i];
-	    if (c.className && c.className.split(" ").contains("details"))
-	      c.style.display = "none";
-	  }
-	  return true;
-	}
-	</script>
 </head>
 
-<body style="padding: 0px; border: 0px" onLoad="extractPrototypes()">
+<body>
 	<div id="commit">
 		<div id="rightcontent">
 			<div id="buttons">
-				<a class="servicebutton" id="gist" onclick="confirm_gist();return false" href="#">
+				<a class="servicebutton" id="gist" href="#">
 					Gist it
 				</a>
 			</div>
 		</div>
-		
+
 		<table>
 			<tr>
 				<td width="50%">
-					<table >
+					<table>
 						<tr>
 							<td class="property_name">Subject:</td>
-							<td id="subjectID" style="font-weight:bold"></td>
+							<td id="subjectID"></td>
 						</tr>
 						<td colspan="2">
 							<table id="authorTable">
 								<tr>
 									<td class="property_name">Author:</td>
-									<td class="gravatar" rowspan="2" align="center" style="display:none">
+									<td class="gravatar hidden" rowspan="2" align="center">
 										<img id="author_gravatar" src=""></img>
 									</td>
 									<td id="authorID"></td>
@@ -72,14 +45,14 @@
 									<td class="property_name">Date:</td>
 									<td id="date"></td>
 								</tr>
-								<tr style="display:none">
+								<tr class="hidden">
 									<td class="property_name">Committer:</td>
-									<td class="gravatar" rowspan="2" align="center" style="display:none">
+									<td class="gravatar hidden" rowspan="2" align="center">
 										<img id="committer_gravatar" src=""></img>
 									</td>
 									<td id="committerID"></td>
 								</tr>
-								<tr style="display:none">
+								<tr class="hidden">
 									<td class="property_name">Date:</td>
 									<td id="committerDate"></td>
 								</tr>
@@ -94,16 +67,16 @@
 							<td class="property_name">SHA:</td>
 							<td id="commitID" class="SHA"></td>
 						</tr>
-						<tr style="display:none">
+						<tr class="hidden">
 							<td class="property_name">Refs:</td>
 							<td id="refs"></td>
 						</tr>
-					</table>	
+					</table>
 				</td>
 			</tr>
 		</table>
-		
-		<div id="notification" style="display:none;">
+
+		<div id="notification" class="hidden">
 			<img src="../../images/spinner.gif" alt="Spinner" id="spinner"></img>
 			<div id="notification_message"></div>
 		</div>
@@ -121,11 +94,11 @@
 						<div class="diffstat-info">
 							<div class="changes-bar added"></div>
 							<div class="changes-bar removed"></div>
-							<span style="display:none;" class="diffstat-numbers details">
+							<span class="diffstat-numbers details hidden">
 								<span class="added"></span>
 								<span class="removed"></span>
 							</span>
-							<div class="diffstat-numbers summary" onmouseover="expandDiffstatDetails(this)" onmouseout="collapseDiffstatDetails(this)"></div>
+							<div class="diffstat-numbers summary"></div>
 						</div>
 					</li>
 				</ul>

--- a/Resources/html/views/log/format.html
+++ b/Resources/html/views/log/format.html
@@ -1,8 +1,0 @@
-<div id='%h' class='commit'>
-<p class="title">%s</p>
-	<table>
-		<tr><td>Author:</td><td>%aN</td></tr>
-		<tr><td>Date:</td><td>%ar</td></tr>
-		<tr><td>Commit:</td><td><a href='' onclick='selectCommit(this.innerHTML);'>%H</a></td></tr>
-	</table>
-</div>

--- a/Resources/html/views/log/index.html
+++ b/Resources/html/views/log/index.html
@@ -1,5 +1,8 @@
+<!DOCTYPE html>
 <html>
 <head>
+	<meta charset="utf-8">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self';">
 	<title>Details for commit</title>
 	<link rel="stylesheet" href="../../css/GitX.css" type="text/css" media="screen" title="no title" charset="utf-8">
 	<script src="../../lib/jquery-2.0.2.min.js" type="text/javascript" charset="utf-8"></script>
@@ -13,8 +16,6 @@
 </head>
 
 <body>
-	<div id="message" style="display:none">
-		There are no differences
-	</div>
+	<div id="message" class="hidden"></div>
 	<div id='log'></div>
 </body>

--- a/Resources/html/views/log/log.js
+++ b/Resources/html/views/log/log.js
@@ -3,8 +3,10 @@ var selectCommit = function(a) {
 	return false;
 }
 
-var showFile = function(txt) {
-	$("log").style.display = "";
-	$("log").innerHTML=txt;
+var showFile = function(html) {
+	var el = $("log");
+	el.style.display = "";
+	el.innerHTML = html;
+	bindCommitSelectionLinks(el);
 	return;
 }

--- a/Resources/html/views/log/log.js
+++ b/Resources/html/views/log/log.js
@@ -5,7 +5,7 @@ var selectCommit = function(a) {
 
 var showFile = function(html) {
 	var el = $("log");
-	el.style.display = "";
+	el.classList.remove("hidden");
 	el.innerHTML = html;
 	bindCommitSelectionLinks(el);
 	return;

--- a/Resources/html/views/log/test.html
+++ b/Resources/html/views/log/test.html
@@ -1,4 +1,8 @@
-<html><head>
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self';">
 	<title>Details for commit</title>
 	<link rel="stylesheet" href="../../css/GitX.css" type="text/css" media="screen" title="no title" charset="utf-8">
 	<script src="../../lib/jquery-2.0.2.min.js" type="text/javascript" charset="utf-8"></script>
@@ -16,7 +20,7 @@
 		}
 	</script>
 </head><body>
-	<div id="message" style="display:none">
+	<div id="message" class="hidden">
 		There are no differences
 	</div>
 	<div id="log"><div id="7037821" class="commit">

--- a/Resources/html/views/source/index.html
+++ b/Resources/html/views/source/index.html
@@ -1,5 +1,8 @@
+<!DOCTYPE html>
 <html>
 	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self';">
 		<script src="../../lib/GitX.js" type="text/javascript" charset="utf-8"></script>
 		<script src="../../lib/syntaxhighlighter_2.1.364/scripts/shCore.js" type="text/javascript" charset="utf-8"></script>
 		<script src="../../lib/syntaxhighlighter_2.1.364/scripts/shBrushObjC.js" type="text/javascript" charset="utf-8"></script>
@@ -11,4 +14,4 @@
 	<body>
 		<div id="source"></div>
 	</body>
-</html> 
+</html>

--- a/Resources/html/views/source/source.js
+++ b/Resources/html/views/source/source.js
@@ -1,6 +1,6 @@
-var showFile = function(txt) {
+var showFile = function(html) {
 	$("source").style.display = "";
-	$("source").innerHTML="<pre class='first-line: 1;brush: objc'>"+txt+"</pre>";
+	$("source").innerHTML="<pre class='first-line: 1;brush: objc'>"+html+"</pre>";
 	
 	SyntaxHighlighter.defaults['toolbar'] = false;
 	SyntaxHighlighter.highlight();


### PR DESCRIPTION
It appears that the HTML view code was not originally written with XSS in mind, with nearly all text being interpreted as raw HTML. If a user opens a repository with malicious commits, arbitrary JavaScript could be run.

I've fixed all of the code injection bugs I could find, and have also added Content-Security-Policy headers to each of the views to mitigate possible remaining or future injection bugs. Inline scripts and styles have been moved into external files as needed.