### PR TITLE
Fix thread prio inversion warning right after start caused by waiting on low prio thread

### DIFF
--- a/Classes/Util/PBTask.m
+++ b/Classes/Util/PBTask.m
@@ -203,7 +203,7 @@ const BOOL PBTaskDebugEnable = NO;
 
 	__block NSError *taskError = nil;
 
-	[self performTaskOnQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)
+	[self performTaskOnQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
 		   completionHandler:^(NSData *readData, NSError *error) {
 			   taskError = error;
 


### PR DESCRIPTION
This little PR solves a thread inversion warning right after start 'caused by waiting on a lower prio thread.
Using the same prio as the calling thread will prevent this warning.

I observed it for a few days and did not notice any negative consequences.

<img width="1030" height="936" alt="image" src="https://github.com/user-attachments/assets/89cf8fa3-a1c2-4477-a483-230e646d8c8f" />
