### PR TITLE
Add reset option

### DIFF
--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -684,7 +684,6 @@
 
 - (IBAction)resetSoft:(id)sender
 {
-	NSLog(@"resetSoft()");
 	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXBranchType, kGitXCommitType]];
 	if (!refish) return;
 	

--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -682,6 +682,19 @@
 	}
 }
 
+- (IBAction)resetSoft:(id)sender
+{
+	NSLog(@"resetSoft()");
+	id <PBGitRefish> refish = [self refishForSender:sender refishTypes:@[kGitXBranchType, kGitXCommitType]];
+	if (!refish) return;
+	
+	NSError *error = nil;
+	BOOL success = [self.repository resetSoftRefish:refish error:&error];
+	if (!success) {
+		[self showErrorSheet:error];
+	}
+}
+
 - (IBAction)stashSave:(id)sender
 {
 	NSError *error = nil;

--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -688,7 +688,7 @@
 	if (!refish) return;
 	
 	NSError *error = nil;
-	BOOL success = [self.repository resetSoftRefish:refish error:&error];
+	BOOL success = [self.repository resetRefish:GTRepositoryResetTypeSoft to:refish error:&error];
 	if (!success) {
 		[self showErrorSheet:error];
 	}

--- a/Classes/Views/PBRefMenuItem.m
+++ b/Classes/Views/PBRefMenuItem.m
@@ -126,6 +126,12 @@
 		[items addObject:[NSMenuItem pb_itemWithTitle:rebaseTitle action:@selector(rebaseHeadBranch:) enabled:!isOnHeadBranch]];
 
 		[items addObject:[NSMenuItem separatorItem]];
+		
+		// reset
+		NSString *resetTitle = [NSString stringWithFormat:NSLocalizedString(@"Reset to “%@”", @"Contextual Menu Item to reset to the selected ref"), refName];
+		[items addObject:[NSMenuItem pb_itemWithTitle:resetTitle action:@selector(resetSoft:) enabled:!isHead]];
+		
+		[items addObject:[NSMenuItem separatorItem]];
 	}
 
 	// fetch
@@ -244,6 +250,10 @@
 			? NSLocalizedString(@"Rebase Commit", @"Inactive Contextual Menu Item for rebasing onto commits")
 			: [NSString stringWithFormat:NSLocalizedString(@"Rebase “%@” onto Commit", @"Contextual Menu Item to rebase the HEAD branch onto the selected commit"), headBranchName];
 		[items addObject:[NSMenuItem pb_itemWithTitle:rebaseTitle action:@selector(rebaseHeadBranch:) enabled:!isOnHeadBranch]];
+		
+		// reset
+		NSString *resetTitle = NSLocalizedString(@"Reset to commit", @"Contextual Menu Item to reset to the selected ref");
+		[items addObject:[NSMenuItem pb_itemWithTitle:resetTitle action:@selector(resetSoft:) enabled:!isHead]];
 	}
 	
 	for (NSMenuItem *item in items) {

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -65,7 +65,7 @@ typedef enum branchFilterTypes {
 - (BOOL) checkoutFiles:(NSArray *)files fromRefish:(id <PBGitRefish>)ref error:(NSError **)error;
 - (BOOL) mergeWithRefish:(id <PBGitRefish>)ref error:(NSError **)error;
 - (BOOL) cherryPickRefish:(id <PBGitRefish>)ref error:(NSError **)error;
-- (BOOL) resetSoftRefish:(id <PBGitRefish>)ref error:(NSError **)error;
+- (BOOL) resetRefish:(GTRepositoryResetType)mode to:(id <PBGitRefish>)ref error:(NSError **)error;
 - (BOOL) rebaseBranch:(id <PBGitRefish>)branch onRefish:(id <PBGitRefish>)upstream error:(NSError **)error;
 - (BOOL) createBranch:(NSString *)branchName atRefish:(id <PBGitRefish>)ref error:(NSError **)error;
 - (BOOL) createTag:(NSString *)tagName message:(NSString *)message atRefish:(id <PBGitRefish>)commitSHA error:(NSError **)error;

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -65,6 +65,7 @@ typedef enum branchFilterTypes {
 - (BOOL) checkoutFiles:(NSArray *)files fromRefish:(id <PBGitRefish>)ref error:(NSError **)error;
 - (BOOL) mergeWithRefish:(id <PBGitRefish>)ref error:(NSError **)error;
 - (BOOL) cherryPickRefish:(id <PBGitRefish>)ref error:(NSError **)error;
+- (BOOL) resetSoftRefish:(id <PBGitRefish>)ref error:(NSError **)error;
 - (BOOL) rebaseBranch:(id <PBGitRefish>)branch onRefish:(id <PBGitRefish>)upstream error:(NSError **)error;
 - (BOOL) createBranch:(NSString *)branchName atRefish:(id <PBGitRefish>)ref error:(NSError **)error;
 - (BOOL) createTag:(NSString *)tagName message:(NSString *)message atRefish:(id <PBGitRefish>)commitSHA error:(NSError **)error;

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -891,6 +891,31 @@
 	return YES;
 }
 
+- (BOOL) resetSoftRefish:(id <PBGitRefish>)ref error:(NSError **)error
+{
+	if (!ref)
+		return NO;
+	
+	NSString *refName = [ref refishName];
+	
+	NSError *gitError = nil;
+	NSArray *arguments = @[@"reset", @"--soft", refName];
+	NSLog(@"Resetting to %@", refName);
+	
+	NSString *output = [self outputOfTaskWithArguments:arguments error:&gitError];
+	if (!output) {
+		NSString *title = @"Reset failed!";
+		NSString *message = [NSString stringWithFormat:@"There was an error resetting to %@ '%@'.", [ref refishType], [ref shortName]];
+		
+		return PBReturnError(error, title, message, gitError);
+	}
+	
+	[self reloadRefs];
+	[self readCurrentBranch];
+	return YES;
+}
+
+
 - (BOOL) rebaseBranch:(id <PBGitRefish>)branch onRefish:(id <PBGitRefish>)upstream error:(NSError **)error
 {
 	NSParameterAssert(upstream != nil);

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -891,15 +891,28 @@
 	return YES;
 }
 
-- (BOOL) resetSoftRefish:(id <PBGitRefish>)ref error:(NSError **)error
+- (BOOL) resetRefish:(GTRepositoryResetType)mode to:(id <PBGitRefish>)ref error:(NSError **)error
 {
 	if (!ref)
 		return NO;
 	
 	NSString *refName = [ref refishName];
 	
+	NSString *modeParam;
+	switch (mode) {
+		case GTRepositoryResetTypeSoft:
+			modeParam = @"--soft";
+			break;
+		case GTRepositoryResetTypeMixed:
+			modeParam = @"--mixed";
+			break;
+		case GTRepositoryResetTypeHard:
+			modeParam = @"--hard";
+			break;
+	}
+
 	NSError *gitError = nil;
-	NSArray *arguments = @[@"reset", @"--soft", refName];
+	NSArray *arguments = @[@"reset", modeParam, refName];
 	
 	NSString *output = [self outputOfTaskWithArguments:arguments error:&gitError];
 	if (!output) {

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -900,7 +900,6 @@
 	
 	NSError *gitError = nil;
 	NSArray *arguments = @[@"reset", @"--soft", refName];
-	NSLog(@"Resetting to %@", refName);
 	
 	NSString *output = [self outputOfTaskWithArguments:arguments error:&gitError];
 	if (!output) {


### PR DESCRIPTION
This adds a reset option that uses `--soft`. I guess maybe it could use `--mixed` instead which is the default for git but I think `--soft` is a bit more expected. Once you work out what they typically awful naming means anyway - why not `--unstaged`, `--staged`, and `--discard`? Ugh git.

Sorry if I already did a pull request for this - forgot I had this code and found it lying around.