### PR TITLE
Sparkle: use info-only updates until we can sign the app

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -11,28 +11,33 @@ include_prereleases: false
             {% if release.prerelease and page.include_prereleases != true %}{% continue %}{% endif %}
 
             {% assign version = release.tag_name %}
-            {% assign short_version = nil %}
+            {% assign short_version = release.tag_name %}
 
-            {% for asset in release.assets %}
-                {% assign asset_ext = asset.browser_download_url | slice: -3, 3 %}
-                {% if asset_ext != "dmg" %}{% break %}{% endif %}
-                {% assign asset_url = asset.browser_download_url %}
-                {% assign asset_size = asset.size %}
-            {% endfor %}
-            {% if asset_url %}
             <item>
                 <title>{{ release.name }}</title>
-                <description><![CDATA[{{ release.body | markdownify }}]]></description>
+                <description><![CDATA[
+                    <p>
+                        At this time, automatic updates are not working and you
+                        will have to <strong>download and install this update
+                        yourself</strong> from the
+                        <a href="{{ release.html_url }}">GitX release page.</a>
+                    </p>
+
+                    <p>
+                        Builds are available for Intel and Apple Silicon, but
+                        all builds are unsigned at this time.
+                        If you would like to help fix this, please
+                        <a href="https://github.com/gitx/gitx/issues/278">get
+                        in touch</a>.
+                    </p>
+
+                    {{ release.body | markdownify }}]]></description>
                 <pubDate>{{ release.published_at | date_to_rfc822 }}</pubDate>
-                <enclosure
-                    url="{{ asset_url }}"
-                    sparkle:version="{{ version }}"
-                    {% if short_version %}sparkle:shortVersionString="{{ short_version }}"{% endif %}
-                    length="{{ asset_size }}"
-                    type="application/octet-stream"
-                />
+                <sparkle:version>{{ version }}</sparkle:version>
+                <sparkle:shortVersionString>{{ version }}</sparkle:shortVersionString>
+                <sparkle:informationalUpdate />
+                <link>{{ release.html_url }}</link>
             </item>
-            {% endif %}
         {% endfor %}
     </channel>
 </rss>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="1; url=https://gitx.github.io">
+
+        <script>
+            window.location.href = "https://gitx.github.io";
+        </script>
+
+        <title>Page Moved</title>
+    </head>
+    <body>
+        This page has moved. If you are not redirected automatically, please
+        visit <a href="https://gitx.github.io">https://gitx.github.io</a>.
+    </body>
+</html>


### PR DESCRIPTION
1. Adds an `index.html` stub to `gitx.github.io/gitx/` to redirect users to `gitx.github.io` (closes #292)
2. Alters the Sparkle appcast so that it offers "info only" updates instead of offering the option to install the update (which doesn't currently work) (closes #291)

It also adds some info to the release notes for each release (in the appcast only) that briefly explain this. This is what it looks like in-app:

<img width="623" alt="Screen Shot 2022-02-18 at 12 57 54 PM" src="https://user-images.githubusercontent.com/1420419/154738579-05f81545-c09d-4ee0-a3dd-19f327eace8a.png">

The link to "GitX release page" points to the URL for each release, eg https://github.com/gitx/gitx/releases/tag/0.18.1, and the link to get in touch to help w/ app signing points to #278.

Also note that the button that normally says "Install Update" has changed to "Learn More..." which also points to the URL for that release.

I think that this is our best bet for the time being. If we ever get app signing set up, we can revert this and offer proper updates again. 
