### PR TITLE
Use HTTPS instead of SSH for cloning the submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "objective-git"]
 	path = External/objective-git
-	url = git@github.com:gitx/objective-git.git
+	url = https://github.com/gitx/objective-git.git
 [submodule "Sparkle"]
 	path = External/Sparkle
-	url = git@github.com:sparkle-project/Sparkle.git
+	url = https://github.com/sparkle-project/Sparkle.git
 [submodule "SyntaxHighlighter"]
 	path = External/SyntaxHighlighter
-	url = git@github.com:syntaxhighlighter/syntaxhighlighter.git
+	url = https://github.com/syntaxhighlighter/syntaxhighlighter.git
 [submodule "MGScopeBar"]
 	path = External/MGScopeBar
-	url = git@github.com:gitx/MGScopeBar.git
+	url = https://github.com/gitx/MGScopeBar.git
 [submodule "External/MAKVONotificationCenter"]
 	path = External/MAKVONotificationCenter
-	url = git@github.com:mikeash/MAKVONotificationCenter
+	url = https://github.com/mikeash/MAKVONotificationCenter.git


### PR DESCRIPTION
GitHub recommends using HTTPS. It's also easier to clone as we don't need to setup the public/private key pair needed for SSH.

Please run `git submodule sync` to update the actual submodules. See https://stackoverflow.com/a/30885128/1134080 for more info.