### PR TITLE
MacOS 14 arm64 on CI

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -19,6 +19,9 @@ jobs:
         os: [ ARM64 ]
         abi: [ arm64 ]
         include:
+          - xcode: Xcode
+            os: macos-14
+            abi: arm64
           - xcode: Xcode_14.1.0
             os: macos-13
             abi: x86_64

--- a/.github/workflows/BuildRelease.yml
+++ b/.github/workflows/BuildRelease.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         xcode: [ Xcode ]
-        os: [ ARM64 ]
+        os: [ macos-14 ]
         abi: [ arm64 ]
         include:
           - xcode: Xcode_14.1.0


### PR DESCRIPTION
Correctly obsolete because we use an own runner