### PR TITLE
Swap order of x86 and arm64 builds in CI

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -8,20 +8,23 @@ on:
 
 jobs:
   build-gitx:
-    name: build-gitx
+    name: build
     env:
       variableSet: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        xcode: [ Xcode_14.1.0, Xcode_13.3 ]
-        os: [ macos-12 ]
-        abi: [ x86_64 ]
+        xcode: [ Xcode ]
+        os: [ ARM64 ]
+        abi: [ arm64 ]
         include:
-          - xcode: Xcode
-            os: ARM64
-            abi: arm64
+          - xcode: Xcode_14.1.0
+            os: macos-12
+            abi: x86_64
+          - xcode: Xcode_13.3
+            os: macos-12
+            abi: x86_64
     steps:
       - name: ls Xcode
         run: ls -la /Applications/Xcode*

--- a/.github/workflows/BuildRelease.yml
+++ b/.github/workflows/BuildRelease.yml
@@ -12,13 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: [ Xcode_14.1.0 ]
-        os: [ macos-12 ]
-        abi: [ x86_64 ]
+        xcode: [ Xcode ]
+        os: [ ARM64 ]
+        abi: [ arm64 ]
         include:
-          - xcode: Xcode
-            os: ARM64
-            abi: arm64
+          - xcode: Xcode_14.1.0
+            os: macos-12
+            abi: x86_64
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This makes it easier to skip and reintroduce x86 builds in CI