### PR TITLE
Fix relative dates in history view

### DIFF
--- a/Resources/XIBs/PBGitHistoryView.xib
+++ b/Resources/XIBs/PBGitHistoryView.xib
@@ -415,6 +415,7 @@
                                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="sNC-21-Ibh">
                                                                         <rect key="frame" x="0.0" y="3" width="4" height="17"/>
                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="uhv-dO-OCU">
+                                                                            <customFormatter key="formatter" id="PIf-S7-wRN" customClass="GitXRelativeDateFormatter"/>
                                                                             <font key="font" metaFont="system"/>
                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
I'm sorry, but this is another one of my "stab in the dark" PRs. I don't know what I'm doing, but this seems to work. I have been using a build off of master (from 57ed8a0) and just noticed that the relative date formatting was not working correctly (as in: at all). This PR is an attempt to reconnect the relative date column with the relative date formatter.

I'm really not kidding when I say I don't know what I'm doing. I just did a lot of `grep`ing and guessing about how to get things connected, so it would not surprise me to find out that I did something wrong. Any commentary, pointers or review are welcome. 😄 

I use this app every day and would love to help more, but Objective-C/Cocoa/XIB/Xcode are hard for me to get to used to.