### PR TITLE
Release job

### DIFF
--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -1,0 +1,32 @@
+{
+  "categories": [
+    {
+      "title": "## 🚀 Features",
+      "labels": [
+        "feature",
+        "enhancement"
+      ]
+    },
+    {
+      "title": "## 🐛 Fixes",
+      "labels": [
+        "fix",
+        "bug"
+      ]
+    },
+    {
+      "title": "## 💬 Maintenance",
+      "labels": [
+        "maintenance"
+      ]
+    }
+  ],
+  "ignore_labels": [
+    "dependencies",
+    "gradle-wrapper"
+  ],
+  "sort": "ASC",
+  "template": "${{CHANGELOG}}",
+  "pr_template": "- ${{TITLE}}\n   - PR: #${{NUMBER}}",
+  "empty_template": "- no changes"
+}

--- a/.github/workflows/BuildRelease.yml
+++ b/.github/workflows/BuildRelease.yml
@@ -1,0 +1,58 @@
+name: build-gitx
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-gitx:
+    name: build-gitx
+    runs-on: macos-11
+    strategy:
+      fail-fast: false
+      matrix:
+        xcode: [ Xcode_13.2.1 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Find Tag
+        id: tagger
+        uses: jimschubert/query-tag-action@v2
+        with:
+          skip-unshallow: 'true'
+          abbrev: false
+          commit-ish: HEAD
+      - name: Set XCode Version
+        run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app
+      - name: pre build
+        run: cd External/objective-git && script/bootstrap && script/update_libgit2 && cd ../..
+      - name: Build project
+        run: xcodebuild -workspace GitX.xcworkspace -scheme GitX -archivePath ./GitX archive ARCHS="x86_64 arm64"
+      - name: Prepare artifact
+        run: |
+          mv GitX.xcarchive/Products/Applications/GitX.app .
+          hdiutil create -fs HFS+ -srcfolder GitX.app -volname GitX GitX.dmg
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{steps.tagger.outputs.tag}}
+          release_name: Release ${{steps.tagger.outputs.tag}}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset ${{steps.tagger.outputs.tag}}
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: GitX.dmg
+          asset_name: GitX built by ${{ matrix.xcode }}.dmg
+          asset_content_type: application/zip

--- a/.github/workflows/BuildRelease.yml
+++ b/.github/workflows/BuildRelease.yml
@@ -26,6 +26,13 @@ jobs:
           skip-unshallow: 'true'
           abbrev: false
           commit-ish: HEAD
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@main
+        with:
+          configuration: ".github/changelog-configuration.json"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set XCode Version
         run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app
       - name: pre build
@@ -45,6 +52,7 @@ jobs:
           tag_name: ${{steps.tagger.outputs.tag}}
           release_name: Release ${{steps.tagger.outputs.tag}}
           draft: false
+          body: ${{steps.github_release.outputs.changelog}}
           prerelease: false
       - name: Upload Release Asset ${{steps.tagger.outputs.tag}}
         id: upload-release-asset


### PR DESCRIPTION
Only be create a new tag, eg 
```
git tag -a 0.17 -m "something" 
git push --tags
```
the release pipeline is now triggered. 
Here https://github.com/hannesa2/gitx/releases/tag/0.19.dmg you can see one of my test drives.

I will create late a new version to have a new baseline of releases