### PR TITLE
Switch to dark HTML content when user's system is dark

### DIFF
--- a/Classes/Controllers/PBWebChangesController.m
+++ b/Classes/Controllers/PBWebChangesController.m
@@ -9,6 +9,9 @@
 #import "PBWebChangesController.h"
 #import "PBGitIndex.h"
 
+static void * const UnstagedFileSelectedContext = @"UnstagedFileSelectedContext";
+static void * const CachedFileSelectedContext = @"CachedFileSelectedContext";
+
 @interface PBWebChangesController () <WebEditingDelegate, WebUIDelegate>
 @end
 
@@ -22,8 +25,8 @@
 	startFile = @"commit";
 	[super awakeFromNib];
 
-	[unstagedFilesController addObserver:self forKeyPath:@"selection" options:0 context:@"UnstagedFileSelected"];
-	[stagedFilesController addObserver:self forKeyPath:@"selection" options:0 context:@"cachedFileSelected"];
+	[unstagedFilesController addObserver:self forKeyPath:@"selection" options:0 context:UnstagedFileSelectedContext];
+	[stagedFilesController addObserver:self forKeyPath:@"selection" options:0 context:CachedFileSelectedContext];
 
 	self.view.editingDelegate = self;
 	self.view.UIDelegate = self;
@@ -49,6 +52,10 @@
 						change:(NSDictionary *)change
 					   context:(void *)context
 {
+	if (context != UnstagedFileSelectedContext && context != CachedFileSelectedContext) {
+		return [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+	}
+
 	NSArrayController *otherController;
 	otherController = object == unstagedFilesController ? stagedFilesController : unstagedFilesController;
 	NSUInteger count = [object selectedObjects].count;

--- a/Classes/Controllers/PBWebController.m
+++ b/Classes/Controllers/PBWebController.m
@@ -46,6 +46,9 @@
 			 object:self.view.window];
 	
 	finishedLoading = NO;
+
+	[self.view setDrawsBackground:NO];
+
 	[self.view setUIDelegate:self];
 	[self.view setFrameLoadDelegate:self];
 	[self.view setResourceLoadDelegate:self];

--- a/Classes/Controllers/PBWebController.m
+++ b/Classes/Controllers/PBWebController.m
@@ -38,12 +38,12 @@ static void * const PBEffectiveAppearanceContext = @"PBEffectiveAppearanceContex
 		 object:nil];
 
 	[nc addObserver:self
-		   selector:@selector(windowWillStartLiveResitzeWithNotification:)
+		   selector:@selector(windowWillStartLiveResizeWithNotification:)
 			   name:NSWindowWillStartLiveResizeNotification
 			 object:self.view.window];
 	
 	[nc addObserver:self
-		   selector:@selector(windowDidEndLiveResitzeWithNotification:)
+		   selector:@selector(windowDidEndLiveResizeWithNotification:)
 			   name:NSWindowDidEndLiveResizeNotification
 			 object:self.view.window];
 
@@ -263,12 +263,12 @@ dragDestinationActionMaskForDraggingInfo:(id<NSDraggingInfo>)draggingInfo
 	[self preferencesChanged];
 }
 
-- (void)windowWillStartLiveResitzeWithNotification:(NSNotification *)theNotification
+- (void)windowWillStartLiveResizeWithNotification:(NSNotification *)theNotification
 {
 	self.view.autoresizingMask = NSViewMaxXMargin | NSViewMinYMargin | NSViewMaxYMargin | NSViewHeightSizable;
 }
 
-- (void)windowDidEndLiveResitzeWithNotification:(NSNotification *)theNotification
+- (void)windowDidEndLiveResizeWithNotification:(NSNotification *)theNotification
 {
 	self.view.autoresizingMask = NSViewMinXMargin | NSViewMaxXMargin | NSViewMinYMargin | NSViewMaxYMargin | NSViewWidthSizable | NSViewHeightSizable;
 	self.view.frame = self.view.superview.bounds;

--- a/Classes/PBCommitList.m
+++ b/Classes/PBCommitList.m
@@ -16,6 +16,12 @@
 @synthesize mouseDownPoint;
 @synthesize useAdjustScroll;
 
+- (void)awakeFromNib
+{
+	[super awakeFromNib];
+	[webView setDrawsBackground:NO];
+}
+
 - (NSDragOperation)draggingSession:(NSDraggingSession *)session sourceOperationMaskForDraggingContext:(NSDraggingContext)context
 {
 	return NSDragOperationCopy;

--- a/Resources/XIBs/PBGitHistoryView.xib
+++ b/Resources/XIBs/PBGitHistoryView.xib
@@ -600,7 +600,7 @@
                                                                 </webView>
                                                             </subviews>
                                                         </view>
-                                                        <color key="fillColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <color key="fillColor" name="windowBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </box>
                                                 </subviews>
                                             </view>

--- a/Resources/html/css/GitX.css
+++ b/Resources/html/css/GitX.css
@@ -9,6 +9,25 @@ body {
 	font-size: 12px;
 }
 
+.body--light {
+    background: #fff;
+}
+
+.body--dark {
+    -webkit-filter: invert(0.89) hue-rotate(180deg);
+}
+
+.body--dark > * {
+    background-color: #fff;
+    color: #000;
+}
+
+.body--dark img {
+    -webkit-filter: invert(0.89)
+    hue-rotate(180deg)
+    contrast(160%);
+}
+
 table {
 	font-size: 12px;
 }

--- a/Resources/html/lib/GitX.js
+++ b/Resources/html/lib/GitX.js
@@ -66,3 +66,13 @@ var bindCommitSelectionLinks = function(el) {
 		}, false);
 	}
 };
+
+var setAppearance = function (appearance) {
+    if (appearance === "DARK") {
+        document.body.classList.remove('body--light');
+        document.body.classList.add('body--dark');
+    } else {
+        document.body.classList.remove('body--dark');
+        document.body.classList.add('body--light');
+    }
+};


### PR DESCRIPTION
This PR adds additional CSS and on-load hooks in order to make the HTML content of the app appear dark when the user's system is set to use dark mode in macOS Mojave.

e.g.
![gitx-dark](https://user-images.githubusercontent.com/55830/52340397-98e82880-2a07-11e9-9044-ff46a9c312a9.png)
