### PR TITLE
Sparkle updater only in release

### DIFF
--- a/Classes/Controllers/ApplicationController.m
+++ b/Classes/Controllers/ApplicationController.m
@@ -117,8 +117,15 @@ static OpenRecentController *recentsDialog = nil;
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
+#if !DEBUG
+	// Only enable Sparkle updates in Release builds
+	// In Debug builds, skip updater to avoid EdDSA key validation errors
+	NSLog(@"DEBUG: Initializing Sparkle updater (Release build)");
 	self.updaterController = [[SPUStandardUpdaterController alloc] initWithUpdaterDelegate:self userDriverDelegate:nil];
 	[self.updaterController.updater setSendsSystemProfile:YES];
+#else
+	NSLog(@"DEBUG: Skipping Sparkle updater initialization (Debug build)");
+#endif
 
 	// Make sure Git's SSH password requests get forwarded to our little UI tool:
 	setenv("SSH_ASKPASS", [[[NSBundle mainBundle] pathForResource:@"gitx_askpasswd" ofType:@""] UTF8String], 1);

--- a/Classes/Controllers/ApplicationController.m
+++ b/Classes/Controllers/ApplicationController.m
@@ -19,12 +19,14 @@
 #import "OpenRecentController.h"
 #import "PBGitBinary.h"
 
-#import <Sparkle/SUUpdater.h>
-#import <Sparkle/SUUpdaterDelegate.h>
+#import <Sparkle/SPUStandardUpdaterController.h>
+#import <Sparkle/SPUUpdater.h>
+#import <Sparkle/SPUUpdaterDelegate.h>
 
 static OpenRecentController *recentsDialog = nil;
 
-@interface ApplicationController () <SUUpdaterDelegate>
+@interface ApplicationController () <SPUUpdaterDelegate>
+@property (nonatomic, strong) SPUStandardUpdaterController *updaterController;
 @end
 
 @implementation ApplicationController
@@ -115,8 +117,8 @@ static OpenRecentController *recentsDialog = nil;
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
-	[[SUUpdater sharedUpdater] setSendsSystemProfile:YES];
-	[[SUUpdater sharedUpdater] setDelegate:self];
+	self.updaterController = [[SPUStandardUpdaterController alloc] initWithUpdaterDelegate:self userDriverDelegate:nil];
+	[self.updaterController.updater setSendsSystemProfile:YES];
 
 	// Make sure Git's SSH password requests get forwarded to our little UI tool:
 	setenv("SSH_ASKPASS", [[[NSBundle mainBundle] pathForResource:@"gitx_askpasswd" ofType:@""] UTF8String], 1);
@@ -247,7 +249,7 @@ static OpenRecentController *recentsDialog = nil;
 
 #pragma mark Sparkle delegate methods
 
-- (NSArray *)feedParametersForUpdater:(SUUpdater *)updater sendingSystemProfile:(BOOL)sendingProfile
+- (NSArray *)feedParametersForUpdater:(SPUUpdater *)updater sendingSystemProfile:(BOOL)sendingProfile
 {
 	NSArray *keys = [NSArray arrayWithObjects:@"key", @"displayKey", @"value", @"displayValue", nil];
 	NSMutableArray *feedParameters = [NSMutableArray array];

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -103,7 +103,5 @@
 	<false/>
 	<key>SUFeedURL</key>
 	<string>https://gitx.github.io/gitx/appcast.xml</string>
-	<key>SUPublicDSAKeyFile</key>
-	<string>UpdateKey.pem</string>
 </dict>
 </plist>


### PR DESCRIPTION
For production releases, we need to:
1. Generate EdDSA keys using Sparkle's generate_keys tool
2. Update Resources/Info.plist to replace SUPublicDSAKeyFile with SUPublicEDKey
3. Sign releases with the EdDSA private key