### PR TITLE
Add a link to Applications in the DMG file

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -75,7 +75,9 @@ jobs:
           echo "EXPORT_OPTIONS_PATH=$EXPORT_OPTIONS_PATH"
           xcodebuild -exportArchive -archivePath GitX.xcarchive -exportPath . -exportOptionsPlist EXPORT_OPTIONS_PATH
           echo "Create GitX-${{ matrix.abi }}.dmg"
-          hdiutil create -fs HFS+ -srcfolder GitX.app -volname GitX GitX-${{ matrix.abi }}.dmg
+          mkdir dist && cp -R GitX.app dist/ && ln -s /Applications dist/
+          hdiutil create -fs HFS+ -srcfolder dist/ -volname GitX GitX-${{ matrix.abi }}.dmg
+          rm -rf dist
           zip -r GitX-${{ matrix.abi }}.zip GitX.app
       - name: Notarize App
         if: ${{ env.variableSet != '' }}

--- a/.github/workflows/BuildRelease.yml
+++ b/.github/workflows/BuildRelease.yml
@@ -74,7 +74,9 @@ jobs:
           echo -n "$EXPORT_OPTIONS" > EXPORT_OPTIONS_PATH
           xcodebuild -exportArchive -archivePath GitX.xcarchive -exportPath . -exportOptionsPlist EXPORT_OPTIONS_PATH
           echo "Create GitX-${{ matrix.abi }}.dmg"
-          hdiutil create -fs HFS+ -srcfolder GitX.app -volname GitX GitX-${{ matrix.abi }}.dmg
+          mkdir dist && cp -R GitX.app dist/ && ln -s /Applications dist/
+          hdiutil create -fs HFS+ -srcfolder dist/ -volname GitX GitX-${{ matrix.abi }}.dmg
+          rm -rf dist
           zip -r GitX-${{ matrix.abi }}.zip GitX.app
       - name: Notarize App
         env:


### PR DESCRIPTION
Fixes #362
It's a copy of #378 @ADTC 

You can test all now with the new artifacts 

>    The generated DMG files should work correctly in both platforms. (This works.)
>    Dragging GitX onto Applications should install it. Finder may ask to replace existing copy. (This works.)
>    Installed GitX should run without issues or crashes. (This doesn't work in forked PR due to lack of signing.)
