### PR TITLE
Github runner macos-15-intel

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -22,8 +22,8 @@ jobs:
 #          - xcode: 16.2.0
 #            os: ARM64
 #            abi: arm64
-          - xcode: 14.1.0
-            os: macos-13
+          - xcode: 16.4.0
+            os: macos-15-intel
             abi: x86_64
     steps:
       - name: ls Xcode

--- a/.github/workflows/BuildRelease.yml
+++ b/.github/workflows/BuildRelease.yml
@@ -16,8 +16,8 @@ jobs:
         os: [ macos-14 ]
         abi: [ arm64 ]
         include:
-          - xcode: Xcode_14.1.0
-            os: macos-13
+          - xcode: 16.4.0
+            os: macos-15-intel
             abi: x86_64
     steps:
       - name: Checkout


### PR DESCRIPTION
macos-13 runners are going away very soon:

'This process will begin October 1, 2025, and the image will be fully retired on December 4, 2025.'