### PR TITLE
Improve the Settings (Preferences) window

### DIFF
--- a/Resources/en.lproj/Preferences.xib
+++ b/Resources/en.lproj/Preferences.xib
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9060" systemVersion="15D21" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9060"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PBPrefsWindowController">
@@ -15,18 +16,14 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="1" userLabel="General">
-            <rect key="frame" x="0.0" y="0.0" width="400" height="250"/>
+            <rect key="frame" x="0.0" y="0.0" width="500" height="250"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-            <userGuides>
-                <userLayoutGuide location="121" affinity="minX"/>
-            </userGuides>
             <subviews>
-                <button id="114">
-                    <rect key="frame" x="18" y="192" width="273" height="18"/>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="114">
+                    <rect key="frame" x="103" y="191" width="273" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Show whitespace differences" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="115">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -35,10 +32,9 @@
                         <binding destination="28" name="value" keyPath="values.PBShowWhitespaceDifferences" id="117"/>
                     </connections>
                 </button>
-                <button id="153">
-                    <rect key="frame" x="18" y="214" width="273" height="18"/>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="153">
+                    <rect key="frame" x="103" y="213" width="273" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Watch for changes in repositories" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="154">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -47,10 +43,9 @@
                         <binding destination="28" name="value" keyPath="values.PBUseRepositoryWatcher" id="163"/>
                     </connections>
                 </button>
-                <button id="77">
-                    <rect key="frame" x="306" y="93" width="54" height="16"/>
+                <button toolTip="Reset to 'No executable set'" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="77">
+                    <rect key="frame" x="378" y="91" width="16" height="16"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="bevel" bezelStyle="regularSquare" image="NSStopProgressFreestandingTemplate" imagePosition="left" alignment="left" alternateImage="NSStopProgressFreestandingTemplate" state="on" imageScaling="proportionallyDown" inset="2" id="78">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -64,20 +59,20 @@
                         </binding>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" id="47">
-                    <rect key="frame" x="118" y="53" width="192" height="28"/>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="47">
+                    <rect key="frame" x="124" y="52" width="270" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
-                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Select the git executable you wish to use or drag it from the finder." id="48">
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="48">
                         <font key="font" metaFont="smallSystem"/>
+                        <string key="title">Select the git executable you wish to use
+or drag it from the Finder.</string>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <pathControl focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" id="45">
-                    <rect key="frame" x="121" y="89" width="179" height="22"/>
+                <pathControl focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="45">
+                    <rect key="frame" x="195" y="88" width="179" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <pathCell key="cell" controlSize="small" selectable="YES" editable="YES" focusRingType="none" alignment="left" pathStyle="popUp" id="46">
                         <font key="font" metaFont="smallSystem"/>
                         <connections>
@@ -89,27 +84,25 @@
                         <binding destination="28" name="value" keyPath="values.gitExecutable" id="86">
                             <dictionary key="options">
                                 <integer key="NSAllowsEditingMultipleValuesSelection" value="0"/>
-                                <string key="NSNullPlaceholder">No Executable set</string>
+                                <string key="NSNullPlaceholder">No executable set</string>
                                 <string key="NSValueTransformerName">PBNSURLPathUserDefaultsTransfomer</string>
                             </dictionary>
                         </binding>
                         <outlet property="delegate" destination="-2" id="54"/>
                     </connections>
                 </pathControl>
-                <textField verticalHuggingPriority="750" id="43">
-                    <rect key="frame" x="17" y="93" width="99" height="17"/>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="43">
+                    <rect key="frame" x="103" y="91" width="99" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Git Executable:" id="44">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button id="126">
-                    <rect key="frame" x="18" y="170" width="279" height="18"/>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="126">
+                    <rect key="frame" x="103" y="169" width="279" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Show column guides in commit message" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="127">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -118,23 +111,22 @@
                         <binding destination="28" name="value" keyPath="values.PBCommitMessageViewHasVerticalLine" id="133"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" id="128">
-                    <rect key="frame" x="47" y="148" width="196" height="17"/>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="128">
+                    <rect key="frame" x="124" y="145" width="196" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Display body guide at column:" id="129">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" id="130">
-                    <rect key="frame" x="248" y="145" width="41" height="22"/>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="130">
+                    <rect key="frame" x="337" y="142" width="41" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="131">
+                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" formatWidth="-1" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="Sk0-yU-eAV"/>
                         <font key="font" metaFont="system"/>
-                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                     <connections>
@@ -145,23 +137,30 @@
                         </binding>
                     </connections>
                 </textField>
-                <textField verticalHuggingPriority="750" id="145">
-                    <rect key="frame" x="47" y="121" width="211" height="17"/>
+                <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oHn-U1-E1H">
+                    <rect key="frame" x="376" y="139" width="19" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
+                    <stepperCell key="cell" continuous="YES" alignment="left" maxValue="200" id="7mM-Lr-k9g"/>
+                    <connections>
+                        <binding destination="28" name="value" keyPath="values.PBCommitMessageViewVerticalLineLength" id="GRU-dK-x5r"/>
+                    </connections>
+                </stepper>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="145">
+                    <rect key="frame" x="124" y="119" width="211" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Display subject guide at column:" id="148">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" id="146">
-                    <rect key="frame" x="263" y="118" width="41" height="22"/>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="146">
+                    <rect key="frame" x="337" y="116" width="41" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="147">
+                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" formatWidth="-1" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="Rih-TW-mKW"/>
                         <font key="font" metaFont="system"/>
-                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                     <connections>
@@ -172,10 +171,17 @@
                         </binding>
                     </connections>
                 </textField>
-                <button toolTip="Resets the of the &quot;Don't show this again&quot; preferences." verticalHuggingPriority="750" id="136">
-                    <rect key="frame" x="182" y="13" width="137" height="32"/>
+                <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8S8-EY-tZ9">
+                    <rect key="frame" x="376" y="113" width="19" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
+                    <stepperCell key="cell" continuous="YES" alignment="left" maxValue="200" id="MFg-eF-42q"/>
+                    <connections>
+                        <binding destination="28" name="value" keyPath="values.PBCommitMessageViewVerticalBodyLineLength" id="Msp-0z-nMb"/>
+                    </connections>
+                </stepper>
+                <button toolTip="Resets the &quot;Don't show this again&quot; preferences." verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="136">
+                    <rect key="frame" x="262" y="13" width="137" height="32"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Reset Warnings" bezelStyle="rounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="139">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -184,10 +190,9 @@
                         <action selector="resetAllDialogWarnings:" target="-2" id="140"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" id="137">
-                    <rect key="frame" x="17" y="23" width="166" height="17"/>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="137">
+                    <rect key="frame" x="103" y="22" width="166" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Reset all dialog warnings:" id="138">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -195,19 +200,15 @@
                     </textFieldCell>
                 </textField>
             </subviews>
-            <animations/>
+            <point key="canvasLocation" x="30" y="125"/>
         </customView>
         <customView id="4" userLabel="Updates">
-            <rect key="frame" x="0.0" y="0.0" width="400" height="139"/>
+            <rect key="frame" x="0.0" y="0.0" width="500" height="139"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-            <userGuides>
-                <userLayoutGuide location="42" affinity="minX"/>
-            </userGuides>
             <subviews>
-                <button verticalHuggingPriority="750" id="23">
-                    <rect key="frame" x="128" y="13" width="96" height="28"/>
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="23">
+                    <rect key="frame" x="156" y="12" width="96" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="push" title="Check Now" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="24">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="smallSystem"/>
@@ -216,11 +217,10 @@
                         <action selector="checkForUpdates:" target="26" id="55"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" id="21">
-                    <rect key="frame" x="130" y="45" width="251" height="14"/>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="21">
+                    <rect key="frame" x="160" y="44" width="263" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
-                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="DATE ..." id="22">
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Wednesday, September 25, 2999 at 12:34:56 AM" id="22">
                         <dateFormatter key="formatter" formatterBehavior="custom10_4" dateStyle="full" timeStyle="medium" id="42"/>
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -230,11 +230,10 @@
                         <binding destination="28" name="value" keyPath="values.SULastCheckTime" id="41"/>
                     </connections>
                 </textField>
-                <textField verticalHuggingPriority="750" id="19">
-                    <rect key="frame" x="39" y="80" width="89" height="17"/>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="19">
+                    <rect key="frame" x="76" y="76" width="80" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
-                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Update interval:" id="20">
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Interval:" id="20">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -243,10 +242,9 @@
                         <binding destination="26" name="enabled" keyPath="automaticallyChecksForUpdates" id="36"/>
                     </connections>
                 </textField>
-                <popUpButton verticalHuggingPriority="750" id="13">
-                    <rect key="frame" x="130" y="78" width="102" height="22"/>
+                <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="13">
+                    <rect key="frame" x="158" y="74" width="102" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <popUpButtonCell key="cell" type="push" title="Monthly" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="2629800" imageScaling="proportionallyDown" inset="2" selectedItem="18" id="14">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="smallSystem"/>
@@ -264,10 +262,9 @@
                         <binding destination="26" name="selectedTag" keyPath="updateCheckInterval" id="31"/>
                     </connections>
                 </popUpButton>
-                <button id="11">
-                    <rect key="frame" x="18" y="103" width="260" height="18"/>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="11">
+                    <rect key="frame" x="76" y="102" width="260" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Automatically check for updates" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="12">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -276,10 +273,9 @@
                         <binding destination="26" name="value" keyPath="automaticallyChecksForUpdates" id="27"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" id="9">
-                    <rect key="frame" x="39" y="45" width="82" height="14"/>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9">
+                    <rect key="frame" x="76" y="44" width="80" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Last update:" id="10">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -287,16 +283,15 @@
                     </textFieldCell>
                 </textField>
             </subviews>
-            <animations/>
+            <point key="canvasLocation" x="30" y="-125.5"/>
         </customView>
         <customView id="62" userLabel="Open Panel Accessory">
             <rect key="frame" x="0.0" y="0.0" width="239" height="54"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <button id="63">
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="63">
                     <rect key="frame" x="18" y="18" width="203" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Show all files and directories" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="64">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -306,18 +301,17 @@
                     </connections>
                 </button>
             </subviews>
-            <animations/>
+            <point key="canvasLocation" x="-102" y="-451"/>
         </customView>
         <customObject id="26" customClass="SUUpdater"/>
         <userDefaultsController representsSharedInstance="YES" id="28"/>
         <customView id="87" userLabel="Integration">
-            <rect key="frame" x="0.0" y="0.0" width="400" height="116"/>
+            <rect key="frame" x="0.0" y="0.0" width="500" height="116"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <button id="108">
-                    <rect key="frame" x="38" y="38" width="179" height="18"/>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="108">
+                    <rect key="frame" x="168" y="38" width="179" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Make Gists public" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="109">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -327,23 +321,21 @@
                         <binding destination="28" name="value" keyPath="values.PBGistPublic" id="113"/>
                     </connections>
                 </button>
-                <button id="97">
-                    <rect key="frame" x="38" y="60" width="181" height="18"/>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="97">
+                    <rect key="frame" x="168" y="60" width="181" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Confirm creation of Gists" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="98">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <binding destination="28" name="enabled" keyPath="values.PBEnableGist" id="107"/>
                         <binding destination="28" name="value" keyPath="values.PBConfirmPublicGists" id="104"/>
+                        <binding destination="28" name="enabled" keyPath="values.PBEnableGist" id="107"/>
                     </connections>
                 </button>
-                <button id="88">
-                    <rect key="frame" x="18" y="18" width="121" height="18"/>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="88">
+                    <rect key="frame" x="148" y="17" width="121" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Enable Gravatar" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="91">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -352,11 +344,10 @@
                         <binding destination="28" name="value" keyPath="values.PBEnableGravatar" id="96"/>
                     </connections>
                 </button>
-                <button id="89">
-                    <rect key="frame" x="18" y="80" width="111" height="18"/>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="89">
+                    <rect key="frame" x="148" y="81" width="169" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <animations/>
-                    <buttonCell key="cell" type="check" title="Enable ‘Gist it’" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="90">
+                    <buttonCell key="cell" type="check" title="Enable ‘Gist it’ button" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="90">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -365,10 +356,10 @@
                     </connections>
                 </button>
             </subviews>
-            <animations/>
+            <point key="canvasLocation" x="29" y="-310"/>
         </customView>
     </objects>
     <resources>
-        <image name="NSStopProgressFreestandingTemplate" width="14" height="14"/>
+        <image name="NSStopProgressFreestandingTemplate" width="20" height="20"/>
     </resources>
 </document>


### PR DESCRIPTION
Fixes #219

* The window is wider, avoiding the overflow menu.
* The controls were all re-aligned and adjusted to look nicer with better spacing between them, and center aligned in the window.
* The numeric control is enforced now (doesn't accept non-numeric input) and a stepper is added.
* Some text labels and tooltips were improved.

Note that the changes were done using Xcode Storyboard, so the XML code was automatically generated.

Screenshots:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/6047296/221417893-75887869-aecb-4cd1-bf2a-176fec82c830.png">
<img width="500" alt="image" src="https://user-images.githubusercontent.com/6047296/221417907-f9ba33bd-04aa-4e0e-8d54-c24ae61db0e6.png">
<img width="500" alt="image" src="https://user-images.githubusercontent.com/6047296/221417924-07cd6bae-fdb0-4d89-a039-effd14d13106.png">
