### PR TITLE
Update builds for new Xcode version 26

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -15,13 +15,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: [ 16.2.0 ]
-        os: [ macos-14 ]
-        abi: [ arm64 ]
         include:
           - xcode: 16.4.0
             os: macos-15-intel
             abi: x86_64
+          - xcode: 26.1.0
+            os: macos-26
+            abi: arm64
     steps:
       - name: ls Xcode
         run: ls -la /Applications/Xcode*

--- a/.github/workflows/BuildRelease.yml
+++ b/.github/workflows/BuildRelease.yml
@@ -12,13 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: [ 16.2.0 ]
-        os: [ macos-14 ]
-        abi: [ arm64 ]
         include:
           - xcode: 16.4.0
             os: macos-15-intel
             abi: x86_64
+          - xcode: 26.1.0
+            os: macos-26
+            abi: arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Updated Xcode version and macOS configuration in the workflow. Pulled ARM artifact for macOS 26 and confirmed it works.