### PR TITLE
More modern Syntaxhighlighter submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/sparkle-project/Sparkle.git
 [submodule "SyntaxHighlighter"]
 	path = External/SyntaxHighlighter
-	url = https://github.com/alexgorbatchev/SyntaxHighlighter.git
+	url = https://github.com/syntaxhighlighter/syntaxhighlighter.git
 [submodule "MGScopeBar"]
 	path = External/MGScopeBar
 	url = https://github.com/gitx/MGScopeBar.git


### PR DESCRIPTION
In the current submodule there is a message 'The project has moved to https://github.com/syntaxhighlighter'

The old one has only 2 README.md commits more but is _some_ commits behind

<img width="554" alt="image" src="https://user-images.githubusercontent.com/3314607/106125575-9df69300-615c-11eb-883f-a9755fcb1b3e.png">
