### PR TITLE
ci: save build artifacts

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -32,6 +32,7 @@ jobs:
           tar -acf GitX.xcarchive.zip GitX.xcarchive
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
+        if: ${{ success() }}
         with:
           name: GitX-${{ matrix.xcode }}.xcarchive
           path: GitX.xcarchive.zip

--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -1,6 +1,5 @@
 name: build-gitx
 
-
 on:
   push:
     branches:
@@ -28,4 +27,11 @@ jobs:
       - name: pre build
         run: cd External/objective-git && script/bootstrap && script/update_libgit2 && cd ../..
       - name: Build project
-        run: xcodebuild -workspace GitX.xcworkspace -scheme GitX archive
+        run: |
+          xcodebuild -workspace GitX.xcworkspace -scheme GitX -archivePath ./GitX archive
+          tar -acf GitX.xcarchive.zip GitX.xcarchive
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: GitX-${{ matrix.xcode }}.xcarchive
+          path: GitX.xcarchive.zip


### PR DESCRIPTION
This saves `.xcarchive` build artifacts, which include the prebuilt binaries for each CI run. This is my first time using Github Actions, so any pointers or advice are very welcome. After downloading and extracting, `GitX.app` is located at `GitX.xcarhive/Products/Applications/GitX.app`

This is based on:
- https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
- https://github.com/utmapp/UTM/blob/master/.github/workflows/build.yml
- https://github.com/utmapp/UTM/blob/master/scripts/build_utm.sh

(The latter 2 based @hannesa2's comment in https://github.com/gitx/gitx/issues/240#issuecomment-1014393822)

I followed UTMs lead and zipped the `.xcarchive` in CI, which I assume is just easier/faster for CI to deal with. However, when downloading artifacts, it zips them again, so the downloaded file is a zip that contains a zip that itself contains the `GitX.xcarchive` dir/package. We could skip the tar/zip step in CI, which would result in the download just being a zip that contains the `.xcarchive`, but I don't know if that would slow down CI or anything for having to deal w/ uploading all of the files individually. Opinions?

These are not "releases", they are just artifacts. As such, they will only be retained for 90 days (the default and [max allowed for public repos](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#artifact-and-log-retention-policy)). If someone wants to take this and run w/ it to make it more of a nightly release mechanism, please have at it.

This doesn't fix the local build issues that many of us seem to be having (see #239), but it at least allows us to use whatever black magic is happening in CI to access a recent build.

See #240 #221 #239 and generally any other error w/ a title like "build failure" or "cannot build".