### PR TITLE
Activate GitX after opening the repository

### DIFF
--- a/Classes/gitx.m
+++ b/Classes/gitx.m
@@ -121,8 +121,8 @@ void handleOpenRepository(NSURL *repositoryURL, NSArray *arguments)
 {
     GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
 	[gitXApp setSendMode:kAENoReply];
-	[gitXApp activate];
     [gitXApp open:repositoryURL withOptions:arguments];
+	[gitXApp activate];
     return;
 }
 


### PR DESCRIPTION
This makes the window open in the current Space, instead of where the current main window is, which would have triggered a Space switch.

I'm putting that there for discussion, as I'm really tempted to just merge it anyways since I have been wrangling GitX windows every time I open one for quite some time now…