### PR TITLE
enable gpg signing

### DIFF
--- a/Classes/git/PBGitIndex.m
+++ b/Classes/git/PBGitIndex.m
@@ -351,6 +351,10 @@ NS_ENUM(NSUInteger, PBGitIndexOperation){
 		[arguments addObject:parent];
 	}
 
+    if (/* gpg-signing preference is set */ true) {
+        [arguments addObject:@"--gpg-sign"];
+    }
+
 	[self postCommitUpdate:@"Creating commit"];
 
 	if (doVerify) {


### PR DESCRIPTION
This is based on nanotech's patch here -- however using the `--gpg-sign` arg now seems to work.
https://github.com/gitx/gitx/issues/32#issuecomment-280474077

This is not a complete pull request because adding the arg for gpg signing
should only happen if one or maybe ALL of the following are true:

- A "GPG Sign" GitX preference is set to true
- A git `[commit]` setting in either a local or global .gitconfig includes: `gpgsign = true`
- The directory `~/gnupg` exists

The commit in this pull request created with my local build of GitX with this branch on an M1 Pro Mac is signed -- so it seems to work.

![image](https://user-images.githubusercontent.com/7188/184424244-111dea1a-1fd6-430f-b060-ce39269f5d8c.png)
