### PR TITLE
Use NSString instead of char placeholder in NSLocalizedString

### DIFF
--- a/Classes/git/PBGitBinary.m
+++ b/Classes/git/PBGitBinary.m
@@ -141,7 +141,7 @@ static NSMutableArray *locations = nil;
 						 NSLocalizedString(
 							 @"Could not find a git binary version " MIN_GIT_VERSION " or higher.\n"
 							 @"Please make sure there is a git binary in one of the following locations:"
-							 @"\n\n\t%s",
+							 @"\n\n\t%@",
 							 @"Error message when no git client can be found."),
 						 searchPathsString];
 }


### PR DESCRIPTION
To avoid the broken string in this error message 

<img width="372" height="416" alt="2026-04-14 GitX error message" src="https://github.com/user-attachments/assets/e55100ae-b2c8-47af-a354-069fb802742c" />
