### PR TITLE
Trying to fix visual glitches appearing on Mac OS 10.x

### DIFF
--- a/Resources/XIBs/PBGitHistoryView.xib
+++ b/Resources/XIBs/PBGitHistoryView.xib
@@ -265,7 +265,7 @@
                                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                         <prototypeCellViews>
                                                             <tableCellView id="QW1-Ci-DxI" customClass="PBGitRevisionCell">
-                                                                <rect key="frame" x="66" y="1" width="300" height="20"/>
+                                                                <rect key="frame" x="81" y="1" width="300" height="20"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                 <subviews>
                                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OF0-ZO-8uI">
@@ -309,7 +309,7 @@
                                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                         <prototypeCellViews>
                                                             <tableCellView id="zBQ-pj-UmV">
-                                                                <rect key="frame" x="369" y="1" width="129" height="20"/>
+                                                                <rect key="frame" x="384" y="1" width="129" height="20"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                 <subviews>
                                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="OLP-oG-AlI">
@@ -814,7 +814,7 @@ IA
                             </connections>
                         </button>
                         <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="48">
-                            <rect key="frame" x="268" y="3" width="67" height="23"/>
+                            <rect key="frame" x="268" y="3" width="80" height="23"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="texturedSquare" trackingMode="selectOne" id="51">
                                 <font key="font" metaFont="system"/>

--- a/Resources/XIBs/PBGitSidebarView.xib
+++ b/Resources/XIBs/PBGitSidebarView.xib
@@ -18,19 +18,19 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView wantsLayer="YES" id="36" userLabel="Source List View">
-            <rect key="frame" x="0.0" y="0.0" width="153" height="354"/>
+            <rect key="frame" x="0.0" y="0.0" width="173" height="354"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <scrollView focusRingType="none" fixedFrame="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="22" horizontalPageScroll="10" verticalLineScroll="22" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8">
-                    <rect key="frame" x="0.0" y="0.0" width="153" height="354"/>
+                    <rect key="frame" x="0.0" y="0.0" width="173" height="354"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <clipView key="contentView" ambiguous="YES" drawsBackground="NO" id="gc4-jw-Izc">
-                        <rect key="frame" x="0.0" y="0.0" width="153" height="354"/>
+                        <rect key="frame" x="0.0" y="0.0" width="173" height="354"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <outlineView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="22" viewBased="YES" floatsGroupRows="NO" indentationPerLevel="14" outlineTableColumn="13" id="11" customClass="PBSidebarList">
-                                <rect key="frame" x="0.0" y="0.0" width="153" height="354"/>
                                 <autoresizingMask key="autoresizingMask"/>
+                                <rect key="frame" x="0.0" y="0.0" width="173" height="354"/>
                                 <size key="intercellSpacing" width="3" height="0.0"/>
                                 <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
@@ -154,7 +154,7 @@
                     </popUpButtonCell>
                 </popUpButton>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="47">
-                    <rect key="frame" x="96" y="1" width="157" height="25"/>
+                    <rect key="frame" x="96" y="1" width="180" height="25"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="texturedSquare" trackingMode="momentary" id="48">
                         <font key="font" metaFont="system"/>

--- a/Resources/en.lproj/RepositoryWindow.xib
+++ b/Resources/en.lproj/RepositoryWindow.xib
@@ -122,6 +122,10 @@
                             <constraint firstAttribute="height" constant="31" id="kbj-zH-ihc"/>
                         </constraints>
                     </customView>
+                    <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Im1-ZH-qxe">
+                        <rect key="frame" x="0.0" y="28" width="890" height="5"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                    </box>
                 </subviews>
                 <constraints>
                     <constraint firstItem="351" firstAttribute="top" secondItem="5" secondAttribute="top" id="2S1-Si-krf"/>


### PR DESCRIPTION
Just a try to fix https://github.com/gitx/gitx/issues/348.
- Added separator in main window footer area
- Added some extra spacing to toolbar segmented buttons

Disclaimer:
- Wasn't able to compile to test properly
- Was unsure which how many automatic modifications by Xcode I had to cut out again