### PR TITLE
Add a link to Applications in the DMG file

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -75,7 +75,9 @@ jobs:
           echo "EXPORT_OPTIONS_PATH=$EXPORT_OPTIONS_PATH"
           xcodebuild -exportArchive -archivePath GitX.xcarchive -exportPath . -exportOptionsPlist EXPORT_OPTIONS_PATH
           echo "Create GitX-${{ matrix.abi }}.dmg"
-          hdiutil create -fs HFS+ -srcfolder GitX.app -volname GitX GitX-${{ matrix.abi }}.dmg
+          mkdir dist && cp -R GitX.app dist/ && ln -s /Applications dist/
+          hdiutil create -fs HFS+ -srcfolder dist/ -volname GitX GitX-${{ matrix.abi }}.dmg
+          rm -rf dist
           zip -r GitX-${{ matrix.abi }}.zip GitX.app
       - name: Notarize App
         if: ${{ env.variableSet != '' }}

--- a/.github/workflows/BuildRelease.yml
+++ b/.github/workflows/BuildRelease.yml
@@ -74,7 +74,9 @@ jobs:
           echo -n "$EXPORT_OPTIONS" > EXPORT_OPTIONS_PATH
           xcodebuild -exportArchive -archivePath GitX.xcarchive -exportPath . -exportOptionsPlist EXPORT_OPTIONS_PATH
           echo "Create GitX-${{ matrix.abi }}.dmg"
-          hdiutil create -fs HFS+ -srcfolder GitX.app -volname GitX GitX-${{ matrix.abi }}.dmg
+          mkdir dist && cp -R GitX.app dist/ && ln -s /Applications dist/
+          hdiutil create -fs HFS+ -srcfolder dist/ -volname GitX GitX-${{ matrix.abi }}.dmg
+          rm -rf dist
           zip -r GitX-${{ matrix.abi }}.zip GitX.app
       - name: Notarize App
         env:


### PR DESCRIPTION
Fixes #362

# Notice

@hannesa2 this cannot be fully tested in the forked PR because the CI step with the change will be skipped.

I partially tested it though in #377 by enabling the `Prepare artifact` step. The DMG files work correctly, but the GitX app won't run due to the lack of signing (which we fixed already in #376).

If needed to confirm a full test, please use an origin PR to do an integration test with `xcodebuild -exportArchive`.
- The generated DMG files should work correctly in both platforms. _(This works.)_
- Dragging GitX onto Applications should install it. Finder may ask to replace existing copy. _(This works.)_
- Installed GitX should run without issues or crashes. _(This doesn't work in forked PR due to lack of signing.)_

# Screenshot

<img width="453" alt="image" src="https://user-images.githubusercontent.com/6047296/221515779-871d9a17-c9c9-4002-a7cc-e05e1dc67d36.png">
