### PR TITLE
few small diff view improvements

### DIFF
--- a/Resources/html/css/GitX.css
+++ b/Resources/html/css/GitX.css
@@ -15,6 +15,7 @@ body {
 
 .body--dark {
     -webkit-filter: invert(0.89) hue-rotate(180deg);
+    background: #1c1c1c;
 }
 
 .body--dark > * {

--- a/Resources/html/css/diff.css
+++ b/Resources/html/css/diff.css
@@ -4,8 +4,11 @@
 }
 
 .diff .file .fileHeader {
-	margin: 5px;
+	padding: 5px;
 	font-weight: bold;
+	position: sticky;
+	top: 0;
+	background: #fff;
 }
 
 .diff .file .fileHeader a {

--- a/Resources/html/lib/diffHighlighter.js
+++ b/Resources/html/lib/diffHighlighter.js
@@ -6,19 +6,30 @@ if (typeof Controller == 'undefined') {
 	Controller.log_ = console.log;
 }
 
-var toggleDiff = function(id)
-{
-  var content = document.getElementById('content_' + id);
+// https://stackoverflow.com/a/22480938/96823
+const isScrolledIntoView = function(el) {
+  const rect = el.getBoundingClientRect();
+  return (rect.top >= 0) && (rect.bottom <= window.innerHeight);
+}
+
+const toggleDiff = function(id) {
+  const content = document.getElementById('content_' + id);
   if (content) {
-    var collapsed = (content.style.display == 'none');
-	  if (collapsed) {
-		  content.style.display = 'box';
-		  jQuery(content).slideDown(100);
-	  } else {
-          jQuery(content).slideUp(100, function () {content.style.display = 'none'});
-	  }
-	
-    var title = document.getElementById('title_' + id);
+    const title = document.getElementById('title_' + id);
+    const collapsed = (content.style.display == 'none');
+
+    if (collapsed) {
+      content.style.display = 'box';
+      jQuery(content).slideDown(100);
+    } else {
+      jQuery(content).slideUp(100, function () {
+        content.style.display = 'none';
+        if (title && !isScrolledIntoView(title)) {
+          title.scrollIntoView()
+        }
+      });
+    }
+
     if (title) {
       if (collapsed) {
         title.classList.remove('collapsed');

--- a/Resources/html/views/history/history.css
+++ b/Resources/html/views/history/history.css
@@ -209,9 +209,7 @@ a {
 
 .top-link {
     text-align: right;
-    margin-top: -5px;
-    margin-right: 20px;
-    padding-bottom: 5px;
+    margin: 11px;
     font-size: 90%;
 }
 


### PR DESCRIPTION
* the background below the diffs is made same as diffs background
* make top link not so oddly positioned
* make file name of each diff stick to the top of the page

please tell me if I should split into separate PRs

| note | was | now |
|---|---|---|
| both background and top link positioning | <img width="2526" height="1230" alt="a-was-dark" src="https://github.com/user-attachments/assets/129dc3c5-5324-4529-9eb5-785ab4041484" /> | <img width="2526" height="1230" alt="a-now-dark" src="https://github.com/user-attachments/assets/ea355e2f-8bc2-4eeb-a8a4-980bd4812735" /> |
| only top link positioning | <img width="2526" height="1230" alt="a-was-light" src="https://github.com/user-attachments/assets/fa6fda9c-39be-4c79-b2c2-530f99ecc6d6" /> | <img width="2526" height="1230" alt="a-now-light" src="https://github.com/user-attachments/assets/f1bde1ed-75a0-45e3-aacf-c73e73a6d4ad" /> |
| file name stickiness | <img width="2526" height="1476" alt="b-was-dark" src="https://github.com/user-attachments/assets/e80e8423-a83d-4e44-82f6-13ddc3499984" /> | <img width="2526" height="1476" alt="b-now-dark" src="https://github.com/user-attachments/assets/335a565f-3603-401e-afc2-33f884cfa228" /> |
| ditto | <img width="2526" height="1476" alt="b-was-light" src="https://github.com/user-attachments/assets/aa1e3c15-5e3d-4054-830a-a650583c3045" /> | <img width="2526" height="1476" alt="b-now-light" src="https://github.com/user-attachments/assets/697d58d3-1b07-4af8-aaf9-24b7362e1845" /> |
