### PR TITLE
Implement a Dark theme for syntaxhighlighter and blame

### DIFF
--- a/Resources/html/css/shThemeDark.css
+++ b/Resources/html/css/shThemeDark.css
@@ -1,0 +1,160 @@
+/**
+ * SyntaxHighlighter
+ * http://alexgorbatchev.com/SyntaxHighlighter
+ *
+ * SyntaxHighlighter is donationware. If you are using it, please donate.
+ * http://alexgorbatchev.com/SyntaxHighlighter/donate.html
+ *
+ * @version
+ * 3.0.83 (July 02 2010)
+ * 
+ * @copyright
+ * Copyright (C) 2004-2010 Alex Gorbatchev.
+ *
+ * @license
+ * Dual licensed under the MIT and GPL licenses.
+ */
+.syntaxhighlighter {
+  background-color: #121212 !important;
+}
+
+.syntaxhighlighter .line.alt1 {
+  background-color: #121212 !important;
+}
+
+.syntaxhighlighter .line.alt2 {
+  background-color: #121212 !important;
+}
+
+.syntaxhighlighter .line.highlighted.alt1,
+.syntaxhighlighter .line.highlighted.alt2 {
+  background-color: #2c2c29 !important;
+}
+
+.syntaxhighlighter .line.highlighted.number {
+  color: white !important;
+}
+
+.syntaxhighlighter table caption {
+  color: white !important;
+}
+
+.syntaxhighlighter table td.code .container textarea {
+  background: #121212;
+  color: white;
+}
+
+.syntaxhighlighter .gutter {
+  color: #afafaf !important;
+  border: 1px solid transparent !important;
+  background-color: transparent !important;
+}
+
+.syntaxhighlighter .gutter .line {
+  border-right: 3px solid #3185b9 !important;
+}
+
+.syntaxhighlighter .gutter .line.highlighted {
+  background-color: #3185b9 !important;
+  color: #121212 !important;
+}
+
+.syntaxhighlighter.printing .line .content {
+  border: none !important;
+}
+
+.syntaxhighlighter.collapsed {
+  overflow: visible !important;
+}
+
+.syntaxhighlighter.collapsed .toolbar {
+  color: #3185b9 !important;
+  background: black !important;
+  border: 1px solid #3185b9 !important;
+}
+
+.syntaxhighlighter.collapsed .toolbar a {
+  color: #3185b9 !important;
+}
+
+.syntaxhighlighter.collapsed .toolbar a:hover {
+  color: #d01d33 !important;
+}
+
+.syntaxhighlighter .toolbar {
+  color: white !important;
+  background: #3185b9 !important;
+  border: none !important;
+}
+
+.syntaxhighlighter .toolbar a {
+  color: white !important;
+}
+
+.syntaxhighlighter .toolbar a:hover {
+  color: #96daff !important;
+}
+
+.syntaxhighlighter .plain,
+.syntaxhighlighter .plain a {
+  color: white !important;
+}
+
+.syntaxhighlighter .comments,
+.syntaxhighlighter .comments a {
+  color: #696854 !important;
+}
+
+.syntaxhighlighter .string,
+.syntaxhighlighter .string a {
+  color: #e3e658 !important;
+}
+
+.syntaxhighlighter .keyword {
+  color: #d01d33 !important;
+}
+
+.syntaxhighlighter .preprocessor {
+  color: #435a5f !important;
+}
+
+.syntaxhighlighter .variable {
+  color: #898989 !important;
+}
+
+.syntaxhighlighter .value {
+  color: #009900 !important;
+}
+
+.syntaxhighlighter .functions {
+  color: #aaaaaa !important;
+}
+
+.syntaxhighlighter .constants {
+  color: #96daff !important;
+}
+
+.syntaxhighlighter .script {
+  font-weight: bold !important;
+  color: #d01d33 !important;
+  background-color: none !important;
+}
+
+.syntaxhighlighter .color1,
+.syntaxhighlighter .color1 a {
+  color: #ffc074 !important;
+}
+
+.syntaxhighlighter .color2,
+.syntaxhighlighter .color2 a {
+  color: #4a8cdb !important;
+}
+
+.syntaxhighlighter .color3,
+.syntaxhighlighter .color3 a {
+  color: #96daff !important;
+}
+
+.syntaxhighlighter .functions {
+  font-weight: bold !important;
+}

--- a/Resources/html/views/blame/blame.css
+++ b/Resources/html/views/blame/blame.css
@@ -35,7 +35,7 @@ tr.block.l1 p.summary{
 	display: none !important;
 }
 
-table.blocks td {
+table.blocks tr.block > td {
 	vertical-align: top !important;
 }
 
@@ -44,28 +44,44 @@ p.author {
 }
 
 table.blocks {
-	font: 11px "Menlo" !important !important;
-}
-
-table tr.block{
-	border-top: 1px solid #c9c9c9 !important;
-}
-table.blocks{
+	font: 11px "Menlo" !important;
 	border-bottom: 1px solid #c9c9c9 !important;
 	width: 100% !important;
 }
 
-table.blocks tr td:nth-of-type(1) {
+table.blocks tr.block {
+	border-top: 1px solid #c9c9c9 !important;
+}
+
+table.blocks tr.block > td:nth-of-type(1) {
   background-color: #ececec !important;
 	border-right: 1px solid #c9c9c9 !important;
-}
-
-table.blocks tr td:nth-of-type(2) {
-	width: 100% !important;
-  padding-left: 1em !important;
-}
-
-table.blocks tr.block td:nth-of-type(1){
 	padding-right: 5px !important;
 	padding-left: 5px !important;
+}
+
+table.blocks tr.block > td:nth-of-type(2) {
+	width: 100% !important;
+}
+
+@media screen and (prefers-color-scheme: dark) {
+	p.author,p.summary {
+		color: white !important;
+	}
+	a {
+		color: #e3e658 !important;
+	}
+
+	table.blocks {
+		border-bottom: 1px solid #2c2c29 !important;
+	}
+
+	table.blocks tr.block {
+		border-top: 1px solid #2c2c29 !important;
+	}
+
+	table.blocks tr.block > td:nth-of-type(1) {
+		background-color: #121212 !important;
+		border-right: 1px solid #2c2c29 !important;
+	}
 }

--- a/Resources/html/views/blame/index.html
+++ b/Resources/html/views/blame/index.html
@@ -9,6 +9,7 @@
 		<link rel="stylesheet" href="blame.css" type="text/css" media="screen" title="no title" charset="utf-8">
 		<link rel="stylesheet" href="../../css/shCoreGitX.css" type="text/css" media="screen" title="no title" charset="utf-8">
 		<link rel="stylesheet" href="../../css/shThemeGitX.css" type="text/css" media="screen" title="no title" charset="utf-8">
+		<link rel="stylesheet" href="../../css/shThemeDark.css" type="text/css" media="screen and (prefers-color-scheme: dark)" title="no title" charset="utf-8">
 	</head>
 	<body>
 		<div id="txt">hola</pre>

--- a/Resources/html/views/fileview/index.html
+++ b/Resources/html/views/fileview/index.html
@@ -37,6 +37,7 @@
 		<link rel="stylesheet" href="source.css" type="text/css" media="screen" title="no title" charset="utf-8">
 		<link rel="stylesheet" href="../../css/shCoreGitX.css" type="text/css" media="screen" title="no title" charset="utf-8">
 		<link rel="stylesheet" href="../../css/shThemeGitX.css" type="text/css" media="screen" title="no title" charset="utf-8">
+		<link rel="stylesheet" href="../../css/shThemeDark.css" type="text/css" media="screen and (prefers-color-scheme: dark)" title="no title" charset="utf-8">
 	</head>
 	<body>
 		<div id="source"></div>

--- a/Resources/html/views/fileview/index_test.html
+++ b/Resources/html/views/fileview/index_test.html
@@ -10,6 +10,7 @@
 		<link rel="stylesheet" href="source.css" type="text/css" media="screen" title="no title" charset="utf-8">
 		<link rel="stylesheet" href="../../css/shCoreGitX.css" type="text/css" media="screen" title="no title" charset="utf-8">
 		<link rel="stylesheet" href="../../css/shThemeGitX.css" type="text/css" media="screen" title="no title" charset="utf-8">
+		<link rel="stylesheet" href="../../css/shThemeDark.css" type="text/css" media="screen and (prefers-color-scheme: dark)" title="no title" charset="utf-8">
 	</head>
 	<body onload="test();">
 		<div id="source">


### PR DESCRIPTION
The SH dark theme is the same as the following file, with formatting and minor modifications: `Resources/html/lib/syntaxhighlighter/styles/shThemeFadeToGrey.css`

Fixes #356

It takes care of the source code and blame views. Unfortunately I don't know how to apply dark background on [`MGScopeBar`](https://github.com/gitx/MGScopeBar) so for now I'm keeping it a draft. @hannesa2 please help with the bar. How do we make it have a dark background?

Screenshots:

Soucre:
<img width="670" alt="image" src="https://user-images.githubusercontent.com/6047296/224494194-43e98f78-a5d7-48a7-9932-a5c6e2dee45d.png">

Blame:
<img width="787" alt="image" src="https://user-images.githubusercontent.com/6047296/224494200-940e1105-60ab-4e08-b9db-b591c6b2fc09.png">
