### PR TITLE
Cleanup commit header in history view for elements to stay in place

### DIFF
--- a/Resources/html/views/history/history.css
+++ b/Resources/html/views/history/history.css
@@ -62,6 +62,10 @@ a.servicebutton:hover {
 	font-family: Menlo, Monaco, monospace;
 }
 
+#parents span:not(:first-child)::before {
+	content: ', ';
+}
+
 .gravatar {
   float: left;
   margin-right: 5px;

--- a/Resources/html/views/history/history.css
+++ b/Resources/html/views/history/history.css
@@ -49,21 +49,27 @@ a.servicebutton:hover {
 	border: 2px solid #3465a4;
 }
 
-#gravatar {
-	margin-left: 5px;
-	padding: 2px;
-	width: 60px;
-	height: 60px;
+.commit_info {
+  table-layout: fixed;
+  width: 100%;
+}
 
-	border: solid gray 1px;
-	-webkit-border-radius: 2px;
+.commit_info th {
+  vertical-align: top;
+}
+
+.commit_info .date {
+	font-family: Menlo, Monaco, monospace;
+}
+
+.gravatar {
+  float: left;
+  margin-right: 5px;
 }
 
 .gravatar img {
-	width: 2.9em;
-	height: 2.9em;
-	max-height: 60px;
-	max-width: 60px;
+	height: 30px;
+	width: 30px;
 }
 
 .property_name {
@@ -265,51 +271,6 @@ a {
 	display: inline-block;
 	right: 30px;
 }
-
-/*
-div.button
-{
-	color: #666666;
-
-	font-size: 60%;
-	text-align: center;
-
-	width: 70px;
-
-	margin-right: 10px;
-
-	padding: 2px;
-
-	float: left;
-	clear: both;
-
-	border: 1px solid;
-	-webkit-border-radius: 3px;
-}
-
-div.created
-{
-	background-color: #ccffcc;
-	border-color: #66ff66;
-}
-
-div.changed
-{
-	background-color: #ffcc99;
-	border-color: #ff9933;
-}
-
-div.deleted
-{
-	background-color: #ffcccc;
-	border-color: #ff6666;
-}
-
-div.renamed
-{
-	// No colour needed right now.
-}
-*/
 
 #notification_message .cancel {
 	color: red;

--- a/Resources/html/views/history/history.js
+++ b/Resources/html/views/history/history.js
@@ -139,7 +139,7 @@ var reload = function() {
 var showRefs = function() {
 	var refs = $("refs");
 	if (commit.refs) {
-		refs.parentNode.classList.remove("hidden");
+		refs.classList.remove("hidden");
 		refs.textContent = "";
 		for (var i = 0; i < commit.refs.length; i++) {
 			var ref = commit.refs[i];
@@ -152,7 +152,7 @@ var showRefs = function() {
 			refs.appendChild(span);
 		}
 	} else
-		refs.parentNode.classList.add("hidden");
+		refs.classList.add("hidden");
 }
 
 var loadCommit = function(commitObject, currentRef) {
@@ -190,16 +190,22 @@ var loadCommit = function(commitObject, currentRef) {
 	$("date").textContent = commit.author_date;
 	setGravatar(commit.author_email, $("author_gravatar"));
 
-	if (commit.committer_name != commit.author_name) {
-		$("committerID").parentNode.classList.remove("hidden");
+	if (commit.committer_name != commit.author_name || commit.committer_email != commit.author_email) {
+		$("committerID").parentNode.parentNode.classList.remove("hidden");
 		setFormattedEmailContent($("committerID"), commit.committer_name, commit.committer_email);
-
-		$("committerDate").parentNode.classList.remove("hidden");
 		$("committerDate").textContent = commit.committer_date;
 		setGravatar(commit.committer_email, $("committer_gravatar"));
+
+		$("commitDate").parentNode.classList.add("hidden");
+	} else if (commit.committer_date != commit.author_date) {
+		$("commitDate").parentNode.classList.remove("hidden");
+
+		$("commitDate").textContent = commit.committer_date;
+
+		$("committerID").parentNode.parentNode.classList.add("hidden");
 	} else {
-		$("committerID").parentNode.classList.add("hidden");
-		$("committerDate").parentNode.classList.add("hidden");
+		$("committerID").parentNode.parentNode.classList.add("hidden");
+		$("commitDate").parentNode.classList.add("hidden");
 	}
 
 	var textToHTML = function (txt) {

--- a/Resources/html/views/history/history.js
+++ b/Resources/html/views/history/history.js
@@ -228,20 +228,19 @@ var loadCommit = function(commitObject, currentRef) {
 	while (filelist.hasChildNodes())
 		filelist.removeChild(filelist.lastChild);
 	showRefs();
-	removeParentsFromCommitHeader();
 
 	// Scroll to top
 	scroll(0, 0);
 
-	if (!commit.parents)
-		return;
-
-	for (var i = 0; i < commit.parents.length; i++) {
-		var newRow = $("commit_header").insertRow(-1);
-		newRow.innerHTML = "<td class='property_name'>Parent:</td><td>" +
-			"<a class='SHA commit-link' href=''>" +
-			commit.parents[i].SHA() + "</a></td>";
-		bindCommitSelectionLinks(newRow);
+	var parentsNode = $("parents");
+	parentsNode.innerHTML = '';
+	if (commit.parents) {
+		for (var i = 0; i < commit.parents.length; i++) {
+			var container = document.createElement("span");
+			container.innerHTML = '<a class="SHA commit-link" href="">' + commit.parents[i].SHA() + "</a>";
+			parentsNode.appendChild(container);
+		}
+		bindCommitSelectionLinks(parentsNode);
 	}
 
 	commit.notificationID = setTimeout(function() { 
@@ -251,16 +250,6 @@ var loadCommit = function(commitObject, currentRef) {
 	}, 500);
 
 }
-
-var removeParentsFromCommitHeader = function() {
-	for (var i = 0; i < $("commit_header").rows.length; ++i) {
-		var row = $("commit_header").rows[i];
-		if (row.innerHTML.match(/Parent:/)) {
-			row.parentNode.removeChild(row);
-			--i;
-		}
-	}
-};
 
 var showMultipleSelectionMessage = function(messageParts) {
 	jQuery("#commit").hide();

--- a/Resources/html/views/history/index.html
+++ b/Resources/html/views/history/index.html
@@ -37,6 +37,10 @@
 				</td>
 			</tr>
 			<tr>
+				<th class="property_name">Parents</th>
+				<td id="parents"></td>
+			</tr>
+			<tr>
 				<th class="property_name">Author</th>
 				<td>
 					<div class="gravatar hidden">

--- a/Resources/html/views/history/index.html
+++ b/Resources/html/views/history/index.html
@@ -24,60 +24,46 @@
 			</div>
 		</div>
 
-		<table>
+		<table class="commit_info">
 			<tr>
-				<td width="50%">
-					<table>
-						<tr>
-							<td class="property_name">Subject:</td>
-							<td id="subjectID"></td>
-						</tr>
-						<td colspan="2">
-							<table id="authorTable">
-								<tr>
-									<td class="property_name">Author:</td>
-									<td class="gravatar hidden" rowspan="2" align="center">
-										<img id="author_gravatar" src=""></img>
-									</td>
-									<td id="authorID"></td>
-								</tr>
-								<tr>
-									<td class="property_name">Date:</td>
-									<td id="date"></td>
-								</tr>
-								<tr class="hidden">
-									<td class="property_name">Committer:</td>
-									<td class="gravatar hidden" rowspan="2" align="center">
-										<img id="committer_gravatar" src=""></img>
-									</td>
-									<td id="committerID"></td>
-								</tr>
-								<tr class="hidden">
-									<td class="property_name">Date:</td>
-									<td id="committerDate"></td>
-								</tr>
-							</table>
-						</td>
-					</table>
+				<th class="property_name">Subject</th>
+				<td id="subjectID"></td>
+			</tr>
+			<tr>
+				<th class="property_name">ID</th>
+				<td>
+					<span id="commitID" class="SHA"></span>
+					<span id="refs"></span>
 				</td>
-				<td width="50%">
-					<table  id="commit_header">
-						<tr></tr>
-						<tr>
-							<td class="property_name">SHA:</td>
-							<td id="commitID" class="SHA"></td>
-						</tr>
-						<tr class="hidden">
-							<td class="property_name">Refs:</td>
-							<td id="refs"></td>
-						</tr>
-					</table>
+			</tr>
+			<tr>
+				<th class="property_name">Author</th>
+				<td>
+					<div class="gravatar hidden">
+						<img id="author_gravatar" src="" />
+					</div>
+					<div id="authorID"></div>
+					<div id="date" class="date"></div>
+					<div class="hidden">
+						<span id="commitDate" class="date"></span>
+						(Commit date)
+					</div>
+				</td>
+			</tr>
+			<tr class="hidden">
+				<th class="property_name">Committer</th>
+				<td>
+					<div class="gravatar hidden">
+						<img id="committer_gravatar" src="" />
+					</div>
+					<div id="committerID"></div>
+					<div id="committerDate" class="date"></div>
 				</td>
 			</tr>
 		</table>
 
 		<div id="notification" class="hidden">
-			<img src="../../images/spinner.gif" alt="Spinner" id="spinner"></img>
+			<img src="../../images/spinner.gif" alt="Spinner" id="spinner" />
 			<div id="notification_message"></div>
 		</div>
 


### PR DESCRIPTION
Originally I wanted to get rid of fields jumping due to height change. In the end I flattened multi-level table structure and converted view to 3 possible states:
- when name, email and date of author and committer are same, then only author info is shown
- when name and email are same, but date is different, then additional commit date is shown in author info
- when name or email of author and committer are different, then author and committer info are shown separately.

Plus a bit of cleanup