### PR TITLE
Change CI artifact to dmg

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -27,7 +27,7 @@ jobs:
       - name: pre build
         run: cd External/objective-git && script/bootstrap && script/update_libgit2 && cd ../..
       - name: Build project
-        run: xcodebuild -workspace GitX.xcworkspace -scheme GitX -archivePath ./GitX archive
+        run: xcodebuild -workspace GitX.xcworkspace -scheme GitX -archivePath ./GitX archive ARCHS="x86_64 arm64"
       - name: Prepare artifact
         run: |
           mv GitX.xcarchive/Products/Applications/GitX.app .

--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: [ Xcode_12.5, Xcode_13.1, Xcode_13.2.1, Xcode_13.0, Xcode_12.4 ]
+        xcode: [ Xcode_12.4, Xcode_12.5, Xcode_13.0, Xcode_13.1, Xcode_13.2.1 ]
     steps:
       - name: ls Xcode
         run: ls -la /Applications/Xcode*
@@ -27,12 +27,14 @@ jobs:
       - name: pre build
         run: cd External/objective-git && script/bootstrap && script/update_libgit2 && cd ../..
       - name: Build project
+        run: xcodebuild -workspace GitX.xcworkspace -scheme GitX -archivePath ./GitX archive
+      - name: Prepare artifact
         run: |
-          xcodebuild -workspace GitX.xcworkspace -scheme GitX -archivePath ./GitX archive
-          tar -acf GitX.xcarchive.zip GitX.xcarchive
-      - name: Upload artifacts
+          mv GitX.xcarchive/Products/Applications/GitX.app .
+          hdiutil create -fs HFS+ -srcfolder GitX.app -volname GitX GitX.dmg
+      - name: Upload artifact
         uses: actions/upload-artifact@v2
         if: ${{ success() }}
         with:
-          name: GitX-${{ matrix.xcode }}.xcarchive
-          path: GitX.xcarchive.zip
+          name: GitX built by ${{ matrix.xcode }}
+          path: GitX.dmg


### PR DESCRIPTION
This changes the CI artifact from a `.xcarchive` directory to `.dmg` that contains a working `GitX.app`. I'm not sure what I was running into yesterday when it seemed like the `.xcarchive` was important. I suspect that it had to do w/ the artifact upload CI workflow losing some Mac specific info from some files, but that's just a guess.

I went deep into using `xcodebuild` to export an app directly from the `.xcarchive`, but that appears to require developer certificates, signing, etc, so I abandoned that and went back to study how it's done by UTM (which I'm not familiar with and have never used, but which was shared by @hannesa2). They have a [`package_mac.sh`](https://github.com/utmapp/UTM/blob/master/scripts/package_mac.sh) script running in CI that has a pretty clear "unsigned" code path, and produces a dmg containing a `.app`. The relevant parts of this PR are just lifted from that.

**Notes**
- Personally, I would prefer a `.zip` to a `.dmg`. A zip gets extracted to a working `.app` w/o any need to mount/unmount a dmg. I find that simpler, but this isn't super important to me, as long as it works for other folks.
- I also reordered the list of Xcode targets so they're in ascending order.
- I changed the name of the artifact from `GitX-Xcode_13.2.1` to `GitX build by Xcode_13.2.1`, but I'm fine to change it back if others prefer that.