### PR TITLE
Fix commit message font on 10.13

### DIFF
--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -77,6 +77,9 @@
 	commitMessageView.delegate = self;
 
 	NSMutableDictionary *attrs = commitMessageView.typingAttributes.mutableCopy;
+	if (!attrs) {
+		attrs = [NSMutableDictionary dictionary];
+	}
 	attrs[NSFontAttributeName] = [NSFont fontWithName:@"Menlo" size:12.0];
 	commitMessageView.typingAttributes = attrs;
 


### PR DESCRIPTION
Ensure the commitMessageView.typingAttributes dictionary is not nil before setting properties on it.

Fixes #173
Fixes regression from a1184707748e3aa8e2a659ad6458f695dce00f93 on 10.13