### PR TITLE
Fix exception when dragging files in the unstaged and staged changes table views

### DIFF
--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -670,11 +670,11 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray<PBChangedFile *> *files)
 	NSArray *files = [controller.arrangedObjects objectsAtIndexes:rowIndexes];
 	NSURL *workingDirectoryURL = self.repository.workingDirectoryURL;
 
-	NSMutableArray<NSURL *> *URLs = [NSMutableArray arrayWithCapacity:rowIndexes.count];
+	NSMutableArray<NSString *> *paths = [NSMutableArray arrayWithCapacity:rowIndexes.count];
 	for (PBChangedFile *file in files) {
-		[URLs addObject:[workingDirectoryURL URLByAppendingPathComponent:file.path]];
+		[paths addObject:[[workingDirectoryURL URLByAppendingPathComponent:file.path] path]];
 	}
-	[pboard writeObjects:URLs];
+	[pboard setPropertyList:paths forType:NSFilenamesPboardType];
 
 	return YES;
 }


### PR DESCRIPTION
Drag and drop in NSTableView became more strict on 10.14.

Use setPropertyList:forType: to silence this exception when dragging:
> There are 2 items on the pasteboard, but 1 drag images. There must be 1 draggingItem per pasteboardItem.