### PR TITLE
Drop x86 support

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -18,13 +18,13 @@ jobs:
         xcode: [ Xcode ]
         os: [ ARM64 ]
         abi: [ arm64 ]
-        include:
-          - xcode: Xcode_14.1.0
-            os: macos-12
-            abi: x86_64
-          - xcode: Xcode_13.3
-            os: macos-12
-            abi: x86_64
+#        include:
+#          - xcode: Xcode_14.1.0
+#            os: macos-12
+#            abi: x86_64
+#          - xcode: Xcode_13.3
+#            os: macos-12
+#            abi: x86_64
     steps:
       - name: ls Xcode
         run: ls -la /Applications/Xcode*

--- a/.github/workflows/BuildRelease.yml
+++ b/.github/workflows/BuildRelease.yml
@@ -15,10 +15,10 @@ jobs:
         xcode: [ Xcode ]
         os: [ ARM64 ]
         abi: [ arm64 ]
-        include:
-          - xcode: Xcode_14.1.0
-            os: macos-12
-            abi: x86_64
+#        include:
+#          - xcode: Xcode_14.1.0
+#            os: macos-12
+#            abi: x86_64
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Build for x86 is broken since one year and we were not able to fix it. 
That's why I comment x86 support out in CI to have a proper build.

If you want to have further x86 support, please remove comment and try to fix it. I would happy to merge any pull request. 