### PR TITLE
Fix index.lock contention caused by git update-index on every FSEvents notification

### DIFF
--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -65,6 +65,7 @@
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(indexChanged:) name:PBGitIndexIndexUpdated object:index];
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(indexOperationFailed:) name:PBGitIndexOperationFailed object:index];
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(repositoryUpdatedNotification:) name:PBGitRepositoryEventNotification object:theRepository];
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidBecomeActive:) name:NSApplicationDidBecomeActiveNotification object:nil];
 
 	return self;
 }
@@ -119,6 +120,11 @@
 	// Copy the menu over so we have two discrete menu objects
 	// which allows us to tell them apart in our delegate methods
 	stagedTable.menu = [unstagedTable.menu copy];
+}
+
+- (void)applicationDidBecomeActive:(NSNotification *)notification
+{
+	[self.repository.index refreshStatCache];
 }
 
 - (void)repositoryUpdatedNotification:(NSNotification *)notification

--- a/Classes/git/PBGitIndex.h
+++ b/Classes/git/PBGitIndex.h
@@ -59,6 +59,10 @@ extern NSString *PBGitIndexOperationFailed;
 // Refresh the index
 - (void)refresh;
 
+// Update the stat cache (git update-index --refresh). Clears phantom "modified"
+// entries caused by stat mismatches. Call on app activation, not on every change.
+- (void)refreshStatCache;
+
 // Run the prepare-git-msg hook and return the result
 - (nullable NSString *)createPrepareCommitMessage;
 

--- a/Classes/git/PBGitIndex.m
+++ b/Classes/git/PBGitIndex.m
@@ -169,7 +169,6 @@ NS_ENUM(NSUInteger, PBGitIndexOperation){
 	// Enter the group for ALL tasks upfront, before launching any of them.
 	// This prevents dispatch_group_notify from firing prematurely if an
 	// early task completes before later tasks have called group_enter.
-	dispatch_group_enter(_indexRefreshGroup); // update-index
 	BOOL isBare = [self.repository isBareRepository];
 	if (!isBare) {
 		dispatch_group_enter(_indexRefreshGroup); // ls-files
@@ -203,20 +202,6 @@ NS_ENUM(NSUInteger, PBGitIndexOperation){
 
 		[self postIndexRefreshFinished];
 	});
-
-	// Ask Git to refresh the index
-	[PBTask launchTask:[PBGitBinary path]
-				arguments:@[ @"update-index", @"-q", @"--unmerged", @"--ignore-missing", @"--refresh" ]
-			  inDirectory:self.repository.workingDirectoryURL.path
-		completionHandler:^(NSData *readData, NSError *error) {
-			if (error) {
-				[self postIndexRefreshSuccess:NO message:@"update-index failed"];
-			} else {
-				[self postIndexRefreshSuccess:YES message:@"update-index success"];
-			}
-
-			dispatch_group_leave(self->_indexRefreshGroup);
-		}];
 
 	if (isBare) {
 		return;
@@ -290,6 +275,22 @@ NS_ENUM(NSUInteger, PBGitIndexOperation){
 
 			dispatch_group_leave(self->_indexRefreshGroup);
 		}];
+}
+
+// Refreshes the stat cache in the index by running git update-index --refresh.
+// This clears phantom "modified" entries caused by stat mismatches (same content,
+// different mtime). Called on app activation rather than every FSEvents notification
+// to avoid holding index.lock constantly.
+- (void)refreshStatCache
+{
+	if ([self.repository isBareRepository]) return;
+
+	[PBTask launchTask:[PBGitBinary path]
+			 arguments:@[ @"update-index", @"-q", @"--unmerged", @"--ignore-missing", @"--refresh" ]
+		   inDirectory:self.repository.workingDirectoryURL.path
+	 completionHandler:^(NSData *readData, NSError *error) {
+		[self refresh];
+	}];
 }
 
 // Returns the tree to compare the index to, based


### PR DESCRIPTION
## Summary

Fixes #164

While GitX has a repo open in the commit view, every file-system event triggered `git update-index --refresh`, which holds `.git/index.lock` for its entire run. This caused concurrent git operations from terminals or editors (`git add`, `git commit`, `git stash`, etc.) to intermittently fail with `Unable to create index.lock: File exists`.

- Remove `git update-index --refresh` from the `PBGitIndex` refresh path; the remaining reads (`diff-index`, `diff-files`, `ls-files`) are read-only and never acquire the index lock
- Add `-refreshStatCache` which runs `update-index --refresh` as a fire-and-forget call (followed by a refresh) to clear phantom stat-dirty entries
- Call `refreshStatCache` on `NSApplicationDidBecomeActiveNotification` so the stat cache is reconciled when the user switches back to GitX, rather than on every file-system event

## Test plan

Reproducing the bug requires commands that actually acquire `index.lock` (e.g. `git add`) and a repo large enough that `update-index --refresh` holds the lock for a measurable window.

**Reproduce on unpatched build:**
1. Create a repo with many tracked files (500+ increases the lock-hold window)
2. Open it in GitX with the Commit tab visible
3. In a terminal on that repo, run a background writer and a `git add` loop:

```bash
   # keep FSEvents firing
   while true; do for i in 1 50 100 200 300; do echo $RANDOM > file_$i.txt; done; sleep 0.2; done &

   # hammer git add and watch for lock errors
   for i in $(seq 1 500); do
     echo "$i" > file_1.txt
     git add file_1.txt 2>&1 | grep -q "index.lock" && echo "LOCK ERROR on attempt $i"
   done
```

With the unpatched binary, expect several `LOCK ERROR` lines. With the fix applied, expect zero.

**Verify stat-cache refresh still works:**
- Edit a file externally (e.g. `touch file_1.txt`) so its mtime drifts
- Switch away from GitX and back -- the phantom "modified" entry should clear on reactivation