### PR TITLE
Ignore the generated build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__/
 *.pyc
 /GitX.xcworkspace/xcuserdata
 .idea
+GitX.xcarchive/
+GitX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/
+GitX.xcworkspace/xcshareddata/swiftpm/


### PR DESCRIPTION
These are generated by the build process (`xcodebuild`) and shouldn't be committed.