### PR TITLE
Add native history and harden Git workflows

### DIFF
--- a/.agents/skills/domain-modeling/ADR-FORMAT.md
+++ b/.agents/skills/domain-modeling/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/.agents/skills/domain-modeling/CONTEXT-FORMAT.md
+++ b/.agents/skills/domain-modeling/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/.agents/skills/domain-modeling/SKILL.md
+++ b/.agents/skills/domain-modeling/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: domain-modeling
+description: Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, record an architectural decision, or when another skill needs to maintain the domain model.
+---
+
+# Domain Modeling
+
+Actively build and sharpen the project's domain model as you design. This is the *active* discipline — challenging terms, inventing edge-case scenarios, and writing the glossary and decisions down the moment they crystallise. (Merely *reading* `CONTEXT.md` for vocabulary is not this skill — that's a one-line habit any skill can do. This skill is for when you're changing the model, not just consuming it.)
+
+## File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).

--- a/.agents/skills/domain-modeling/agents/openai.yaml
+++ b/.agents/skills/domain-modeling/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Domain Modeling"
+  short_description: "Build and sharpen a domain model"

--- a/.agents/skills/grill-with-docs/SKILL.md
+++ b/.agents/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: grill-with-docs
+description: A relentless interview to sharpen a plan or design, which also creates docs (ADR's and glossary) as we go.
+disable-model-invocation: true
+---
+
+Run a `/grilling` session, using the `/domain-modeling` skill.

--- a/.agents/skills/grill-with-docs/agents/openai.yaml
+++ b/.agents/skills/grill-with-docs/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Grill with Docs"
+  short_description: "Grill a design and write its docs"
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/grilling/SKILL.md
+++ b/.agents/skills/grilling/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: grilling
+description: Grill the user relentlessly about a plan, decision, or idea. Use when the user wants to stress-test their thinking, or uses any 'grill' trigger phrases.
+---
+
+Interview me relentlessly about every aspect of this until we reach a shared understanding. Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
+
+If a *fact* can be found by exploring the environment (filesystem, tools, etc.), look it up rather than asking me. The *decisions*, though, are mine — put each one to me and wait for my answer.
+
+Do not act on it until I confirm we have reached a shared understanding.

--- a/.agents/skills/grilling/agents/openai.yaml
+++ b/.agents/skills/grilling/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Grilling"
+  short_description: "Stress-test thinking one question at a time"

--- a/.clang-format
+++ b/.clang-format
@@ -16,7 +16,6 @@ AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: true
 AllowShortIfStatementsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: All
 AllowShortLoopsOnASingleLine: true
@@ -91,4 +90,3 @@ Language: ObjC
 ---
 Language: Cpp
 ...
-

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,10 +4,18 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 
-[*.{c,css,h,js,m}]
+[*.{c,css,h,js,m,mm}]
 indent_style = tab
 indent_size = tab
 tab_width = 4
+
+[*.swift]
+indent_style = space
+indent_size = 4
+
+[*.{json,yaml,yml}]
+indent_style = space
+indent_size = 2
 
 [*.py]
 indent_style = space

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,25 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      submodules:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "swift"
+    directory: "/GitX.xcworkspace/xcshareddata/swiftpm"
+    schedule:
+      interval: "weekly"
+    groups:
+      swift-packages:
+        patterns:
+          - "*"

--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -44,26 +44,27 @@ jobs:
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           # create variables
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          PP_PATH=$RUNNER_TEMP/build_pp.provisionprofile
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          CERTIFICATE_PATH="$RUNNER_TEMP/build_certificate.p12"
+          PP_PATH="$RUNNER_TEMP/build_pp.provisionprofile"
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
 
           # import certificate and provisioning profile from secrets
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
-          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERTIFICATE_PATH"
+          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o "$PP_PATH"
 
           # create temporary keychain
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           # import certificate to keychain
-          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
+          security import "$CERTIFICATE_PATH" -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
 
           # apply provisioning profile
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+          PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$PROFILE_DIR"
+          cp "$PP_PATH" "$PROFILE_DIR"
       - name: Show openssl version
         run: |
           openssl version
@@ -86,29 +87,30 @@ jobs:
         if: ${{ env.variableSet != '' && matrix.abi == 'arm64' && github.event_name == 'pull_request' }}
         run: brew install exiftool imagemagick
       - name: Checkout fixed repo snapshot for screenshots
-        if: ${{ env.variableSet != '' && matrix.abi == 'arm64' && github.event_name == 'pull_request' }}
+        if: ${{ matrix.abi == 'arm64' && github.event_name == 'pull_request' }}
         run: |
           git clone --no-checkout "$GITHUB_WORKSPACE" /tmp/gitx-screenshot-repo
           git -C /tmp/gitx-screenshot-repo checkout 52ff1051d0c8e5cf3ee5
       - name: Run tests
-        if: ${{ env.variableSet != '' && matrix.abi == 'arm64' && github.event_name == 'pull_request' }}
+        if: ${{ matrix.abi == 'arm64' && github.event_name == 'pull_request' }}
         run: |
           xcodebuild test \
             -workspace GitX.xcworkspace \
             -scheme GitX \
             -destination "platform=macOS,arch=${{ matrix.abi }}" \
+            -only-testing:GitXUITests \
             ARCHS="${{ matrix.abi }}" \
             CODE_SIGN_IDENTITY="-" \
             GITX_SCREENSHOT_REPO=/tmp/gitx-screenshot-repo \
             -resultBundlePath TestResults-${{ matrix.abi }}.xcresult
       - name: Extract screenshots from test results
-        if: ${{ env.variableSet != '' && matrix.abi == 'arm64' && github.event_name == 'pull_request' }}
+        if: ${{ matrix.abi == 'arm64' && github.event_name == 'pull_request' }}
         run: |
           python3 scripts/extract_screenshots.py \
             TestResults-${{ matrix.abi }}.xcresult \
             ./scripts/screenshots-${{ matrix.abi }}
       - name: Upload screenshots
-        if: ${{ env.variableSet != '' && matrix.abi == 'arm64' && github.event_name == 'pull_request' }}
+        if: ${{ matrix.abi == 'arm64' && github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@v7
         with:
           name: Screenshots-${{ matrix.abi }}
@@ -121,7 +123,7 @@ jobs:
           SCREENSHOT_PASSWORD: ${{ secrets.SCREENSHOT_PASSWORD }}
           emulatorApi: ${{ matrix.abi }}
         run: |
-          ls -ls ./scripts/Screenshots-${{ matrix.abi }}
+          ls -ls ./scripts/screenshots-${{ matrix.abi }}
           ./screenShotScript/screenShotCompare.sh false
       - name: Archive screenshots diffs
         if: ${{ env.variableSet != '' && matrix.abi == 'arm64' && github.event_name == 'pull_request' }}
@@ -148,10 +150,10 @@ jobs:
         env:
           EXPORT_OPTIONS: ${{ secrets.NOTARY_EXPORT_OPTIONS }}
         run: |
-          EXPORT_OPTIONS_PATH=$RUNNER_TEMP/ExportOptions.plist
-          echo -n "$EXPORT_OPTIONS" > EXPORT_OPTIONS_PATH
+          EXPORT_OPTIONS_PATH="$RUNNER_TEMP/ExportOptions.plist"
+          echo -n "$EXPORT_OPTIONS" > "$EXPORT_OPTIONS_PATH"
           echo "EXPORT_OPTIONS_PATH=$EXPORT_OPTIONS_PATH"
-          xcodebuild -exportArchive -archivePath GitX.xcarchive -exportPath . -exportOptionsPlist EXPORT_OPTIONS_PATH
+          xcodebuild -exportArchive -archivePath GitX.xcarchive -exportPath . -exportOptionsPlist "$EXPORT_OPTIONS_PATH"
           echo "Create GitX-${{ matrix.abi }}.dmg"
           mkdir dist && cp -R GitX.app dist/ && ln -s /Applications dist/
           hdiutil create -fs HFS+ -srcfolder dist/ -volname GitX GitX-${{ matrix.abi }}.dmg
@@ -168,17 +170,15 @@ jobs:
           APP_PATH="GitX.app"
           ZIP_PATH="GitX.zip"
           NOTARY_LOG="notary.log"
-          ID_FILE="id.txt"
-
           ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
 
-          xcrun notarytool submit "$ZIP_PATH" --key-id $KEY_ID --apple-id $APPLE_ID --team-id $TEAM_ID --password $APPLE_PASSWORD --wait | tee "$NOTARY_LOG" echo "print log output"
+          xcrun notarytool submit "$ZIP_PATH" --key-id "$KEY_ID" --apple-id "$APPLE_ID" --team-id "$TEAM_ID" --password "$APPLE_PASSWORD" --wait | tee "$NOTARY_LOG"
           cat "$NOTARY_LOG"
 
-          ID=$(cat "$NOTARY_LOG" | tail -3 | cut -d':' -f2 | head -n 1)
+          ID=$(tail -3 "$NOTARY_LOG" | cut -d':' -f2 | head -n 1)
           echo "Id is: $ID"
 
-          xcrun notarytool log $ID --apple-id $APPLE_ID --team-id $TEAM_ID --password $APPLE_PASSWORD
+          xcrun notarytool log "$ID" --apple-id "$APPLE_ID" --team-id "$TEAM_ID" --password "$APPLE_PASSWORD"
       - name: Staple Notarization
         if: ${{ env.variableSet != '' }}
         run: |
@@ -209,8 +209,8 @@ jobs:
       - name: Clean up keychain and provisioning profile
         if: ${{ env.variableSet != '' }}
         run: |
-          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
-          rm ~/Library/MobileDevice/Provisioning\ Profiles/build_pp.provisionprofile
+          security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db"
+          rm "$HOME/Library/MobileDevice/Provisioning Profiles/build_pp.provisionprofile"
   
   release:
     if: startsWith(github.event.ref, 'refs/tags/')
@@ -242,15 +242,17 @@ jobs:
         with:
           name: GitX-arm64.zip
       - name: Check pre-release
+        env:
+          RELEASE_TAG: ${{ steps.tagger.outputs.tag }}
         run: |
-          echo "tag=${{steps.tagger.outputs.tag}}"
-          if [[ ${{ steps.tagger.outputs.tag }} == *alpha* || ${{ steps.tagger.outputs.tag }} == *beta* ]]
+          echo "tag=$RELEASE_TAG"
+          if [[ "$RELEASE_TAG" == *alpha* || "$RELEASE_TAG" == *beta* ]]
           then
              prerelease=true
           else
              prerelease=false
           fi
-          echo "PRE_RELEASE=$prerelease" >> $GITHUB_ENV
+          echo "PRE_RELEASE=$prerelease" >> "$GITHUB_ENV"
           echo "prerelease=$prerelease"
       - name: Create Release
         uses: softprops/action-gh-release@v3
@@ -269,7 +271,9 @@ jobs:
 
       - name: update Sparkle
         if: ${{ env.PRE_RELEASE == 'false' }}
-        run: curl -u $GITHUB_ACTOR:${{ secrets.CLASSIC_TOKEN }} -X POST https://api.github.com/repos/$GITHUB_REPOSITORY/pages/builds
+        env:
+          CLASSIC_TOKEN: ${{ secrets.CLASSIC_TOKEN }}
+        run: curl -u "$GITHUB_ACTOR:$CLASSIC_TOKEN" -X POST "https://api.github.com/repos/$GITHUB_REPOSITORY/pages/builds"
 
       - name: Checkout brew repo
         uses: actions/checkout@v7
@@ -281,16 +285,18 @@ jobs:
       - name: Show shasum
         run: |
           find . -name "gitx.rb"
-          export shax86=$(shasum -a 256 GitX-x86_64.dmg | cut -d " " -f1)
+          shax86=$(shasum -a 256 GitX-x86_64.dmg | cut -d " " -f1)
           echo "x86 sha256=$shax86"
-          export shaarm64=$(shasum -a 256 GitX-arm64.dmg | cut -d " " -f1)
+          shaarm64=$(shasum -a 256 GitX-arm64.dmg | cut -d " " -f1)
           echo "arm64 sha256=$shaarm64"
           cd brew/Casks/g
-          sed -n 1,3p gitx.rb > gitx.rb.new
-          echo "  version \"${{ steps.tagger.outputs.tag }}\"" >> gitx.rb.new
-          echo "  sha256 arm:   \"$shaarm64\"," >> gitx.rb.new
-          echo "         intel: \"$shax86\"" >> gitx.rb.new
-          sed -n 7,33p gitx.rb >> gitx.rb.new
+          {
+            sed -n 1,3p gitx.rb
+            echo "  version \"${{ steps.tagger.outputs.tag }}\""
+            echo "  sha256 arm:   \"$shaarm64\","
+            echo "         intel: \"$shax86\""
+            sed -n 7,33p gitx.rb
+          } > gitx.rb.new
           cat gitx.rb.new
           cp gitx.rb.new gitx.rb
           rm gitx.rb.new

--- a/.github/workflows/Verify.yml
+++ b/.github/workflows/Verify.yml
@@ -1,0 +1,110 @@
+name: verify
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+  schedule:
+    - cron: "23 9 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  static:
+    name: static verification
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+      - name: Install formatters and workflow linters
+        run: brew install swiftformat shellcheck actionlint
+      - name: Run static checks
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: scripts/verify_static.sh "$BASE_REF"
+
+  unit-and-analyze:
+    name: unit tests and analyzer
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+      - name: Prepare ObjectiveGit
+        run: |
+          cd External/objective-git
+          script/bootstrap
+          script/update_libgit2
+      - name: Run unit and integration tests
+        run: |
+          xcodebuild test \
+            -workspace GitX.xcworkspace \
+            -scheme GitX \
+            -destination "platform=macOS,arch=arm64" \
+            -only-testing:GitXTests \
+            -enableCodeCoverage YES \
+            CODE_SIGN_IDENTITY="-" \
+            -resultBundlePath "$RUNNER_TEMP/GitXTests.xcresult"
+      - name: Enforce coverage floors
+        run: scripts/check_coverage.py "$RUNNER_TEMP/GitXTests.xcresult"
+      - name: Run Clang static analyzer
+        env:
+          DERIVED_DATA_PATH: ${{ runner.temp }}/GitXAnalyze
+          ANALYZER_LOG_PATH: ${{ runner.temp }}/GitXAnalyze.log
+        run: scripts/run_analyzer.sh
+      - name: Upload test and analyzer results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: GitX-verification-results
+          path: |
+            ${{ runner.temp }}/GitXTests.xcresult
+            ${{ runner.temp }}/GitXAnalyze.log
+
+  sanitizers:
+    name: ${{ matrix.name }}
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-26
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Address and undefined behavior sanitizers
+            test_plan: GitXAddressUndefined
+          - name: Thread sanitizer
+            test_plan: GitXThreadSanitizer
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+      - name: Prepare ObjectiveGit
+        run: |
+          cd External/objective-git
+          script/bootstrap
+          script/update_libgit2
+      - name: Run sanitizer configuration
+        run: |
+          xcodebuild test \
+            -workspace GitX.xcworkspace \
+            -scheme GitX \
+            -testPlan "${{ matrix.test_plan }}" \
+            -destination "platform=macOS,arch=arm64" \
+            CODE_SIGN_IDENTITY="-"

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ __pycache__/
 .idea
 GitX.xcarchive/
 GitX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/
-GitX.xcworkspace/xcshareddata/swiftpm/
 /Dev.xcconfig
+reviews_triage/

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,8 @@
+--swiftversion 5.0
+--indent 4
+--indentcase false
+--linebreaks lf
+--maxwidth none
+--self remove
+--stripunusedargs closure-only
+--disable andOperator,strongOutlets

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,33 @@
+# GitX Repository History
+
+GitX presents immutable repository history alongside the repository's mutable working state. These terms distinguish revisions, selections, and comparisons consistently across History, Tree, and Commit views.
+
+## Language
+
+**Commit**:
+An immutable Git revision stored in the repository object database.
+_Avoid_: Revision when specifically referring to a stored commit
+
+**Working State**:
+The mutable combination of staged, unstaged, untracked, and deleted content in a repository checkout.
+_Avoid_: Working commit, fake commit
+
+**Uncommitted Changes**:
+The selectable History entry that represents the current Working State rather than a Commit.
+_Avoid_: Dirty commit, working-tree commit
+
+**Sequential Diff**:
+The ordered presentation of each selected Commit's own patch, from oldest to newest.
+_Avoid_: Combined diff, aggregate diff
+
+**Combined Diff**:
+The single net patch spanning the first parent of the oldest selected Commit through the newest selected Commit on one ancestry path.
+_Avoid_: Sequential diff, merge diff
+
+**File Mode**:
+One of Source, Blame, History, or Diff used to inspect selected files in the Tree view.
+_Avoid_: Tab, scope
+
+**Scheduled Fetch**:
+A noninteractive background fetch performed for repositories selected by the global auto-refresh scope.
+_Avoid_: Pull, background sync

--- a/Classes/Controllers/ApplicationController.m
+++ b/Classes/Controllers/ApplicationController.m
@@ -18,6 +18,7 @@
 #import "PBCloneRepositoryPanel.h"
 #import "OpenRecentController.h"
 #import "PBGitBinary.h"
+#import "PBAutoFetchManager.h"
 
 #import <Sparkle/SPUStandardUpdaterController.h>
 #import <Sparkle/SPUUpdater.h>
@@ -133,6 +134,7 @@ static OpenRecentController *recentsDialog = nil;
 
 	[NSApp registerObserverForAppearanceChanges:self];
 	[self registerServices];
+	[[PBAutoFetchManager sharedManager] start];
 	started = YES;
 
 	// UI-test hook: open a repo path passed via environment variable so that

--- a/Classes/Controllers/ApplicationController.m
+++ b/Classes/Controllers/ApplicationController.m
@@ -28,6 +28,7 @@ static OpenRecentController *recentsDialog = nil;
 
 @interface ApplicationController () <SPUUpdaterDelegate>
 @property (nonatomic, strong) SPUStandardUpdaterController *updaterController;
+- (void)applyAppearancePreference;
 @end
 
 @implementation ApplicationController
@@ -49,11 +50,53 @@ static OpenRecentController *recentsDialog = nil;
 	NSValueTransformer *transformer = [[PBNSURLPathUserDefaultsTransfomer alloc] init];
 	[NSValueTransformer setValueTransformer:transformer forName:@"PBNSURLPathUserDefaultsTransfomer"];
 
-	// Make sure the PBGitDefaults is initialized, by calling a random method
-	[PBGitDefaults class];
+	[[NSNotificationCenter defaultCenter] addObserver:self
+											 selector:@selector(appearancePreferenceChanged:)
+												 name:PBAppearancePreferenceDidChangeNotification
+											   object:nil];
+	[self applyAppearancePreference];
 
 	started = NO;
 	return self;
+}
+
+- (void)dealloc
+{
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)applyAppearancePreference
+{
+	PBAppearancePreference preference = [PBGitDefaults appearancePreference];
+	void (^applyAppearance)(void) = ^{
+		switch (preference) {
+			case PBAppearancePreferenceLight:
+				NSApp.appearance = [NSAppearance appearanceNamed:NSAppearanceNameAqua];
+				break;
+			case PBAppearancePreferenceDark:
+				NSApp.appearance = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
+				break;
+			case PBAppearancePreferenceAutomatic:
+			default:
+				NSApp.appearance = nil;
+				break;
+		}
+	};
+
+	if (NSThread.isMainThread)
+		applyAppearance();
+	else
+		dispatch_sync(dispatch_get_main_queue(), applyAppearance);
+}
+
+- (void)appearancePreferenceChanged:(NSNotification *)notification
+{
+	[self applyAppearancePreference];
+}
+
+- (void)applicationWillFinishLaunching:(NSNotification *)notification
+{
+	[self applyAppearancePreference];
 }
 
 - (void)registerServices
@@ -145,6 +188,12 @@ static OpenRecentController *recentsDialog = nil;
 	if (uitestRepo.length > 0) {
 		NSURL *repoURL = [NSURL fileURLWithPath:uitestRepo];
 		PBRepositoryDocumentController *controller = [PBRepositoryDocumentController sharedDocumentController];
+		// UI tests request one deterministic document. Remove any windows that
+		// AppKit restored from an earlier test process before opening it.
+		for (NSDocument *document in controller.documents.copy) {
+			if (![document.fileURL isEqual:repoURL])
+				[document close];
+		}
 		// Defer to the next run-loop iteration so the app is fully initialised.
 		dispatch_async(dispatch_get_main_queue(), ^{
 			[controller openDocumentWithContentsOfURL:repoURL
@@ -171,7 +220,7 @@ static OpenRecentController *recentsDialog = nil;
 	[panel setCanChooseDirectories:true];
 
 	[panel beginWithCompletionHandler:^(NSInteger result) {
-		if (result == NSFileHandlingPanelOKButton) {
+		if (result == NSModalResponseOK) {
 			PBRepositoryDocumentController *controller = [PBRepositoryDocumentController sharedDocumentController];
 			[controller openDocumentWithContentsOfURL:panel.URL
 											  display:true

--- a/Classes/Controllers/PBAutoFetchManager.h
+++ b/Classes/Controllers/PBAutoFetchManager.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Coordinates unattended remote refreshes for the repositories selected by
+/// the global auto-fetch preference. Failures pause only the affected
+/// repository for the remainder of the application session.
+@interface PBAutoFetchManager : NSObject
+
++ (instancetype)sharedManager;
+- (void)start;
+- (void)recordManualFetchSucceededForRepositoryURL:(NSURL *)repositoryURL;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Controllers/PBAutoFetchManager.h
+++ b/Classes/Controllers/PBAutoFetchManager.h
@@ -3,8 +3,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Coordinates unattended remote refreshes for the repositories selected by
-/// the global auto-fetch preference. Failures pause only the affected
-/// repository for the remainder of the application session.
+/// the global auto-fetch preference. Failures retry with bounded exponential
+/// backoff independently for each repository.
 @interface PBAutoFetchManager : NSObject
 
 + (instancetype)sharedManager;

--- a/Classes/Controllers/PBAutoFetchManager.m
+++ b/Classes/Controllers/PBAutoFetchManager.m
@@ -15,13 +15,15 @@
 #import <UserNotifications/UserNotifications.h>
 
 static NSTimeInterval const PBAutoFetchTimerResolution = 30.0;
+static NSTimeInterval const PBAutoFetchRetryBaseInterval = 60.0;
+static NSTimeInterval const PBAutoFetchRetryMaximumInterval = 15.0 * 60.0;
 
 @interface PBAutoFetchManager () <UNUserNotificationCenterDelegate>
 @property (nonatomic) NSTimer *timer;
 @property (nonatomic) dispatch_queue_t fetchQueue;
 @property (nonatomic) NSMutableDictionary<NSString *, NSDate *> *nextFetchDates;
 @property (nonatomic) NSMutableSet<NSString *> *inFlightRepositories;
-@property (nonatomic) NSMutableSet<NSString *> *pausedRepositories;
+@property (nonatomic) NSMutableDictionary<NSString *, NSNumber *> *failureCounts;
 @property (nonatomic) PBAutoFetchScope lastScope;
 @property (nonatomic) BOOL started;
 @property (nonatomic) BOOL requestedNotificationAuthorization;
@@ -46,7 +48,7 @@ static NSTimeInterval const PBAutoFetchTimerResolution = 30.0;
 	_fetchQueue = dispatch_queue_create("com.gitx.autofetch", DISPATCH_QUEUE_SERIAL);
 	_nextFetchDates = [NSMutableDictionary dictionary];
 	_inFlightRepositories = [NSMutableSet set];
-	_pausedRepositories = [NSMutableSet set];
+	_failureCounts = [NSMutableDictionary dictionary];
 	_lastScope = PBAutoFetchScopeNone;
 	return self;
 }
@@ -88,7 +90,10 @@ static NSTimeInterval const PBAutoFetchTimerResolution = 30.0;
 	self.lastScope = scope;
 	if (scope == PBAutoFetchScopeNone) return;
 	[self ensureNotificationAuthorization];
-	if (wasDisabled) [self.nextFetchDates removeAllObjects];
+	if (wasDisabled) {
+		[self.nextFetchDates removeAllObjects];
+		[self.failureCounts removeAllObjects];
+	}
 	[self evaluateRepositoriesForImmediateFetch:wasDisabled];
 }
 
@@ -101,12 +106,21 @@ static NSTimeInterval const PBAutoFetchTimerResolution = 30.0;
 {
 	// A wake represents one catch-up opportunity. The normal interval starts
 	// again when that fetch is scheduled.
+	[self.failureCounts removeAllObjects];
 	[self evaluateRepositoriesForImmediateFetch:YES];
+}
+
++ (NSTimeInterval)retryDelayForFailureCount:(NSUInteger)failureCount
+{
+	if (failureCount == 0) return 0;
+	NSUInteger exponent = MIN(failureCount - 1, (NSUInteger)4);
+	return MIN(PBAutoFetchRetryBaseInterval * (NSTimeInterval)(1UL << exponent), PBAutoFetchRetryMaximumInterval);
 }
 
 - (NSString *)keyForURL:(NSURL *)url
 {
-	return url.URLByStandardizingPath.path ?: url.path ?: @"";
+	return url.URLByStandardizingPath.path ?: url.path ?:
+														 @"";
 }
 
 - (NSDictionary<NSString *, NSURL *> *)candidateRepositoryURLs
@@ -144,12 +158,11 @@ static NSTimeInterval const PBAutoFetchTimerResolution = 30.0;
 	NSDate *now = [NSDate date];
 	NSDictionary<NSString *, NSURL *> *candidates = [self candidateRepositoryURLs];
 	for (NSString *key in candidates) {
-		if ([self.pausedRepositories containsObject:key] || [self.inFlightRepositories containsObject:key]) continue;
+		if ([self.inFlightRepositories containsObject:key]) continue;
 		NSDate *next = self.nextFetchDates[key];
 		if (!immediate && next && [next compare:now] == NSOrderedDescending) continue;
 		NSURL *url = candidates[key];
 		[self.inFlightRepositories addObject:key];
-		self.nextFetchDates[key] = [now dateByAddingTimeInterval:(NSTimeInterval)[PBGitDefaults autoFetchIntervalMinutes] * 60.0];
 		dispatch_async(self.fetchQueue, ^{
 			[self fetchRepositoryAtURL:url key:key];
 		});
@@ -159,6 +172,7 @@ static NSTimeInterval const PBAutoFetchTimerResolution = 30.0;
 - (PBTask *)taskForRepositoryURL:(NSURL *)url arguments:(NSArray<NSString *> *)arguments
 {
 	PBTask *task = [PBTask taskWithLaunchPath:[PBGitBinary path] arguments:arguments inDirectory:url.path];
+	task.timeout = 10.0 * 60.0;
 	task.additionalEnvironment = @{
 		@"GIT_TERMINAL_PROMPT" : @"0",
 		@"GCM_INTERACTIVE" : @"never",
@@ -238,10 +252,14 @@ static NSTimeInterval const PBAutoFetchTimerResolution = 30.0;
 	dispatch_async(dispatch_get_main_queue(), ^{
 		[self.inFlightRepositories removeObject:key];
 		if (!before || !after) {
-			[self.pausedRepositories addObject:key];
-			[self postFailureNotificationForURL:url error:error];
+			NSUInteger failureCount = self.failureCounts[key].unsignedIntegerValue + 1;
+			self.failureCounts[key] = @(failureCount);
+			self.nextFetchDates[key] = [[NSDate date] dateByAddingTimeInterval:[PBAutoFetchManager retryDelayForFailureCount:failureCount]];
+			if (failureCount == 1) [self postFailureNotificationForURL:url error:error];
 			return;
 		}
+		[self.failureCounts removeObjectForKey:key];
+		self.nextFetchDates[key] = [[NSDate date] dateByAddingTimeInterval:(NSTimeInterval)[PBGitDefaults autoFetchIntervalMinutes] * 60.0];
 		[self refreshOpenRepositoryAtURL:url];
 		if (advances.count && [PBGitDefaults notifyAboutFetchedCommitsForRepositoryURL:url]) {
 			[self postAdvanceNotificationForURL:url advances:advances];
@@ -270,10 +288,12 @@ static NSTimeInterval const PBAutoFetchTimerResolution = 30.0;
 - (void)postFailureNotificationForURL:(NSURL *)url error:(NSError *)error
 {
 	UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
-	content.title = [NSString stringWithFormat:@"Auto-fetch paused for %@", url.lastPathComponent];
-	content.body = error.localizedFailureReason ?: error.localizedDescription ?: @"Git could not refresh this repository. A successful manual fetch will resume scheduled fetching.";
+	content.title = [NSString stringWithFormat:@"Auto-fetch failed for %@", url.lastPathComponent];
+	NSString *reason = error.localizedFailureReason ?: error.localizedDescription ?:
+																					@"Git could not refresh this repository.";
+	content.body = [reason stringByAppendingString:@" GitX will retry automatically."];
 	content.sound = [UNNotificationSound defaultSound];
-	content.userInfo = @{ @"repository" : url.path ?: @"", @"kind" : @"failure" };
+	content.userInfo = @{@"repository" : url.path ?: @"", @"kind" : @"failure"};
 	UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:[NSString stringWithFormat:@"gitx-fetch-failure-%@", [self keyForURL:url]] content:content trigger:nil];
 	[[UNUserNotificationCenter currentNotificationCenter] addNotificationRequest:request withCompletionHandler:nil];
 }
@@ -308,13 +328,13 @@ static NSTimeInterval const PBAutoFetchTimerResolution = 30.0;
 - (void)recordManualFetchSucceededForRepositoryURL:(NSURL *)repositoryURL
 {
 	NSString *key = [self keyForURL:repositoryURL];
-	[self.pausedRepositories removeObject:key];
+	[self.failureCounts removeObjectForKey:key];
 	self.nextFetchDates[key] = [[NSDate date] dateByAddingTimeInterval:(NSTimeInterval)[PBGitDefaults autoFetchIntervalMinutes] * 60.0];
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
-	 didReceiveNotificationResponse:(UNNotificationResponse *)response
-			withCompletionHandler:(void (^)(void))completionHandler
+	didReceiveNotificationResponse:(UNNotificationResponse *)response
+			 withCompletionHandler:(void (^)(void))completionHandler
 {
 	NSDictionary *info = response.notification.request.content.userInfo;
 	NSString *path = info[@"repository"];

--- a/Classes/Controllers/PBAutoFetchManager.m
+++ b/Classes/Controllers/PBAutoFetchManager.m
@@ -1,0 +1,376 @@
+#import "PBAutoFetchManager.h"
+
+#import "PBGitBinary.h"
+#import "PBGitDefaults.h"
+#import "PBGitHistoryController.h"
+#import "PBGitRef.h"
+#import "PBGitRepository.h"
+#import "PBGitRepositoryDocument.h"
+#import "PBGitRevSpecifier.h"
+#import "PBGitWindowController.h"
+#import "PBRepositoryDocumentController.h"
+#import "PBTask.h"
+
+#import <ObjectiveGit/GTOID.h>
+#import <UserNotifications/UserNotifications.h>
+
+static NSTimeInterval const PBAutoFetchTimerResolution = 30.0;
+
+@interface PBAutoFetchManager () <UNUserNotificationCenterDelegate>
+@property (nonatomic) NSTimer *timer;
+@property (nonatomic) dispatch_queue_t fetchQueue;
+@property (nonatomic) NSMutableDictionary<NSString *, NSDate *> *nextFetchDates;
+@property (nonatomic) NSMutableSet<NSString *> *inFlightRepositories;
+@property (nonatomic) NSMutableSet<NSString *> *pausedRepositories;
+@property (nonatomic) PBAutoFetchScope lastScope;
+@property (nonatomic) BOOL started;
+@property (nonatomic) BOOL requestedNotificationAuthorization;
+@end
+
+@implementation PBAutoFetchManager
+
++ (instancetype)sharedManager
+{
+	static PBAutoFetchManager *manager;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		manager = [[self alloc] init];
+	});
+	return manager;
+}
+
+- (instancetype)init
+{
+	self = [super init];
+	if (!self) return nil;
+	_fetchQueue = dispatch_queue_create("com.gitx.autofetch", DISPATCH_QUEUE_SERIAL);
+	_nextFetchDates = [NSMutableDictionary dictionary];
+	_inFlightRepositories = [NSMutableSet set];
+	_pausedRepositories = [NSMutableSet set];
+	_lastScope = PBAutoFetchScopeNone;
+	return self;
+}
+
+- (void)start
+{
+	if (self.started) return;
+	self.started = YES;
+	self.lastScope = [PBGitDefaults autoFetchScope];
+
+	[UNUserNotificationCenter currentNotificationCenter].delegate = self;
+
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(autoFetchPreferencesChanged:) name:PBAutoFetchPreferencesDidChangeNotification object:nil];
+	[[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self selector:@selector(workspaceDidWake:) name:NSWorkspaceDidWakeNotification object:nil];
+
+	self.timer = [NSTimer scheduledTimerWithTimeInterval:PBAutoFetchTimerResolution
+										 target:self
+									 selector:@selector(timerFired:)
+									 userInfo:nil
+									  repeats:YES];
+	if (self.lastScope != PBAutoFetchScopeNone) {
+		[self ensureNotificationAuthorization];
+		[self evaluateRepositoriesForImmediateFetch:YES];
+	}
+}
+
+- (void)ensureNotificationAuthorization
+{
+	if (self.requestedNotificationAuthorization) return;
+	self.requestedNotificationAuthorization = YES;
+	[[UNUserNotificationCenter currentNotificationCenter] requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound)
+												 completionHandler:^(__unused BOOL granted, __unused NSError *error) {}];
+}
+
+- (void)autoFetchPreferencesChanged:(NSNotification *)notification
+{
+	PBAutoFetchScope scope = [PBGitDefaults autoFetchScope];
+	BOOL wasDisabled = self.lastScope == PBAutoFetchScopeNone;
+	self.lastScope = scope;
+	if (scope == PBAutoFetchScopeNone) return;
+	[self ensureNotificationAuthorization];
+	if (wasDisabled) [self.nextFetchDates removeAllObjects];
+	[self evaluateRepositoriesForImmediateFetch:wasDisabled];
+}
+
+- (void)timerFired:(NSTimer *)timer
+{
+	[self evaluateRepositoriesForImmediateFetch:NO];
+}
+
+- (void)workspaceDidWake:(NSNotification *)notification
+{
+	// A wake represents one catch-up opportunity. The normal interval starts
+	// again when that fetch is scheduled.
+	[self evaluateRepositoriesForImmediateFetch:YES];
+}
+
+- (NSString *)keyForURL:(NSURL *)url
+{
+	return url.URLByStandardizingPath.path ?: url.path ?: @"";
+}
+
+- (NSDictionary<NSString *, NSURL *> *)candidateRepositoryURLs
+{
+	PBAutoFetchScope scope = [PBGitDefaults autoFetchScope];
+	if (scope == PBAutoFetchScopeNone) return @{};
+
+	NSArray<NSDocument *> *documents = [NSDocumentController sharedDocumentController].documents;
+	NSMutableDictionary<NSString *, NSURL *> *openURLs = [NSMutableDictionary dictionary];
+	for (NSDocument *candidate in documents) {
+		if (![candidate isKindOfClass:PBGitRepositoryDocument.class]) continue;
+		PBGitRepository *repository = [(PBGitRepositoryDocument *)candidate repository];
+		NSURL *url = repository.workingDirectoryURL;
+		if (url) openURLs[[self keyForURL:url]] = url;
+	}
+
+	if (scope == PBAutoFetchScopeActiveRepository) {
+		NSDocument *activeDocument = NSApp.keyWindow.windowController.document ?: [NSDocumentController sharedDocumentController].currentDocument;
+		if (![activeDocument isKindOfClass:PBGitRepositoryDocument.class]) return @{};
+		NSURL *url = [(PBGitRepositoryDocument *)activeDocument repository].workingDirectoryURL;
+		return url ? @{ [self keyForURL:url] : url } : @{};
+	}
+
+	if (scope == PBAutoFetchScopeOpenAndRecentRepositories) {
+		for (NSURL *url in [NSDocumentController sharedDocumentController].recentDocumentURLs) {
+			if (url.isFileURL && url.path.length) openURLs[[self keyForURL:url]] = url;
+		}
+	}
+	return openURLs;
+}
+
+- (void)evaluateRepositoriesForImmediateFetch:(BOOL)immediate
+{
+	if ([PBGitDefaults autoFetchScope] == PBAutoFetchScopeNone) return;
+	NSDate *now = [NSDate date];
+	NSDictionary<NSString *, NSURL *> *candidates = [self candidateRepositoryURLs];
+	for (NSString *key in candidates) {
+		if ([self.pausedRepositories containsObject:key] || [self.inFlightRepositories containsObject:key]) continue;
+		NSDate *next = self.nextFetchDates[key];
+		if (!immediate && next && [next compare:now] == NSOrderedDescending) continue;
+		NSURL *url = candidates[key];
+		[self.inFlightRepositories addObject:key];
+		self.nextFetchDates[key] = [now dateByAddingTimeInterval:(NSTimeInterval)[PBGitDefaults autoFetchIntervalMinutes] * 60.0];
+		dispatch_async(self.fetchQueue, ^{
+			[self fetchRepositoryAtURL:url key:key];
+		});
+	}
+}
+
+- (PBTask *)taskForRepositoryURL:(NSURL *)url arguments:(NSArray<NSString *> *)arguments
+{
+	PBTask *task = [PBTask taskWithLaunchPath:[PBGitBinary path] arguments:arguments inDirectory:url.path];
+	task.additionalEnvironment = @{
+		@"GIT_TERMINAL_PROMPT" : @"0",
+		@"GCM_INTERACTIVE" : @"never",
+		@"GIT_ASKPASS" : @"/usr/bin/false",
+	};
+	return task;
+}
+
+- (nullable NSString *)outputForRepositoryURL:(NSURL *)url arguments:(NSArray<NSString *> *)arguments error:(NSError **)error
+{
+	PBTask *task = [self taskForRepositoryURL:url arguments:arguments];
+	if (![task launchTask:error]) return nil;
+	return task.standardOutputString ?: @"";
+}
+
+- (nullable NSDictionary<NSString *, NSString *> *)remoteSnapshotForURL:(NSURL *)url error:(NSError **)error
+{
+	NSString *output = [self outputForRepositoryURL:url
+									  arguments:@[ @"for-each-ref", @"--format=%(refname)\t%(objectname)", @"refs/remotes" ]
+										 error:error];
+	if (!output) return nil;
+	NSMutableDictionary *snapshot = [NSMutableDictionary dictionary];
+	[output enumerateLinesUsingBlock:^(NSString *line, BOOL *stop) {
+		NSArray<NSString *> *parts = [line componentsSeparatedByString:@"\t"];
+		if (parts.count != 2 || [parts[0] hasSuffix:@"/HEAD"]) return;
+		snapshot[parts[0]] = parts[1];
+	}];
+	return snapshot;
+}
+
+- (BOOL)isAncestor:(NSString *)oldSHA of:(NSString *)newSHA repositoryURL:(NSURL *)url
+{
+	NSError *error = nil;
+	PBTask *task = [self taskForRepositoryURL:url arguments:@[ @"merge-base", @"--is-ancestor", oldSHA, newSHA ]];
+	return [task launchTask:&error];
+}
+
+- (NSInteger)commitCountFrom:(NSString *)oldSHA to:(NSString *)newSHA repositoryURL:(NSURL *)url
+{
+	NSError *error = nil;
+	NSString *range = [NSString stringWithFormat:@"%@..%@", oldSHA, newSHA];
+	NSString *output = [self outputForRepositoryURL:url arguments:@[ @"rev-list", @"--count", range ] error:&error];
+	return MAX(0, output.integerValue);
+}
+
+- (NSTimeInterval)commitTimestampForSHA:(NSString *)sha repositoryURL:(NSURL *)url
+{
+	NSError *error = nil;
+	NSString *output = [self outputForRepositoryURL:url arguments:@[ @"show", @"-s", @"--format=%ct", sha ] error:&error];
+	return error ? 0 : output.doubleValue;
+}
+
+- (void)fetchRepositoryAtURL:(NSURL *)url key:(NSString *)key
+{
+	NSError *error = nil;
+	NSDictionary *before = [self remoteSnapshotForURL:url error:&error];
+	if (before) {
+		PBTask *fetch = [self taskForRepositoryURL:url arguments:@[ @"fetch", @"--all" ]];
+		if (![fetch launchTask:&error]) before = nil;
+	}
+	NSDictionary *after = before ? [self remoteSnapshotForURL:url error:&error] : nil;
+
+	NSMutableArray<NSDictionary *> *advances = [NSMutableArray array];
+	if (before && after) {
+		[after enumerateKeysAndObjectsUsingBlock:^(NSString *ref, NSString *newSHA, BOOL *stop) {
+			NSString *oldSHA = before[ref];
+			if (!oldSHA || [oldSHA isEqualToString:newSHA]) return;
+			if (![self isAncestor:oldSHA of:newSHA repositoryURL:url]) return;
+			NSInteger count = [self commitCountFrom:oldSHA to:newSHA repositoryURL:url];
+			if (count > 0) {
+				NSTimeInterval timestamp = [self commitTimestampForSHA:newSHA repositoryURL:url];
+				[advances addObject:@{ @"ref" : ref, @"sha" : newSHA, @"count" : @(count), @"timestamp" : @(timestamp) }];
+			}
+		}];
+	}
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[self.inFlightRepositories removeObject:key];
+		if (!before || !after) {
+			[self.pausedRepositories addObject:key];
+			[self postFailureNotificationForURL:url error:error];
+			return;
+		}
+		[self refreshOpenRepositoryAtURL:url];
+		if (advances.count && [PBGitDefaults notifyAboutFetchedCommitsForRepositoryURL:url]) {
+			[self postAdvanceNotificationForURL:url advances:advances];
+		}
+	});
+}
+
+- (PBGitRepositoryDocument *)openDocumentForRepositoryURL:(NSURL *)url
+{
+	NSString *key = [self keyForURL:url];
+	for (NSDocument *candidate in [NSDocumentController sharedDocumentController].documents) {
+		if (![candidate isKindOfClass:PBGitRepositoryDocument.class]) continue;
+		NSURL *candidateURL = [(PBGitRepositoryDocument *)candidate repository].workingDirectoryURL;
+		if ([[self keyForURL:candidateURL] isEqualToString:key]) return (PBGitRepositoryDocument *)candidate;
+	}
+	return nil;
+}
+
+- (void)refreshOpenRepositoryAtURL:(NSURL *)url
+{
+	PBGitRepository *repository = [self openDocumentForRepositoryURL:url].repository;
+	[repository reloadRefs];
+	[repository forceUpdateRevisions];
+}
+
+- (void)postFailureNotificationForURL:(NSURL *)url error:(NSError *)error
+{
+	UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+	content.title = [NSString stringWithFormat:@"Auto-fetch paused for %@", url.lastPathComponent];
+	content.body = error.localizedFailureReason ?: error.localizedDescription ?: @"Git could not refresh this repository. A successful manual fetch will resume scheduled fetching.";
+	content.sound = [UNNotificationSound defaultSound];
+	content.userInfo = @{ @"repository" : url.path ?: @"", @"kind" : @"failure" };
+	UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:[NSString stringWithFormat:@"gitx-fetch-failure-%@", [self keyForURL:url]] content:content trigger:nil];
+	[[UNUserNotificationCenter currentNotificationCenter] addNotificationRequest:request withCompletionHandler:nil];
+}
+
+- (void)postAdvanceNotificationForURL:(NSURL *)url advances:(NSArray<NSDictionary *> *)advances
+{
+	NSInteger total = 0;
+	NSMutableArray<NSString *> *summaries = [NSMutableArray array];
+	NSDictionary *newest = advances.firstObject;
+	for (NSDictionary *advance in advances) {
+		NSInteger count = [advance[@"count"] integerValue];
+		total += count;
+		NSString *branch = [advance[@"ref"] stringByReplacingOccurrencesOfString:@"refs/remotes/" withString:@""];
+		[summaries addObject:[NSString stringWithFormat:@"%@ (+%ld)", branch, (long)count]];
+		if ([advance[@"timestamp"] doubleValue] > [newest[@"timestamp"] doubleValue]) newest = advance;
+	}
+	UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+	content.title = [NSString stringWithFormat:@"%@ fetched %ld new commit%@", url.lastPathComponent, (long)total, total == 1 ? @"" : @"s"];
+	content.body = [summaries componentsJoinedByString:@", "];
+	content.sound = [UNNotificationSound defaultSound];
+	content.userInfo = @{
+		@"repository" : url.path ?: @"",
+		@"kind" : @"advance",
+		@"sha" : newest[@"sha"] ?: @"",
+		@"ref" : newest[@"ref"] ?: @"",
+		@"multipleBranches" : @(advances.count > 1),
+	};
+	UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:[NSString stringWithFormat:@"gitx-fetch-advance-%@-%@", [self keyForURL:url], NSUUID.UUID.UUIDString] content:content trigger:nil];
+	[[UNUserNotificationCenter currentNotificationCenter] addNotificationRequest:request withCompletionHandler:nil];
+}
+
+- (void)recordManualFetchSucceededForRepositoryURL:(NSURL *)repositoryURL
+{
+	NSString *key = [self keyForURL:repositoryURL];
+	[self.pausedRepositories removeObject:key];
+	self.nextFetchDates[key] = [[NSDate date] dateByAddingTimeInterval:(NSTimeInterval)[PBGitDefaults autoFetchIntervalMinutes] * 60.0];
+}
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+	 didReceiveNotificationResponse:(UNNotificationResponse *)response
+			withCompletionHandler:(void (^)(void))completionHandler
+{
+	NSDictionary *info = response.notification.request.content.userInfo;
+	NSString *path = info[@"repository"];
+	if (!path.length) {
+		completionHandler();
+		return;
+	}
+	dispatch_async(dispatch_get_main_queue(), ^{
+		NSURL *url = [NSURL fileURLWithPath:path isDirectory:YES];
+		void (^showDocument)(PBGitRepositoryDocument *) = ^(PBGitRepositoryDocument *document) {
+			PBGitWindowController *windowController = document.windowController;
+			[windowController showHistoryView:self];
+			[windowController.window makeKeyAndOrderFront:self];
+			[NSApp activateIgnoringOtherApps:YES];
+			if ([info[@"multipleBranches"] boolValue]) {
+				document.repository.currentBranchFilter = kGitXAllBranchesFilter;
+				[PBGitDefaults setBranchFilter:kGitXAllBranchesFilter];
+			} else {
+				NSString *refName = info[@"ref"];
+				if (refName.length) {
+					PBGitRef *ref = [PBGitRef refFromString:refName];
+					if ([document.repository refExists:ref]) {
+						PBGitRevSpecifier *specifier = [[PBGitRevSpecifier alloc] initWithRef:ref];
+						specifier.workingDirectory = document.repository.workingDirectoryURL;
+						document.repository.currentBranch = [document.repository addBranch:specifier];
+						document.repository.currentBranchFilter = kGitXSelectedBranchFilter;
+						[PBGitDefaults setBranchFilter:kGitXSelectedBranchFilter];
+					}
+				}
+			}
+			[document.repository forceUpdateRevisions];
+			NSString *sha = info[@"sha"];
+			if (sha.length) {
+				dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.75 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+					[windowController.historyViewController selectCommit:[GTOID oidWithSHA:sha]];
+				});
+			}
+		};
+
+		PBGitRepositoryDocument *document = [self openDocumentForRepositoryURL:url];
+		if (document) {
+			showDocument(document);
+		} else {
+			[[PBRepositoryDocumentController sharedDocumentController] openDocumentWithContentsOfURL:url display:YES completionHandler:^(NSDocument *openedDocument, BOOL alreadyOpen, NSError *error) {
+				if ([openedDocument isKindOfClass:PBGitRepositoryDocument.class]) showDocument((PBGitRepositoryDocument *)openedDocument);
+			}];
+		}
+	});
+	completionHandler();
+}
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+		 willPresentNotification:(UNNotification *)notification
+		   withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler
+{
+	completionHandler(UNNotificationPresentationOptionBanner | UNNotificationPresentationOptionSound);
+}
+
+@end

--- a/Classes/Controllers/PBDiffWindowController.h
+++ b/Classes/Controllers/PBDiffWindowController.h
@@ -10,13 +10,19 @@
 
 @class PBGitCommit;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PBDiffWindowController : NSWindowController
 
 + (void)showDiff:(NSString *)diff;
-+ (void)showDiffWindowWithFiles:(NSArray *)filePaths fromCommit:(PBGitCommit *)startCommit diffCommit:(PBGitCommit *)diffCommit;
++ (void)showDiffWindowWithFiles:(nullable NSArray *)filePaths
+					 fromCommit:(PBGitCommit *)startCommit
+					 diffCommit:(nullable PBGitCommit *)diffCommit;
 - (instancetype)initWithDiff:(NSString *)diff;
 
 @property (readonly) NSString *diff;
 @property (readonly, nullable) PBGitCommit *startCommit;
 @property (readonly, nullable) PBGitCommit *diffCommit;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Controllers/PBDiffWindowController.h
+++ b/Classes/Controllers/PBDiffWindowController.h
@@ -17,4 +17,6 @@
 - (instancetype)initWithDiff:(NSString *)diff;
 
 @property (readonly) NSString *diff;
+@property (readonly, nullable) PBGitCommit *startCommit;
+@property (readonly, nullable) PBGitCommit *diffCommit;
 @end

--- a/Classes/Controllers/PBDiffWindowController.m
+++ b/Classes/Controllers/PBDiffWindowController.m
@@ -14,6 +14,9 @@
 
 @implementation PBDiffWindowController
 
+@synthesize startCommit = _startCommit;
+@synthesize diffCommit = _diffCommit;
+
 + (void)showDiff:(NSString *)diff
 {
 	PBDiffWindowController *diffController = [[self alloc] initWithDiff:diff];
@@ -25,7 +28,10 @@
 	NSParameterAssert(startCommit != nil);
 	NSString *diff = [startCommit.repository performDiff:startCommit against:diffCommit forFiles:filePaths];
 
-	[PBDiffWindowController showDiff:[diff copy]];
+	PBDiffWindowController *diffController = [[self alloc] initWithDiff:[diff copy]];
+	diffController->_startCommit = startCommit;
+	diffController->_diffCommit = diffCommit ?: startCommit.repository.headCommit;
+	[diffController showWindow:self];
 }
 
 - (id)initWithDiff:(NSString *)aDiff

--- a/Classes/Controllers/PBGitCommitController.h
+++ b/Classes/Controllers/PBGitCommitController.h
@@ -11,7 +11,7 @@
 
 @class PBGitIndex;
 
-@interface PBGitCommitController : PBViewController
+@interface PBGitCommitController : PBViewController <NSMenuItemValidation>
 
 - (IBAction)refresh:(id)sender;
 - (IBAction)prepareCommitMessage:(id)sender;

--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -692,7 +692,12 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray<PBChangedFile *> *files)
 	[pboard declareTypes:[NSArray arrayWithObjects:FileChangesTableViewType, NSFilenamesPboardType, nil] owner:self];
 
 	// Internal, for dragging from one tableview to the other
-	NSData *data = [NSKeyedArchiver archivedDataWithRootObject:rowIndexes];
+	NSError *archiveError = nil;
+	NSData *data = [NSKeyedArchiver archivedDataWithRootObject:rowIndexes requiringSecureCoding:YES error:&archiveError];
+	if (!data) {
+		PBLogError(archiveError);
+		return NO;
+	}
 	[pboard setData:data forType:FileChangesTableViewType];
 
 	// External, to drag them to for example XCode or Textmate
@@ -728,7 +733,12 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray<PBChangedFile *> *files)
 {
 	NSPasteboard *pboard = [info draggingPasteboard];
 	NSData *rowData = [pboard dataForType:FileChangesTableViewType];
-	NSIndexSet *rowIndexes = [NSKeyedUnarchiver unarchiveObjectWithData:rowData];
+	NSError *unarchiveError = nil;
+	NSIndexSet *rowIndexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:rowData error:&unarchiveError];
+	if (!rowIndexes) {
+		PBLogError(unarchiveError);
+		return NO;
+	}
 
 	NSArrayController *controller = [aTableView tag] == 0 ? stagedFilesController : unstagedFilesController;
 	NSArray *files = [[controller arrangedObjects] objectsAtIndexes:rowIndexes];

--- a/Classes/Controllers/PBGitHistoryController.h
+++ b/Classes/Controllers/PBGitHistoryController.h
@@ -22,14 +22,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface PBGitHistoryController : PBViewController
+@interface PBGitHistoryController : PBViewController <NSMenuItemValidation>
 
 @property (readonly) NSArrayController *commitController;
 @property (readonly) NSTreeController *treeController;
 @property (readonly) PBHistorySearchController *searchController;
 
 @property (assign) NSInteger selectedCommitDetailsIndex;
-@property PBGitTree *gitTree;
+@property (nullable) PBGitTree *gitTree;
 @property NSArray<PBGitCommit *> *webCommits;
 @property NSArray<PBGitCommit *> *selectedCommits;
 

--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -291,7 +291,11 @@
 	}
 
 	PBGitCommit *firstSelectedCommit = self.selectedCommits.firstObject;
-	if (!firstSelectedCommit) return;
+	if (!firstSelectedCommit) {
+		self.gitTree = nil;
+		if (self.webCommits.count) self.webCommits = @[];
+		return;
+	}
 	if (self.selectedCommits.count > 1 && self.selectedCommitDetailsIndex == kHistoryTreeViewIndex)
 		self.selectedCommitDetailsIndex = kHistoryDetailViewIndex;
 
@@ -441,7 +445,7 @@
 		return;
 	PBGitTree *tree = [selectedFiles objectAtIndex:0];
 	NSString *name = [tree tmpFileNameForContents];
-	[[NSWorkspace sharedWorkspace] openFile:name];
+	[[NSWorkspace sharedWorkspace] openURL:[NSURL fileURLWithPath:name]];
 }
 
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem
@@ -541,6 +545,7 @@
 	PBGitCommit *selectedCommit = selectedObjects[0];
 
 	NSArray<GTOID *> *parents = selectedCommit.parents;
+	if (parents.count == 0) return;
 	/* TODO: This is a merge commit. It would be nice to choose the parent with
 	 * the most commits, but for now we will use whatever commit is our first parent.
 	 */
@@ -742,7 +747,11 @@
 		if ([[[self.repository headRef] ref] isEqualToRef:ref])
 			return NO;
 
-		NSData *data = [NSKeyedArchiver archivedDataWithRootObject:[NSArray arrayWithObjects:[NSNumber numberWithInteger:row], [NSNumber numberWithInt:index], NULL]];
+		NSArray<NSNumber *> *referenceLocation = @[ @(row), @(index) ];
+		NSData *data = [NSPropertyListSerialization dataWithPropertyList:referenceLocation
+																  format:NSPropertyListBinaryFormat_v1_0
+																 options:0
+																   error:nil];
 		[pboard declareTypes:[NSArray arrayWithObject:@"PBGitRef"] owner:self];
 		[pboard setData:data forType:@"PBGitRef"];
 	} else {
@@ -789,7 +798,10 @@
 	if (!data)
 		return NO;
 
-	NSArray *numbers = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+	NSArray *numbers = [NSPropertyListSerialization propertyListWithData:data
+																 options:NSPropertyListImmutable
+																  format:nil
+																   error:nil];
 	int oldRow = [[numbers objectAtIndex:0] intValue];
 	if (oldRow == row)
 		return NO;
@@ -939,7 +951,7 @@
 - (BOOL)previewPanel:(id)panel handleEvent:(NSEvent *)event
 {
 	// redirect all key down events to the table view
-	if ([event type] == NSKeyDown) {
+	if ([event type] == NSEventTypeKeyDown) {
 		[fileBrowser keyDown:event];
 		return YES;
 	}
@@ -984,7 +996,7 @@
 	if (!isEnabled)
 		selector = nil;
 
-	NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:title action:selector keyEquivalent:@""];
+	NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(title, @"Commit context menu item") action:selector keyEquivalent:@""];
 	[item setEnabled:isEnabled];
 	return item;
 }

--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -27,6 +27,9 @@
 #import "PBGitRevisionRow.h"
 #import "PBGitRevisionCell.h"
 #import "PBGitStash.h"
+#import "PBHistoryArrayController.h"
+#import "PBUncommittedChanges.h"
+#import "PBGitIndex.h"
 
 #define kHistorySelectedDetailIndexKey @"PBHistorySelectedDetailIndex"
 #define kHistoryDetailViewIndex 0
@@ -56,11 +59,13 @@
 	PBGitTree *gitTree;
 	NSArray<PBGitCommit *> *webCommits;
 	NSArray<PBGitCommit *> *selectedCommits;
+	PBUncommittedChanges *uncommittedChanges;
 }
 
 - (void)updateBranchFilterMatrix;
 - (void)restoreFileBrowserSelection;
 - (void)saveFileBrowserSelection;
+- (void)updateUncommittedChanges;
 
 @end
 
@@ -158,8 +163,11 @@
 	NSSize cellSpacing = [commitList intercellSpacing];
 	cellSpacing.height = 0;
 	[commitList setIntercellSpacing:cellSpacing];
+	commitList.allowsMultipleSelection = YES;
+	commitList.accessibilityIdentifier = @"CommitList";
 	[fileBrowser setTarget:self];
 	[fileBrowser setDoubleAction:@selector(openSelectedFile:)];
+	fileBrowser.allowsMultipleSelection = YES;
 
 	if (!repository.currentBranch) {
 		[repository reloadRefs];
@@ -190,8 +198,42 @@
 
 	// listen for updates
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_repositoryUpdatedNotification:) name:PBGitRepositoryEventNotification object:repository];
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(indexUpdated:) name:PBGitIndexIndexUpdated object:repository.index];
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(historySortingPreferenceChanged:) name:PBGitHistorySortingPreferenceDidChangeNotification object:nil];
+	[self updateUncommittedChanges];
 
 	[super awakeFromNib];
+}
+
+- (void)indexUpdated:(NSNotification *)notification
+{
+	[self updateUncommittedChanges];
+}
+
+- (void)historySortingPreferenceChanged:(NSNotification *)notification
+{
+	if (![PBGitDefaults historyColumnSortingEnabled]) commitController.sortDescriptors = @[];
+	[commitController rearrangeObjects];
+	[commitList reloadData];
+}
+
+- (void)updateUncommittedChanges
+{
+	BOOL wasSelected = [self.selectedCommits.firstObject isKindOfClass:PBUncommittedChanges.class];
+	BOOL isDirty = self.repository.index.indexChanges.count > 0;
+	if (isDirty) {
+		uncommittedChanges = [[PBUncommittedChanges alloc] initWithRepository:self.repository];
+		((PBHistoryArrayController *)commitController).pinnedObject = uncommittedChanges;
+		if (wasSelected) [commitController setSelectedObjects:@[ uncommittedChanges ]];
+	} else {
+		uncommittedChanges = nil;
+		((PBHistoryArrayController *)commitController).pinnedObject = nil;
+		if (wasSelected) {
+			PBGitCommit *newest = self.firstCommit;
+			[commitController setSelectedObjects:newest ? @[ newest ] : @[]];
+		}
+	}
+	[self updateStatus];
 }
 
 - (void)_repositoryUpdatedNotification:(NSNotification *)notification
@@ -206,6 +248,10 @@
 - (void)reselectCommitAfterUpdate
 {
 	[self updateStatus];
+	if ([self.selectedCommits.firstObject isKindOfClass:PBUncommittedChanges.class] && uncommittedChanges) {
+		[commitController setSelectedObjects:@[ uncommittedChanges ]];
+		return;
+	}
 
 	if ([self.repository.currentBranch isSimpleRef])
 		[self selectCommit:[self.repository OIDForRef:self.repository.currentBranch.ref]];
@@ -231,11 +277,23 @@
 - (void)updateKeys
 {
 	NSArray<PBGitCommit *> *newSelectedCommits = commitController.selectedObjects;
+	if (newSelectedCommits.count > 1) {
+		for (PBGitCommit *commit in newSelectedCommits) {
+			if ([commit isKindOfClass:PBUncommittedChanges.class]) {
+				newSelectedCommits = @[ commit ];
+				[commitController setSelectedObjects:newSelectedCommits];
+				break;
+			}
+		}
+	}
 	if (![self.selectedCommits isEqualToArray:newSelectedCommits]) {
 		self.selectedCommits = newSelectedCommits;
 	}
 
 	PBGitCommit *firstSelectedCommit = self.selectedCommits.firstObject;
+	if (!firstSelectedCommit) return;
+	if (self.selectedCommits.count > 1 && self.selectedCommitDetailsIndex == kHistoryTreeViewIndex)
+		self.selectedCommitDetailsIndex = kHistoryDetailViewIndex;
 
 	if (self.selectedCommitDetailsIndex == kHistoryTreeViewIndex) {
 		self.gitTree = firstSelectedCommit.tree;
@@ -250,7 +308,7 @@
 
 - (BOOL)singleCommitSelected
 {
-	return self.selectedCommits.count == 1;
+	return self.selectedCommits.count == 1 && ![self.selectedCommits.firstObject isKindOfClass:PBUncommittedChanges.class];
 }
 
 + (NSSet *)keyPathsForValuesAffectingSingleCommitSelected
@@ -299,8 +357,8 @@
 - (PBGitCommit *)firstCommit
 {
 	NSArray *arrangedObjects = [commitController arrangedObjects];
-	if ([arrangedObjects count] > 0)
-		return [arrangedObjects objectAtIndex:0];
+	for (PBGitCommit *commit in arrangedObjects)
+		if (![commit isKindOfClass:PBUncommittedChanges.class]) return commit;
 
 	return nil;
 }
@@ -329,7 +387,8 @@
 - (void)updateStatus
 {
 	self.isBusy = self.repository.revisionList.isUpdating;
-	self.status = [NSString stringWithFormat:@"%lu commits loaded", [[commitController arrangedObjects] count]];
+	NSUInteger count = [[commitController arrangedObjects] count] - (uncommittedChanges ? 1 : 0);
+	self.status = [NSString stringWithFormat:@"%lu commits loaded", (unsigned long)count];
 }
 
 - (void)restoreFileBrowserSelection
@@ -594,6 +653,13 @@
 - (BOOL)hasNonlinearPath
 {
 	return [commitController filterPredicate] || [[commitController sortDescriptors] count] > 0;
+}
+
+- (NSIndexSet *)tableView:(NSTableView *)tableView selectionIndexesForProposedSelection:(NSIndexSet *)proposedSelectionIndexes
+{
+	if ([proposedSelectionIndexes containsIndex:0] && uncommittedChanges && proposedSelectionIndexes.count > 1)
+		return [NSIndexSet indexSetWithIndex:0];
+	return proposedSelectionIndexes;
 }
 
 - (void)closeView

--- a/Classes/Controllers/PBGitSidebarController.m
+++ b/Classes/Controllers/PBGitSidebarController.m
@@ -65,6 +65,7 @@
 {
 	[super awakeFromNib];
 	window.contentView = self.view;
+	sourceView.accessibilityIdentifier = @"RepositorySidebar";
 	[self populateList];
 
 	PBGitRepository *repository = self.repository;

--- a/Classes/Controllers/PBGitWindowController.h
+++ b/Classes/Controllers/PBGitWindowController.h
@@ -21,7 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface PBGitWindowController : NSWindowController <NSWindowDelegate>
+@interface PBGitWindowController : NSWindowController <NSWindowDelegate, NSMenuItemValidation>
 
 @property (nonatomic, strong) PBGitRepository *repository;
 /* This is assign because that's what NSWindowController says :-S */
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)changeContentController:(PBViewController *)controller;
 
-- (void)showCommitHookFailedSheet:(NSString *)messageText infoText:(NSString *)infoText commitController:(PBGitCommitController *)controller GITX_DEPRECATED;
+- (void)showCommitHookFailedSheet:(NSString *)messageText infoText:(NSString *)infoText commitController:(PBGitCommitController *)controller;
 
 - (void)showMessageSheet:(NSString *)messageText infoText:(NSString *)infoText;
 - (void)showErrorSheet:(NSError *)error;

--- a/Classes/Controllers/PBGitWindowController.h
+++ b/Classes/Controllers/PBGitWindowController.h
@@ -49,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (IBAction)revealInFinder:(id)sender;
 - (IBAction)openInTerminal:(id)sender;
 - (IBAction)refresh:(id)sender;
+- (IBAction)showRepositorySettings:(id)sender;
 
 - (IBAction)checkout:(id)sender;
 - (IBAction)createBranch:(id)sender;

--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -27,6 +27,7 @@
 #import "PBDiffWindowController.h"
 #import "PBGitStash.h"
 #import "PBGitCommit.h"
+#import "PBAutoFetchManager.h"
 
 @interface PBGitWindowController () {
 	__weak PBViewController *contentController;
@@ -95,6 +96,8 @@
 		return ![self.repository isBareRepository];
 	} else if (menuItem.action == @selector(fetchRemote:)) {
 		return [self validateMenuItem:menuItem remoteTitle:@"Fetch “%@”" plainTitle:@"Fetch"];
+	} else if (menuItem.action == @selector(showRepositorySettings:)) {
+		return self.repository != nil;
 	} else if (menuItem.action == @selector(pullRemote:)) {
 		return [self validateMenuItem:menuItem remoteTitle:@"Pull From “%@”" plainTitle:@"Pull"];
 	} else if (menuItem.action == @selector(pullRebaseRemote:)) {
@@ -102,6 +105,27 @@
 	}
 
 	return YES;
+}
+
+- (IBAction)showRepositorySettings:(id)sender
+{
+	NSAlert *alert = [[NSAlert alloc] init];
+	alert.messageText = [NSString stringWithFormat:@"Settings for %@", self.repository.projectName];
+	alert.informativeText = @"These settings apply only to this repository.";
+	[alert addButtonWithTitle:@"Done"];
+	[alert addButtonWithTitle:@"Cancel"];
+
+	NSButton *notifications = [NSButton checkboxWithTitle:@"Notify me when scheduled fetch finds new commits" target:nil action:nil];
+	notifications.state = [PBGitDefaults notifyAboutFetchedCommitsForRepositoryURL:self.repository.workingDirectoryURL] ? NSControlStateValueOn : NSControlStateValueOff;
+	notifications.frame = NSMakeRect(0, 0, 390, 24);
+	alert.accessoryView = notifications;
+
+	[alert beginSheetModalForWindow:self.window completionHandler:^(NSModalResponse returnCode) {
+		if (returnCode == NSAlertFirstButtonReturn) {
+			[PBGitDefaults setNotifyAboutFetchedCommits:(notifications.state == NSControlStateValueOn)
+										 forRepositoryURL:self.repository.workingDirectoryURL];
+		}
+	}];
 }
 
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem remoteTitle:(NSString *)localisationKeyWithRemote plainTitle:(NSString *)localizationKeyWithoutRemote
@@ -303,6 +327,8 @@
 		completionHandler:^(NSError *error) {
 			if (error) {
 				[self showErrorSheet:error];
+			} else {
+				[[PBAutoFetchManager sharedManager] recordManualFetchSucceededForRepositoryURL:self.repository.workingDirectoryURL];
 			}
 		}];
 }

--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -110,22 +110,23 @@
 - (IBAction)showRepositorySettings:(id)sender
 {
 	NSAlert *alert = [[NSAlert alloc] init];
-	alert.messageText = [NSString stringWithFormat:@"Settings for %@", self.repository.projectName];
-	alert.informativeText = @"These settings apply only to this repository.";
-	[alert addButtonWithTitle:@"Done"];
-	[alert addButtonWithTitle:@"Cancel"];
+	alert.messageText = [NSString stringWithFormat:NSLocalizedString(@"Settings for %@", @"Repository settings title"), self.repository.projectName];
+	alert.informativeText = NSLocalizedString(@"These settings apply only to this repository.", @"Repository settings detail");
+	[alert addButtonWithTitle:NSLocalizedString(@"Done", @"Done button")];
+	[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"Cancel button")];
 
-	NSButton *notifications = [NSButton checkboxWithTitle:@"Notify me when scheduled fetch finds new commits" target:nil action:nil];
+	NSButton *notifications = [NSButton checkboxWithTitle:NSLocalizedString(@"Notify me when scheduled fetch finds new commits", @"Repository fetch notification checkbox") target:nil action:nil];
 	notifications.state = [PBGitDefaults notifyAboutFetchedCommitsForRepositoryURL:self.repository.workingDirectoryURL] ? NSControlStateValueOn : NSControlStateValueOff;
 	notifications.frame = NSMakeRect(0, 0, 390, 24);
 	alert.accessoryView = notifications;
 
-	[alert beginSheetModalForWindow:self.window completionHandler:^(NSModalResponse returnCode) {
-		if (returnCode == NSAlertFirstButtonReturn) {
-			[PBGitDefaults setNotifyAboutFetchedCommits:(notifications.state == NSControlStateValueOn)
-										 forRepositoryURL:self.repository.workingDirectoryURL];
-		}
-	}];
+	[alert beginSheetModalForWindow:self.window
+				  completionHandler:^(NSModalResponse returnCode) {
+					  if (returnCode == NSAlertFirstButtonReturn) {
+						  [PBGitDefaults setNotifyAboutFetchedCommits:(notifications.state == NSControlStateValueOn)
+													 forRepositoryURL:self.repository.workingDirectoryURL];
+					  }
+				  }];
 }
 
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem remoteTitle:(NSString *)localisationKeyWithRemote plainTitle:(NSString *)localizationKeyWithoutRemote
@@ -289,11 +290,14 @@
 		}
 	}
 
-	[[NSWorkspace sharedWorkspace] openURLs:nonSubmoduleURLs
-					withAppBundleIdentifier:nil
-									options:0
-			 additionalEventParamDescriptor:nil
-						  launchIdentifiers:NULL];
+	NSWorkspaceOpenConfiguration *configuration = [NSWorkspaceOpenConfiguration configuration];
+	for (NSURL *URL in nonSubmoduleURLs) {
+		[[NSWorkspace sharedWorkspace] openURL:URL
+								 configuration:configuration
+							 completionHandler:^(__unused NSRunningApplication *application, NSError *error) {
+								 if (error) PBLogError(error);
+							 }];
+	}
 }
 
 - (void)revealURLsInFinder:(NSArray<NSURL *> *)fileURLs

--- a/Classes/Controllers/PBHistorySearchController.m
+++ b/Classes/Controllers/PBHistorySearchController.m
@@ -496,11 +496,10 @@
 	panelRect.origin.y = windowFrame.origin.y + historyFrame.origin.y + ((historyFrame.size.height - kRewindPanelSize) / 2.0f);
 
 	NSPanel *panel = [[NSPanel alloc] initWithContentRect:panelRect
-												styleMask:NSBorderlessWindowMask
+												styleMask:NSWindowStyleMaskBorderless
 												  backing:NSBackingStoreBuffered
 													defer:YES];
 	[panel setIgnoresMouseEvents:YES];
-	[panel setOneShot:YES];
 	[panel setOpaque:NO];
 	[panel setBackgroundColor:[NSColor clearColor]];
 	[panel setHasShadow:NO];
@@ -508,10 +507,11 @@
 
 	NSBox *box = [[NSBox alloc] initWithFrame:[[panel contentView] frame]];
 	[box setBoxType:NSBoxCustom];
-	[box setBorderType:NSLineBorder];
-	[box setFillColor:[NSColor colorWithCalibratedWhite:0.0f alpha:0.5f]];
-	[box setBorderColor:[NSColor colorWithCalibratedWhite:0.5f alpha:0.5f]];
-	[box setCornerRadius:12.0f];
+	box.wantsLayer = YES;
+	box.layer.backgroundColor = [NSColor colorWithCalibratedWhite:0.0f alpha:0.5f].CGColor;
+	box.layer.borderColor = [NSColor colorWithCalibratedWhite:0.5f alpha:0.5f].CGColor;
+	box.layer.borderWidth = 1.0f;
+	box.layer.cornerRadius = 12.0f;
 	[[panel contentView] addSubview:box];
 
 	NSImage *rewindImage = [NSImage imageNamed:@"rewindImage"];
@@ -550,7 +550,7 @@
 	NSImage *reversedRewindImage = [NSImage imageWithSize:rewindImage.size
 												  flipped:isReversed
 										   drawingHandler:^BOOL(NSRect destRect) {
-											   [rewindImage drawInRect:destRect fromRect:NSZeroRect operation:NSCompositeCopy fraction:1.0];
+											   [rewindImage drawInRect:destRect fromRect:NSZeroRect operation:NSCompositingOperationCopy fraction:1.0];
 											   return YES;
 										   }];
 	NSImageView *rewindImageView = [rewindPanel.contentView viewWithTag:kRewindPanelImageViewTag];

--- a/Classes/Controllers/PBPrefsWindowController.m
+++ b/Classes/Controllers/PBPrefsWindowController.m
@@ -13,6 +13,7 @@
 #define kPreferenceViewIdentifier @"PBGitXPreferenceViewIdentifier"
 
 @interface PBPrefsWindowController ()
+@property (nonatomic, strong) NSPopUpButton *appearancePopup;
 @property (nonatomic) NSView *historyAndFetchPrefsView;
 @property (nonatomic) NSButton *historySortingCheckbox;
 @property (nonatomic) NSPopUpButton *autoFetchScopePopup;
@@ -26,17 +27,59 @@
 
 - (void)setupToolbar
 {
+	[self createAppearancePreferenceIfNeeded];
+	[self syncAppearancePreference];
 	// GENERAL
-	[self addView:generalPrefsView label:@"General" image:[NSImage imageNamed:NSImageNameApplicationIcon]];
+	[self addView:generalPrefsView label:NSLocalizedString(@"General", @"General preferences toolbar item") image:[NSImage imageNamed:NSImageNameApplicationIcon]];
 	// INTERGRATION
-	[self addView:integrationPrefsView label:@"Integration" image:[NSImage imageNamed:NSImageNameNetwork]];
+	[self addView:integrationPrefsView label:NSLocalizedString(@"Integration", @"Integration preferences toolbar item") image:[NSImage imageNamed:NSImageNameNetwork]];
 	// UPDATES
-	[self addView:updatesPrefsView label:@"Updates"];
+	[self addView:updatesPrefsView label:NSLocalizedString(@"Updates", @"Updates preferences toolbar item")];
 	[self createHistoryAndFetchPreferencesIfNeeded];
 	[self syncHistoryAndFetchPreferences];
 	[self addView:self.historyAndFetchPrefsView
-			label:@"History & Fetch"
+			label:NSLocalizedString(@"History & Fetch", @"History and fetch preferences toolbar item")
 			image:[NSImage imageWithSystemSymbolName:@"arrow.triangle.2.circlepath" accessibilityDescription:nil]];
+}
+
+- (void)createAppearancePreferenceIfNeeded
+{
+	if (self.appearancePopup) return;
+
+	NSRect frame = generalPrefsView.frame;
+	frame.size.height += 58;
+	generalPrefsView.frame = frame;
+
+	NSTextField *label = [self labelWithString:NSLocalizedString(@"Appearance:", @"Appearance preference label") frame:NSMakeRect(103, 24, 90, 22)];
+	[generalPrefsView addSubview:label];
+
+	self.appearancePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(195, 20, 200, 28) pullsDown:NO];
+	NSArray<NSString *> *titles = @[
+		NSLocalizedString(@"Automatic (System)", @"Follow the system appearance preference"),
+		NSLocalizedString(@"Light", @"Light appearance preference"),
+		NSLocalizedString(@"Dark", @"Dark appearance preference"),
+	];
+	for (PBAppearancePreference preference = PBAppearancePreferenceAutomatic;
+		 preference <= PBAppearancePreferenceDark;
+		 preference++) {
+		[self.appearancePopup addItemWithTitle:titles[preference]];
+		self.appearancePopup.lastItem.tag = preference;
+	}
+	self.appearancePopup.target = self;
+	self.appearancePopup.action = @selector(appearancePreferenceChanged:);
+	self.appearancePopup.accessibilityIdentifier = @"AppearancePreference";
+	self.appearancePopup.accessibilityLabel = NSLocalizedString(@"Appearance", @"Appearance preference accessibility label");
+	[generalPrefsView addSubview:self.appearancePopup];
+}
+
+- (void)syncAppearancePreference
+{
+	[self.appearancePopup selectItemWithTag:[PBGitDefaults appearancePreference]];
+}
+
+- (IBAction)appearancePreferenceChanged:(NSPopUpButton *)sender
+{
+	[PBGitDefaults setAppearancePreference:sender.selectedItem.tag];
 }
 
 - (NSTextField *)labelWithString:(NSString *)string frame:(NSRect)frame
@@ -51,23 +94,28 @@
 	if (self.historyAndFetchPrefsView) return;
 	NSView *view = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 520, 270)];
 
-	NSTextField *historyHeading = [self labelWithString:@"History" frame:NSMakeRect(40, 220, 440, 22)];
+	NSTextField *historyHeading = [self labelWithString:NSLocalizedString(@"History", @"History preferences heading") frame:NSMakeRect(40, 220, 440, 22)];
 	historyHeading.font = [NSFont boldSystemFontOfSize:NSFont.systemFontSize];
 	[view addSubview:historyHeading];
 
-	self.historySortingCheckbox = [NSButton checkboxWithTitle:@"Allow commit columns to sort history" target:self action:@selector(historySortingChanged:)];
+	self.historySortingCheckbox = [NSButton checkboxWithTitle:NSLocalizedString(@"Allow commit columns to sort history", @"History sorting preference") target:self action:@selector(historySortingChanged:)];
 	self.historySortingCheckbox.frame = NSMakeRect(40, 188, 400, 24);
 	[view addSubview:self.historySortingCheckbox];
-	NSTextField *historyHelp = [self labelWithString:@"Turn this off to keep commits exclusively in Git graph order." frame:NSMakeRect(60, 164, 420, 20)];
+	NSTextField *historyHelp = [self labelWithString:NSLocalizedString(@"Turn this off to keep commits exclusively in Git graph order.", @"History sorting preference help") frame:NSMakeRect(60, 164, 420, 20)];
 	historyHelp.textColor = NSColor.secondaryLabelColor;
 	[view addSubview:historyHelp];
 
-	NSTextField *fetchHeading = [self labelWithString:@"Scheduled Fetch" frame:NSMakeRect(40, 126, 440, 22)];
+	NSTextField *fetchHeading = [self labelWithString:NSLocalizedString(@"Scheduled Fetch", @"Scheduled fetch preferences heading") frame:NSMakeRect(40, 126, 440, 22)];
 	fetchHeading.font = [NSFont boldSystemFontOfSize:NSFont.systemFontSize];
 	[view addSubview:fetchHeading];
-	[view addSubview:[self labelWithString:@"Repositories:" frame:NSMakeRect(40, 92, 100, 24)]];
+	[view addSubview:[self labelWithString:NSLocalizedString(@"Repositories:", @"Scheduled fetch repository scope label") frame:NSMakeRect(40, 92, 100, 24)]];
 	self.autoFetchScopePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(142, 88, 270, 28) pullsDown:NO];
-	NSArray<NSString *> *scopeTitles = @[ @"None", @"Active repository", @"All open repositories", @"Open and recent repositories" ];
+	NSArray<NSString *> *scopeTitles = @[
+		NSLocalizedString(@"None", @"No repositories fetch automatically"),
+		NSLocalizedString(@"Active repository", @"Only the active repository fetches automatically"),
+		NSLocalizedString(@"All open repositories", @"All open repositories fetch automatically"),
+		NSLocalizedString(@"Open and recent repositories", @"Open and recent repositories fetch automatically"),
+	];
 	for (NSInteger scope = 0; scope < scopeTitles.count; scope++) {
 		[self.autoFetchScopePopup addItemWithTitle:scopeTitles[scope]];
 		self.autoFetchScopePopup.lastItem.tag = scope;
@@ -76,7 +124,7 @@
 	self.autoFetchScopePopup.action = @selector(autoFetchScopeChanged:);
 	[view addSubview:self.autoFetchScopePopup];
 
-	[view addSubview:[self labelWithString:@"Every:" frame:NSMakeRect(40, 54, 100, 24)]];
+	[view addSubview:[self labelWithString:NSLocalizedString(@"Every:", @"Scheduled fetch interval label") frame:NSMakeRect(40, 54, 100, 24)]];
 	self.autoFetchIntervalField = [[NSTextField alloc] initWithFrame:NSMakeRect(142, 51, 70, 26)];
 	NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
 	formatter.minimum = @1;
@@ -93,9 +141,9 @@
 	self.autoFetchIntervalStepper.target = self;
 	self.autoFetchIntervalStepper.action = @selector(autoFetchIntervalChanged:);
 	[view addSubview:self.autoFetchIntervalStepper];
-	[view addSubview:[self labelWithString:@"minutes (1–1440)" frame:NSMakeRect(242, 54, 170, 24)]];
+	[view addSubview:[self labelWithString:NSLocalizedString(@"minutes (1–1440)", @"Scheduled fetch interval unit and bounds") frame:NSMakeRect(242, 54, 170, 24)]];
 
-	NSTextField *fetchHelp = [self labelWithString:@"Fetches are noninteractive and never prune. A failure pauses only that repository until a successful manual fetch." frame:NSMakeRect(40, 17, 440, 34)];
+	NSTextField *fetchHelp = [self labelWithString:NSLocalizedString(@"Fetches are noninteractive and never prune. A failure pauses only that repository until a successful manual fetch.", @"Scheduled fetch behavior help") frame:NSMakeRect(40, 17, 440, 34)];
 	fetchHelp.maximumNumberOfLines = 2;
 	fetchHelp.lineBreakMode = NSLineBreakByWordWrapping;
 	fetchHelp.textColor = NSColor.secondaryLabelColor;

--- a/Classes/Controllers/PBPrefsWindowController.m
+++ b/Classes/Controllers/PBPrefsWindowController.m
@@ -12,6 +12,14 @@
 
 #define kPreferenceViewIdentifier @"PBGitXPreferenceViewIdentifier"
 
+@interface PBPrefsWindowController ()
+@property (nonatomic) NSView *historyAndFetchPrefsView;
+@property (nonatomic) NSButton *historySortingCheckbox;
+@property (nonatomic) NSPopUpButton *autoFetchScopePopup;
+@property (nonatomic) NSTextField *autoFetchIntervalField;
+@property (nonatomic) NSStepper *autoFetchIntervalStepper;
+@end
+
 @implementation PBPrefsWindowController
 
 #pragma mark DBPrefsWindowController overrides
@@ -24,6 +32,107 @@
 	[self addView:integrationPrefsView label:@"Integration" image:[NSImage imageNamed:NSImageNameNetwork]];
 	// UPDATES
 	[self addView:updatesPrefsView label:@"Updates"];
+	[self createHistoryAndFetchPreferencesIfNeeded];
+	[self syncHistoryAndFetchPreferences];
+	[self addView:self.historyAndFetchPrefsView
+			label:@"History & Fetch"
+			image:[NSImage imageWithSystemSymbolName:@"arrow.triangle.2.circlepath" accessibilityDescription:nil]];
+}
+
+- (NSTextField *)labelWithString:(NSString *)string frame:(NSRect)frame
+{
+	NSTextField *label = [NSTextField labelWithString:string];
+	label.frame = frame;
+	return label;
+}
+
+- (void)createHistoryAndFetchPreferencesIfNeeded
+{
+	if (self.historyAndFetchPrefsView) return;
+	NSView *view = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 520, 270)];
+
+	NSTextField *historyHeading = [self labelWithString:@"History" frame:NSMakeRect(40, 220, 440, 22)];
+	historyHeading.font = [NSFont boldSystemFontOfSize:NSFont.systemFontSize];
+	[view addSubview:historyHeading];
+
+	self.historySortingCheckbox = [NSButton checkboxWithTitle:@"Allow commit columns to sort history" target:self action:@selector(historySortingChanged:)];
+	self.historySortingCheckbox.frame = NSMakeRect(40, 188, 400, 24);
+	[view addSubview:self.historySortingCheckbox];
+	NSTextField *historyHelp = [self labelWithString:@"Turn this off to keep commits exclusively in Git graph order." frame:NSMakeRect(60, 164, 420, 20)];
+	historyHelp.textColor = NSColor.secondaryLabelColor;
+	[view addSubview:historyHelp];
+
+	NSTextField *fetchHeading = [self labelWithString:@"Scheduled Fetch" frame:NSMakeRect(40, 126, 440, 22)];
+	fetchHeading.font = [NSFont boldSystemFontOfSize:NSFont.systemFontSize];
+	[view addSubview:fetchHeading];
+	[view addSubview:[self labelWithString:@"Repositories:" frame:NSMakeRect(40, 92, 100, 24)]];
+	self.autoFetchScopePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(142, 88, 270, 28) pullsDown:NO];
+	NSArray<NSString *> *scopeTitles = @[ @"None", @"Active repository", @"All open repositories", @"Open and recent repositories" ];
+	for (NSInteger scope = 0; scope < scopeTitles.count; scope++) {
+		[self.autoFetchScopePopup addItemWithTitle:scopeTitles[scope]];
+		self.autoFetchScopePopup.lastItem.tag = scope;
+	}
+	self.autoFetchScopePopup.target = self;
+	self.autoFetchScopePopup.action = @selector(autoFetchScopeChanged:);
+	[view addSubview:self.autoFetchScopePopup];
+
+	[view addSubview:[self labelWithString:@"Every:" frame:NSMakeRect(40, 54, 100, 24)]];
+	self.autoFetchIntervalField = [[NSTextField alloc] initWithFrame:NSMakeRect(142, 51, 70, 26)];
+	NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
+	formatter.minimum = @1;
+	formatter.maximum = @1440;
+	formatter.allowsFloats = NO;
+	self.autoFetchIntervalField.formatter = formatter;
+	self.autoFetchIntervalField.target = self;
+	self.autoFetchIntervalField.action = @selector(autoFetchIntervalChanged:);
+	[view addSubview:self.autoFetchIntervalField];
+	self.autoFetchIntervalStepper = [[NSStepper alloc] initWithFrame:NSMakeRect(214, 49, 20, 28)];
+	self.autoFetchIntervalStepper.minValue = 1;
+	self.autoFetchIntervalStepper.maxValue = 1440;
+	self.autoFetchIntervalStepper.increment = 1;
+	self.autoFetchIntervalStepper.target = self;
+	self.autoFetchIntervalStepper.action = @selector(autoFetchIntervalChanged:);
+	[view addSubview:self.autoFetchIntervalStepper];
+	[view addSubview:[self labelWithString:@"minutes (1–1440)" frame:NSMakeRect(242, 54, 170, 24)]];
+
+	NSTextField *fetchHelp = [self labelWithString:@"Fetches are noninteractive and never prune. A failure pauses only that repository until a successful manual fetch." frame:NSMakeRect(40, 17, 440, 34)];
+	fetchHelp.maximumNumberOfLines = 2;
+	fetchHelp.lineBreakMode = NSLineBreakByWordWrapping;
+	fetchHelp.textColor = NSColor.secondaryLabelColor;
+	[view addSubview:fetchHelp];
+
+	self.historyAndFetchPrefsView = view;
+}
+
+- (void)syncHistoryAndFetchPreferences
+{
+	self.historySortingCheckbox.state = [PBGitDefaults historyColumnSortingEnabled] ? NSControlStateValueOn : NSControlStateValueOff;
+	[self.autoFetchScopePopup selectItemWithTag:[PBGitDefaults autoFetchScope]];
+	NSInteger interval = [PBGitDefaults autoFetchIntervalMinutes];
+	self.autoFetchIntervalField.integerValue = interval;
+	self.autoFetchIntervalStepper.integerValue = interval;
+	BOOL enabled = [PBGitDefaults autoFetchScope] != PBAutoFetchScopeNone;
+	self.autoFetchIntervalField.enabled = enabled;
+	self.autoFetchIntervalStepper.enabled = enabled;
+}
+
+- (IBAction)historySortingChanged:(NSButton *)sender
+{
+	[PBGitDefaults setHistoryColumnSortingEnabled:sender.state == NSControlStateValueOn];
+}
+
+- (IBAction)autoFetchScopeChanged:(NSPopUpButton *)sender
+{
+	[PBGitDefaults setAutoFetchScope:sender.selectedItem.tag];
+	[self syncHistoryAndFetchPreferences];
+}
+
+- (IBAction)autoFetchIntervalChanged:(NSControl *)sender
+{
+	NSInteger interval = MAX(1, MIN(1440, sender.integerValue));
+	[PBGitDefaults setAutoFetchIntervalMinutes:interval];
+	self.autoFetchIntervalField.integerValue = interval;
+	self.autoFetchIntervalStepper.integerValue = interval;
 }
 
 - (void)displayViewForIdentifier:(NSString *)identifier animate:(BOOL)animate

--- a/Classes/Controllers/PBWebChangesController.h
+++ b/Classes/Controllers/PBWebChangesController.h
@@ -19,8 +19,6 @@
 	__weak IBOutlet PBGitCommitController *controller;
 	IBOutlet PBGitIndexController *indexController;
 
-	PBChangedFile *selectedFile;
-	BOOL selectedFileIsCached;
 }
 
 - (void)refresh;

--- a/Classes/Controllers/PBWebChangesController.m
+++ b/Classes/Controllers/PBWebChangesController.m
@@ -1,179 +1,147 @@
-//
-//  PBWebChangesController.m
-//  GitX
-//
-//  Created by Pieter de Bie on 22-09-08.
-//  Copyright 2008 __MyCompanyName__. All rights reserved.
-//
-
 #import "PBWebChangesController.h"
 #import "PBGitIndex.h"
+#import "PBNativeContentView.h"
+#import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
+#import "PBTask.h"
 
 static void *const UnstagedFileSelectedContext = @"UnstagedFileSelectedContext";
 static void *const CachedFileSelectedContext = @"CachedFileSelectedContext";
 
-@interface PBWebChangesController () <WebEditingDelegate, WebUIDelegate>
+@interface PBWebChangesController () <PBNativeContentViewDelegate>
+@property (nonatomic) NSUInteger contextLines;
+@property (nonatomic) NSTextField *contextValueLabel;
 @end
 
 @implementation PBWebChangesController
 
 - (void)awakeFromNib
 {
-	selectedFile = nil;
-	selectedFileIsCached = NO;
-
 	startFile = @"commit";
 	[super awakeFromNib];
-
+	self.nativeView.delegate = self;
+	NSNumber *savedContext = [[NSUserDefaults standardUserDefaults] objectForKey:@"PBStageDiffContextLines"];
+	self.contextLines = savedContext ? savedContext.unsignedIntegerValue : 3;
+	NSView *accessory = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 100, 34)];
+	NSStackView *controls = [NSStackView stackViewWithViews:@[]];
+	controls.orientation = NSUserInterfaceLayoutOrientationHorizontal;
+	controls.spacing = 6;
+	controls.translatesAutoresizingMaskIntoConstraints = NO;
+	[accessory addSubview:controls];
+	[NSLayoutConstraint activateConstraints:@[
+		[accessory.heightAnchor constraintEqualToConstant:34],
+		[controls.centerXAnchor constraintEqualToAnchor:accessory.centerXAnchor],
+		[controls.centerYAnchor constraintEqualToAnchor:accessory.centerYAnchor],
+	]];
+	[controls addArrangedSubview:[NSTextField labelWithString:NSLocalizedString(@"Context:", @"Label for the number of surrounding lines shown in a diff")]];
+	self.contextValueLabel = [NSTextField labelWithString:[NSString stringWithFormat:@"%lu lines", (unsigned long)self.contextLines]];
+	self.contextValueLabel.alignment = NSTextAlignmentRight;
+	[self.contextValueLabel.widthAnchor constraintEqualToConstant:52].active = YES;
+	[controls addArrangedSubview:self.contextValueLabel];
+	NSStepper *stepper = [[NSStepper alloc] init];
+	stepper.minValue = 0;
+	stepper.maxValue = 50;
+	stepper.integerValue = self.contextLines;
+	stepper.target = self;
+	stepper.action = @selector(contextLinesChanged:);
+	[controls addArrangedSubview:stepper];
+	[self.nativeView setAccessoryView:accessory];
 	[unstagedFilesController addObserver:self forKeyPath:@"selection" options:0 context:UnstagedFileSelectedContext];
 	[stagedFilesController addObserver:self forKeyPath:@"selection" options:0 context:CachedFileSelectedContext];
+}
 
-	self.view.editingDelegate = self;
-	self.view.UIDelegate = self;
+- (void)contextLinesChanged:(NSStepper *)sender
+{
+	self.contextLines = sender.integerValue;
+	self.contextValueLabel.stringValue = [NSString stringWithFormat:@"%lu lines", (unsigned long)self.contextLines];
+	[[NSUserDefaults standardUserDefaults] setInteger:self.contextLines forKey:@"PBStageDiffContextLines"];
+	[self refresh];
 }
 
 - (void)closeView
 {
-	[[self script] removeWebScriptKey:@"Index"];
 	[unstagedFilesController removeObserver:self forKeyPath:@"selection"];
 	[stagedFilesController removeObserver:self forKeyPath:@"selection"];
-
 	[super closeView];
 }
 
 - (void)didLoad
 {
-	[[self script] setValue:controller.index forKey:@"Index"];
 	[self refresh];
 }
 
-- (void)observeValueForKeyPath:(NSString *)keyPath
-					  ofObject:(id)object
-						change:(NSDictionary *)change
-					   context:(void *)context
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-	if (context != UnstagedFileSelectedContext && context != CachedFileSelectedContext) {
-		return [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
-	}
-
-	NSArrayController *otherController;
-	otherController = object == unstagedFilesController ? stagedFilesController : unstagedFilesController;
-	NSUInteger count = [object selectedObjects].count;
-	if (count == 0) {
-		if ([[otherController selectedObjects] count] == 0 && selectedFile) {
-			selectedFile = nil;
-			selectedFileIsCached = NO;
-			[self refresh];
-		}
+	if (context == UnstagedFileSelectedContext || context == CachedFileSelectedContext) {
+		[self refresh];
 		return;
 	}
-
-	// TODO: Move this to commitcontroller
-	[otherController setSelectionIndexes:[NSIndexSet indexSet]];
-
-	if (count > 1) {
-		[self showMultiple:[object selectedObjects]];
-		return;
-	}
-
-	selectedFile = [[object selectedObjects] objectAtIndex:0];
-	selectedFileIsCached = object == stagedFilesController;
-
-	[self refresh];
+	[super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
 }
 
-- (void)showMultiple:(NSArray *)objects
+- (NSDictionary *)sectionForFile:(PBChangedFile *)file staged:(BOOL)staged
 {
-	[[self script] callWebScriptMethod:@"showMultipleFilesSelection" withArguments:[NSArray arrayWithObject:objects]];
+	NSString *diff = [controller.index diffForFile:file staged:staged contextLines:self.contextLines] ?: @"";
+	return @{
+		PBNativeSectionTitleKey : [NSString stringWithFormat:@"%@ — %@", staged ? @"Staged" : @"Unstaged", file.path],
+		PBNativeSectionPathKey : file.path ?: @"",
+		PBNativeSectionTextKey : diff,
+		PBNativeSectionContextKey : staged ? @"staged" : @"unstaged",
+	};
 }
 
 - (void)refresh
 {
-	if (!finishedLoading)
-		return;
-
-	id script = self.view.windowScriptObject;
-	[script callWebScriptMethod:@"showFileChanges"
-				  withArguments:[NSArray arrayWithObjects:selectedFile ?: (id)[NSNull null],
-														  [NSNumber numberWithBool:selectedFileIsCached], nil]];
+	if (!finishedLoading) return;
+	NSMutableArray<NSDictionary *> *sections = [NSMutableArray array];
+	for (PBChangedFile *file in stagedFilesController.selectedObjects) [sections addObject:[self sectionForFile:file staged:YES]];
+	for (PBChangedFile *file in unstagedFilesController.selectedObjects) [sections addObject:[self sectionForFile:file staged:NO]];
+	if (sections.count == 0) [self.nativeView showMessage:@"No file selected"];
+	else [self.nativeView showDiffSections:sections];
 }
 
-- (void)stageHunk:(NSString *)hunk reverse:(BOOL)reverse
+- (void)showMultiple:(NSArray *)files
 {
-	[controller.index applyPatch:hunk stage:YES reverse:reverse];
-	// FIXME: Don't need a hard refresh
-
 	[self refresh];
-}
-
-- (void)discardHunk:(NSString *)hunk
-{
-	[controller.index applyPatch:hunk stage:NO reverse:YES];
-	[self refresh];
-}
-
-- (void)discardHunk:(NSString *)hunk altKey:(BOOL)altKey
-{
-	if (!altKey) {
-		NSAlert *alert = [[NSAlert alloc] init];
-		alert.messageText = NSLocalizedString(@"Discard hunk", @"Title of dialogue asking whether the user really wanted to press the Discard button on a hunk in the changes view");
-		alert.informativeText = NSLocalizedString(@"Are you sure you wish to discard the changes in this hunk?\n\nYou cannot undo this operation.", @"Asks whether the user really wants to discard a hunk in changes view after pressing the Discard Hunk button");
-
-		[alert addButtonWithTitle:NSLocalizedString(@"OK", @"OK (discarding a hunk in the changes view)")];
-		[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"Cancel (discarding a hunk in the changes view)")];
-
-		[controller.windowController confirmDialog:alert
-							 suppressionIdentifier:nil
-										 forAction:^{
-											 [self discardHunk:hunk];
-										 }];
-	} else {
-		[self discardHunk:hunk];
-	}
 }
 
 - (void)setStateMessage:(NSString *)state
 {
-	id script = self.view.windowScriptObject;
-	[script callWebScriptMethod:@"setState" withArguments:[NSArray arrayWithObject:state]];
+	[self.nativeView showMessage:state ?: @""];
 }
 
-- (void)copy:(NSString *)text
+- (void)nativeContentView:(PBNativeContentView *)view performDiffAction:(NSString *)action patch:(NSString *)patch
 {
-	NSArray *lines = [text componentsSeparatedByString:@"\n"];
-	NSMutableArray *processedLines = [NSMutableArray arrayWithCapacity:lines.count - 1];
-	for (int i = 0; i < lines.count; i++) {
-		NSString *line = [lines objectAtIndex:i];
-		if (line.length > 0) {
-			[processedLines addObject:[line substringFromIndex:1]];
-		} else {
-			[processedLines addObject:line];
-		}
-	}
-	NSString *result = [processedLines componentsJoinedByString:@"\n"];
-	[[NSPasteboard generalPasteboard] declareTypes:[NSArray arrayWithObject:NSPasteboardTypeString] owner:nil];
-	[[NSPasteboard generalPasteboard] setString:result forType:NSPasteboardTypeString];
-}
-
-- (BOOL)webView:(WebView *)webView
-	validateUserInterfaceItem:(id<NSValidatedUserInterfaceItem>)item
-			defaultValidation:(BOOL)defaultValidation
-{
-	if (item.action == @selector(copy:)) {
-		return YES;
-	} else {
-		return defaultValidation;
+	if ([action isEqualToString:@"stage"]) {
+		[controller.index applyPatch:patch stage:YES reverse:NO];
+		[self refresh];
+	} else if ([action isEqualToString:@"unstage"]) {
+		[controller.index applyPatch:patch stage:YES reverse:YES];
+		[self refresh];
+	} else if ([action isEqualToString:@"discard"]) {
+		NSAlert *alert = [[NSAlert alloc] init];
+		alert.messageText = NSLocalizedString(@"Discard hunk", @"");
+		alert.informativeText = NSLocalizedString(@"Are you sure you wish to discard this hunk? This operation cannot be undone.", @"");
+		[alert addButtonWithTitle:NSLocalizedString(@"Discard", @"")];
+		[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"")];
+		[alert beginSheetModalForWindow:self.view.window completionHandler:^(NSModalResponse response) {
+			if (response == NSAlertFirstButtonReturn) {
+				[self->controller.index applyPatch:patch stage:NO reverse:YES];
+				[self refresh];
+			}
+		}];
 	}
 }
 
-- (BOOL)webView:(WebView *)webView doCommandBySelector:(SEL)selector
+- (NSImage *)nativeContentView:(PBNativeContentView *)view imageForPath:(NSString *)path section:(NSUInteger)sectionIndex
 {
-	if (selector == @selector(copy:)) {
-		[self.script callWebScriptMethod:@"copy" withArguments:@[]];
-		return YES;
-	} else {
-		return NO;
+	PBGitRepository *workingRepository = controller.repository;
+	NSData *data = [NSData dataWithContentsOfURL:[workingRepository.workingDirectoryURL URLByAppendingPathComponent:path]];
+	if (!data.length) {
+		PBTask *task = [workingRepository taskWithArguments:@[ @"show", [@":" stringByAppendingString:path] ]];
+		if ([task launchTask:nil]) data = task.standardOutputData;
 	}
+	return data.length ? [[NSImage alloc] initWithData:data] : nil;
 }
 
 @end

--- a/Classes/Controllers/PBWebController.h
+++ b/Classes/Controllers/PBWebController.h
@@ -7,23 +7,24 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#import <WebKit/WebKit.h>
+
+@class PBNativeContentView;
 
 @interface PBWebController : NSObject {
 	NSString *startFile;
 	BOOL finishedLoading;
 
-	// For async git reading
-	NSMapTable *callbacks;
-
 	// For the repository access
 	__weak IBOutlet id repository;
 }
 
-@property (weak) IBOutlet WebView *view;
+@property (weak) IBOutlet NSView *view;
+@property (nonatomic, readonly) PBNativeContentView *nativeView;
 @property NSString *startFile;
 @property (weak) id repository;
 
-- (WebScriptObject *)script;
 - (void)closeView;
+- (void)didLoad;
+- (void)preferencesChanged;
+- (void)makeWebViewFirstResponder;
 @end

--- a/Classes/Controllers/PBWebController.m
+++ b/Classes/Controllers/PBWebController.m
@@ -1,21 +1,8 @@
-//
-//  PBWebController.m
-//  GitX
-//
-//  Created by Pieter de Bie on 08-10-08.
-//  Copyright 2008 __MyCompanyName__. All rights reserved.
-//
-
 #import "PBWebController.h"
-#import "PBGitRepository.h"
-#import "PBGitRepository_PBGitBinarySupport.h"
-#import "PBGitXProtocol.h"
-#import "PBGitDefaults.h"
+#import "PBNativeContentView.h"
 
-#include <SystemConfiguration/SCNetworkReachability.h>
-
-@interface PBWebController () <WebUIDelegate, WebFrameLoadDelegate, WebResourceLoadDelegate>
-- (void)preferencesChangedWithNotification:(NSNotification *)theNotification;
+@interface PBWebController ()
+@property (nonatomic, readwrite) PBNativeContentView *nativeView;
 @end
 
 @implementation PBWebController
@@ -24,227 +11,43 @@
 
 - (void)awakeFromNib
 {
-	NSString *path = [NSString stringWithFormat:@"html/views/%@", startFile];
-	NSString *file = [[NSBundle mainBundle] pathForResource:@"index" ofType:@"html" inDirectory:path];
-	NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL fileURLWithPath:file]];
-	callbacks = [NSMapTable mapTableWithKeyOptions:(NSPointerFunctionsObjectPointerPersonality | NSPointerFunctionsStrongMemory) valueOptions:(NSPointerFunctionsObjectPointerPersonality | NSPointerFunctionsStrongMemory)];
+	self.nativeView = [[PBNativeContentView alloc] initWithFrame:self.view.bounds];
+	self.nativeView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+	self.nativeView.translatesAutoresizingMaskIntoConstraints = YES;
+	[self.view addSubview:self.nativeView positioned:NSWindowAbove relativeTo:nil];
+	self.nativeView.frame = self.view.bounds;
 
-	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-	[nc addObserver:self
-		   selector:@selector(preferencesChangedWithNotification:)
-			   name:NSUserDefaultsDidChangeNotification
-			 object:nil];
-
-	[nc addObserver:self
-		   selector:@selector(windowWillStartLiveResizeWithNotification:)
-			   name:NSWindowWillStartLiveResizeNotification
-			 object:self.view.window];
-
-	[nc addObserver:self
-		   selector:@selector(windowDidEndLiveResizeWithNotification:)
-			   name:NSWindowDidEndLiveResizeNotification
-			 object:self.view.window];
-
-	[nc addObserver:self
-		   selector:@selector(effectiveAppearanceDidChange:)
-			   name:PBEffectiveAppearanceChanged
-			 object:nil];
-
-	finishedLoading = NO;
-
-	[self.view setDrawsBackground:NO];
-
-	[self.view setUIDelegate:self];
-	[self.view setFrameLoadDelegate:self];
-	[self.view setResourceLoadDelegate:self];
-	[self.view.preferences setDefaultFontSize:(int)[NSFont systemFontSize]];
-	[self.view.mainFrame loadRequest:request];
-}
-
-- (WebScriptObject *)script
-{
-	return self.view.windowScriptObject;
-}
-
-- (void)effectiveAppearanceDidChange:(NSNotification *)notif
-{
-	NSString *mode = [NSApp isDarkMode] ? @"DARK" : @"LIGHT";
-	[self.script callWebScriptMethod:@"setAppearance" withArguments:@[ mode ]];
-}
-
-- (void)closeView
-{
-	if (self.view) {
-		[[self script] setValue:nil forKey:@"Controller"];
-		[self.view close];
-	}
-
-	[[NSNotificationCenter defaultCenter] removeObserver:self];
+	[[NSNotificationCenter defaultCenter] addObserver:self
+							 selector:@selector(preferencesChangedWithNotification:)
+								 name:NSUserDefaultsDidChangeNotification
+							  object:nil];
+	finishedLoading = YES;
+	dispatch_async(dispatch_get_main_queue(), ^{ [self didLoad]; });
 }
 
 - (void)didLoad
 {
 }
 
-#pragma mark Delegate methods
-
-- (void)webView:(WebView *)sender didClearWindowObject:(WebScriptObject *)windowObject forFrame:(WebFrame *)frame
+- (void)closeView
 {
-	id script = self.view.windowScriptObject;
-	[script setValue:self forKey:@"Controller"];
-}
-
-- (void)webView:(id)v didFinishLoadForFrame:(id)frame
-{
-	finishedLoading = YES;
-	if ([self respondsToSelector:@selector(didLoad)])
-		[self performSelector:@selector(didLoad)];
-	[self effectiveAppearanceDidChange:nil];
-}
-
-- (void)webView:(WebView *)webView addMessageToConsole:(NSDictionary *)dictionary
-{
-	NSLog(@"Error from webkit: %@", dictionary);
-}
-
-- (NSURLRequest *)webView:(WebView *)sender
-				 resource:(id)identifier
-		  willSendRequest:(NSURLRequest *)request
-		 redirectResponse:(NSURLResponse *)redirectResponse
-		   fromDataSource:(WebDataSource *)dataSource
-{
-	if (!self.repository)
-		return request;
-
-	if ([PBGitXProtocol canInitWithRequest:request]) {
-		NSMutableURLRequest *newRequest = [request mutableCopy];
-		[newRequest setRepository:self.repository];
-		return newRequest;
-	}
-
-	return request;
-}
-
-- (void)webView:(WebView *)sender
-	decidePolicyForNavigationAction:(NSDictionary *)actionInformation
-							request:(NSURLRequest *)request
-							  frame:(WebFrame *)frame
-				   decisionListener:(id<WebPolicyDecisionListener>)listener
-{
-	NSString *scheme = [[request URL] scheme];
-	if ([scheme compare:@"http"] == NSOrderedSame ||
-		[scheme compare:@"https"] == NSOrderedSame) {
-		[listener ignore];
-		[[NSWorkspace sharedWorkspace] openURL:[request URL]];
-	} else {
-		[listener use];
-	}
-}
-
-- (NSUInteger)webView:(WebView *)webView
-	dragDestinationActionMaskForDraggingInfo:(id<NSDraggingInfo>)draggingInfo
-{
-	return NSDragOperationNone;
-}
-
-+ (BOOL)isSelectorExcludedFromWebScript:(SEL)aSelector
-{
-	return NO;
-}
-
-+ (BOOL)isKeyExcludedFromWebScript:(const char *)name
-{
-	return NO;
-}
-
-#pragma mark Functions to be used from JavaScript
-
-- (void)log:(NSString *)logMessage
-{
-	NSLog(@"%@", logMessage);
-}
-
-- (BOOL)isReachable:(NSString *)hostname
-{
-	SCNetworkReachabilityRef target;
-	SCNetworkConnectionFlags flags = 0;
-	Boolean reachable;
-	target = SCNetworkReachabilityCreateWithName(NULL, [hostname cStringUsingEncoding:NSASCIIStringEncoding]);
-	reachable = SCNetworkReachabilityGetFlags(target, &flags);
-	CFRelease(target);
-
-	if (!reachable)
-		return FALSE;
-
-	// If a connection is required, then it's not reachable
-	if (flags & (kSCNetworkFlagsConnectionRequired | kSCNetworkFlagsConnectionAutomatic | kSCNetworkFlagsInterventionRequired))
-		return FALSE;
-
-	return flags > 0;
-}
-
-- (BOOL)isFeatureEnabled:(NSString *)feature
-{
-	if ([feature isEqualToString:@"gravatar"])
-		return [PBGitDefaults isGravatarEnabled];
-	else if ([feature isEqualToString:@"gist"])
-		return [PBGitDefaults isGistEnabled];
-	else if ([feature isEqualToString:@"confirmGist"])
-		return [PBGitDefaults confirmPublicGists];
-	else if ([feature isEqualToString:@"publicGist"])
-		return [PBGitDefaults isGistPublic];
-	else
-		return YES;
-}
-
-#pragma mark Using async function from JS
-
-- (void)runCommand:(WebScriptObject *)arguments inRepository:(PBGitRepository *)repo callBack:(WebScriptObject *)callBack
-{
-	// The JS bridge does not handle JS Arrays, even though the docs say it does. So, we convert it ourselves.
-	int length = [[arguments valueForKey:@"length"] intValue];
-	NSMutableArray *realArguments = [NSMutableArray arrayWithCapacity:length];
-	int i = 0;
-	for (i = 0; i < length; i++)
-		[realArguments addObject:[arguments webScriptValueAtIndex:i]];
-
-	PBTask *task = [repo taskWithArguments:realArguments];
-	[task performTaskWithCompletionHandler:^(NSData *_Nullable readData, NSError *_Nullable error) {
-		if (error) {
-			/* FIXME: Might want to inform the JS that something went wrong */
-			NSLog(@"error: %@", error);
-			return;
-		}
-		[callBack callWebScriptMethod:@"call" withArguments:@[ @"", readData ]];
-	}];
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
+	[self.nativeView removeFromSuperview];
+	self.nativeView = nil;
 }
 
 - (void)preferencesChanged
 {
 }
 
-- (void)makeWebViewFirstResponder
-{
-	[self.view.window makeFirstResponder:self.view];
-}
-
-
-#pragma mark - Notifications
-
-- (void)preferencesChangedWithNotification:(NSNotification *)theNotification
+- (void)preferencesChangedWithNotification:(NSNotification *)notification
 {
 	[self preferencesChanged];
 }
 
-- (void)windowWillStartLiveResizeWithNotification:(NSNotification *)theNotification
+- (void)makeWebViewFirstResponder
 {
-	self.view.autoresizingMask = NSViewMaxXMargin | NSViewMinYMargin | NSViewMaxYMargin | NSViewHeightSizable;
-}
-
-- (void)windowDidEndLiveResizeWithNotification:(NSNotification *)theNotification
-{
-	self.view.autoresizingMask = NSViewMinXMargin | NSViewMaxXMargin | NSViewMinYMargin | NSViewMaxYMargin | NSViewWidthSizable | NSViewHeightSizable;
-	self.view.frame = self.view.superview.bounds;
+	[self.view.window makeFirstResponder:self.nativeView.textView];
 }
 
 @end

--- a/Classes/Controllers/PBWebDiffController.m
+++ b/Classes/Controllers/PBWebDiffController.m
@@ -1,13 +1,12 @@
-//
-//  PBWebDiffController.m
-//  GitX
-//
-//  Created by Pieter de Bie on 13-10-08.
-//  Copyright 2008 Pieter de Bie. All rights reserved.
-//
-
 #import "PBWebDiffController.h"
+#import "PBNativeContentView.h"
+#import "PBGitCommit.h"
+#import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
+#import "PBTask.h"
 
+@interface PBWebDiffController () <PBNativeContentViewDelegate>
+@end
 
 @implementation PBWebDiffController
 
@@ -15,13 +14,23 @@
 {
 	startFile = @"diff";
 	[super awakeFromNib];
+	self.nativeView.delegate = self;
 	[diffController addObserver:self
-						keyPath:@"diff"
-						options:0
-						  block:^(MAKVONotification *notification) {
-							  PBDiffWindowController *target = notification.target;
-							  [notification.observer showDiff:target.diff];
-						  }];
+					 keyPath:@"diff"
+					 options:0
+					   block:^(MAKVONotification *notification) {
+		PBDiffWindowController *target = notification.target;
+		[notification.observer showDiff:target.diff];
+	}];
+}
+
+- (NSImage *)nativeContentView:(PBNativeContentView *)view imageForPath:(NSString *)path section:(NSUInteger)sectionIndex
+{
+	PBGitCommit *commit = diffController.diffCommit;
+	if (!commit.SHA.length) return nil;
+	PBTask *task = [commit.repository taskWithArguments:@[ @"show", [NSString stringWithFormat:@"%@:%@", commit.SHA, path] ]];
+	if (![task launchTask:nil]) return nil;
+	return [[NSImage alloc] initWithData:task.standardOutputData];
 }
 
 - (void)didLoad
@@ -31,14 +40,13 @@
 
 - (void)showDiff:(NSString *)diff
 {
-	if (diff == nil || !finishedLoading)
-		return;
-
-	id script = self.view.windowScriptObject;
-	if ([diff length] == 0)
-		[script callWebScriptMethod:@"setMessage" withArguments:[NSArray arrayWithObject:@"There are no differences"]];
-	else
-		[script callWebScriptMethod:@"showDiff" withArguments:[NSArray arrayWithObject:diff]];
+	if (!finishedLoading || diff == nil) return;
+	if (diff.length == 0) [self.nativeView showMessage:@"There are no differences"];
+	else [self.nativeView showDiffSections:@[@{
+		PBNativeSectionTitleKey : @"Diff",
+		PBNativeSectionTextKey : diff,
+		PBNativeSectionContextKey : @"readOnly",
+	}]];
 }
 
 @end

--- a/Classes/Controllers/PBWebHistoryController.h
+++ b/Classes/Controllers/PBWebHistoryController.h
@@ -24,6 +24,8 @@
 }
 
 - (void)sendKey:(NSString *)key;
+- (void)scrollPageUp;
+- (void)scrollPageDown;
 
 @property (readonly) NSString *diff;
 

--- a/Classes/Controllers/PBWebHistoryController.m
+++ b/Classes/Controllers/PBWebHistoryController.m
@@ -19,6 +19,9 @@ typedef NS_ENUM(NSInteger, PBMultiCommitDiffPresentation) {
 @property (nonatomic) NSSegmentedControl *presentationControl;
 @property (nonatomic) NSArray<PBGitCommit *> *displayedCommits;
 @property (nonatomic) NSArray<PBGitCommit *> *renderedCommits;
+@property (nonatomic) dispatch_queue_t renderQueue;
+@property (nonatomic) NSUInteger contentGeneration;
+@property (nonatomic) PBTask *activeTask;
 @end
 
 @implementation PBWebHistoryController
@@ -31,11 +34,12 @@ typedef NS_ENUM(NSInteger, PBMultiCommitDiffPresentation) {
 	repository = historyController.repository;
 	[super awakeFromNib];
 	self.nativeView.delegate = self;
+	self.renderQueue = dispatch_queue_create("com.gitx.history-render", DISPATCH_QUEUE_SERIAL);
 
 	self.presentationControl = [NSSegmentedControl segmentedControlWithLabels:@[ @"Sequential", @"Combined" ]
-										 trackingMode:NSSegmentSwitchTrackingSelectOne
-											 target:self
-											 action:@selector(presentationChanged:)];
+																 trackingMode:NSSegmentSwitchTrackingSelectOne
+																	   target:self
+																	   action:@selector(presentationChanged:)];
 	self.presentationControl.controlSize = NSControlSizeSmall;
 	self.presentationControl.accessibilityIdentifier = @"MultiCommitDiffPresentation";
 	self.presentationControl.selectedSegment = [[NSUserDefaults standardUserDefaults] integerForKey:PBMultiCommitDiffPresentationKey];
@@ -68,52 +72,102 @@ typedef NS_ENUM(NSInteger, PBMultiCommitDiffPresentation) {
 	return commits.reverseObjectEnumerator.allObjects;
 }
 
-- (NSString *)diffForCommit:(PBGitCommit *)commit
+- (BOOL)isGenerationCurrent:(NSUInteger)generation
 {
-	NSString *base = commit.parents.firstObject.SHA ?: PBEmptyTreeSHA;
-	NSError *error = nil;
-	return [historyController.repository outputOfTaskWithArguments:@[ @"diff", @"--find-renames", @"--no-ext-diff", base, commit.SHA ] error:&error] ?: @"";
+	@synchronized(self) {
+		return generation == self.contentGeneration;
+	}
 }
 
-- (BOOL)commitsShareAncestryPath:(NSArray<PBGitCommit *> *)commits
+- (NSUInteger)beginContentGeneration
+{
+	PBTask *task = nil;
+	NSUInteger generation = 0;
+	@synchronized(self) {
+		generation = ++self.contentGeneration;
+		task = self.activeTask;
+		self.activeTask = nil;
+	}
+	[task terminate];
+	return generation;
+}
+
+- (nullable NSString *)runGitArguments:(NSArray<NSString *> *)arguments generation:(NSUInteger)generation error:(NSError **)error
+{
+	if (![self isGenerationCurrent:generation]) return nil;
+	PBTask *task = [historyController.repository taskWithArguments:arguments];
+	task.timeout = 2.0 * 60.0;
+	@synchronized(self) {
+		if (generation != self.contentGeneration) return nil;
+		self.activeTask = task;
+	}
+	BOOL success = [task launchTask:error];
+	@synchronized(self) {
+		if (self.activeTask == task) self.activeTask = nil;
+	}
+	if (!success || ![self isGenerationCurrent:generation]) return nil;
+	return task.standardOutputString ?: @"";
+}
+
+- (NSString *)diffForCommit:(PBGitCommit *)commit generation:(NSUInteger)generation
+{
+	NSString *base = commit.parents.firstObject.SHA ?: PBEmptyTreeSHA;
+	return [self runGitArguments:@[ @"diff", @"--find-renames", @"--no-ext-diff", base, commit.SHA ] generation:generation error:nil] ?: @"";
+}
+
+- (BOOL)commitsShareAncestryPath:(NSArray<PBGitCommit *> *)commits generation:(NSUInteger)generation
 {
 	for (NSUInteger index = 1; index < commits.count; index++) {
-		NSError *error = nil;
-		NSString *lineage = [historyController.repository outputOfTaskWithArguments:@[ @"rev-list", @"--first-parent", commits[index].SHA ] error:&error];
-		if (!lineage) return NO;
-		NSSet<NSString *> *firstParents = [NSSet setWithArray:[lineage componentsSeparatedByCharactersInSet:NSCharacterSet.newlineCharacterSet]];
-		if (![firstParents containsObject:commits[index - 1].SHA]) return NO;
+		NSString *oldSHA = commits[index - 1].SHA;
+		NSString *newSHA = commits[index].SHA;
+		NSString *range = [NSString stringWithFormat:@"%@..%@", oldSHA, newSHA];
+		NSString *lineage = [self runGitArguments:@[ @"rev-list", @"--first-parent", @"--parents", range ] generation:generation error:nil];
+		if (!lineage || ![self isGenerationCurrent:generation]) return NO;
+		NSArray<NSString *> *lines = [lineage componentsSeparatedByCharactersInSet:NSCharacterSet.newlineCharacterSet];
+		NSString *oldestLine = nil;
+		for (NSString *line in lines.reverseObjectEnumerator) {
+			if (line.length) {
+				oldestLine = line;
+				break;
+			}
+		}
+		NSArray<NSString *> *parts = [oldestLine componentsSeparatedByCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+		NSMutableArray<NSString *> *nonempty = [NSMutableArray array];
+		for (NSString *part in parts)
+			if (part.length) [nonempty addObject:part];
+		if (nonempty.count < 2 || ![nonempty[1] isEqualToString:oldSHA]) return NO;
 	}
 	return YES;
 }
 
-- (NSArray<NSDictionary *> *)sequentialSectionsForCommits:(NSArray<PBGitCommit *> *)commits
+- (nullable NSArray<NSDictionary *> *)sequentialSectionsForCommits:(NSArray<PBGitCommit *> *)commits generation:(NSUInteger)generation
 {
 	NSMutableArray *sections = [NSMutableArray array];
 	for (PBGitCommit *commit in commits) {
+		if (![self isGenerationCurrent:generation]) return nil;
 		NSString *shortSHA = commit.shortName ?: @"";
 		NSString *title = [NSString stringWithFormat:@"%@  %@\n%@ — %@", shortSHA, commit.subject ?: @"", commit.author ?: @"", commit.authorDate ?: @""];
 		[sections addObject:@{
 			PBNativeSectionTitleKey : title,
-			PBNativeSectionTextKey : [self diffForCommit:commit],
+			PBNativeSectionTextKey : [self diffForCommit:commit generation:generation],
 			PBNativeSectionContextKey : @"readOnly",
 		}];
 	}
-	return sections;
+	return [self isGenerationCurrent:generation] ? sections : nil;
 }
 
-- (NSArray<NSDictionary *> *)combinedSectionsForCommits:(NSArray<PBGitCommit *> *)commits
+- (nullable NSArray<NSDictionary *> *)combinedSectionsForCommits:(NSArray<PBGitCommit *> *)commits generation:(NSUInteger)generation
 {
 	PBGitCommit *oldest = commits.firstObject;
 	PBGitCommit *newest = commits.lastObject;
 	NSString *base = oldest.parents.firstObject.SHA ?: PBEmptyTreeSHA;
-	NSError *error = nil;
-	NSString *combined = [historyController.repository outputOfTaskWithArguments:@[ @"diff", @"--find-renames", @"--no-ext-diff", base, newest.SHA ] error:&error] ?: @"";
-	return @[@{
+	NSString *combined = [self runGitArguments:@[ @"diff", @"--find-renames", @"--no-ext-diff", base, newest.SHA ] generation:generation error:nil];
+	if (!combined || ![self isGenerationCurrent:generation]) return nil;
+	return @[ @{
 		PBNativeSectionTitleKey : [NSString stringWithFormat:@"Combined Diff — %@ through %@", oldest.shortName, newest.shortName],
 		PBNativeSectionTextKey : combined,
 		PBNativeSectionContextKey : @"readOnly",
-	}];
+	} ];
 }
 
 - (NSString *)syntheticUntrackedDiffForFile:(PBChangedFile *)file
@@ -129,52 +183,72 @@ typedef NS_ENUM(NSInteger, PBMultiCommitDiffPresentation) {
 	return [NSString stringWithFormat:@"diff --git a/%@ b/%@\nnew file mode 100644\n--- /dev/null\n+++ b/%@\n@@ -0,0 +1,%lu @@\n%@", file.path, file.path, file.path, (unsigned long)lines.count, added];
 }
 
-- (NSArray<NSDictionary *> *)workingStateSections
+- (nullable NSArray<NSDictionary *> *)workingStateSectionsForChanges:(NSArray<PBChangedFile *> *)changes generation:(NSUInteger)generation
 {
-	NSError *error = nil;
-	NSString *staged = [historyController.repository outputOfTaskWithArguments:@[ @"diff", @"--cached", @"--find-renames", @"--no-ext-diff" ] error:&error] ?: @"";
-	NSMutableString *unstaged = [[historyController.repository outputOfTaskWithArguments:@[ @"diff", @"--find-renames", @"--no-ext-diff" ] error:&error] ?: @"" mutableCopy];
-	for (PBChangedFile *file in historyController.repository.index.indexChanges) {
+	NSString *staged = [self runGitArguments:@[ @"diff", @"--cached", @"--find-renames", @"--no-ext-diff" ] generation:generation error:nil];
+	if (!staged || ![self isGenerationCurrent:generation]) return nil;
+	NSString *unstagedOutput = [self runGitArguments:@[ @"diff", @"--find-renames", @"--no-ext-diff" ] generation:generation error:nil];
+	if (!unstagedOutput || ![self isGenerationCurrent:generation]) return nil;
+	NSMutableString *unstaged = [unstagedOutput mutableCopy];
+	for (PBChangedFile *file in changes) {
+		if (![self isGenerationCurrent:generation]) return nil;
 		if (file.status == NEW && file.hasUnstagedChanges) [unstaged appendString:[self syntheticUntrackedDiffForFile:file]];
 	}
 	return @[
-		@{ PBNativeSectionTitleKey : @"Staged Changes", PBNativeSectionTextKey : staged, PBNativeSectionContextKey : @"readOnly" },
-		@{ PBNativeSectionTitleKey : @"Unstaged Changes", PBNativeSectionTextKey : unstaged, PBNativeSectionContextKey : @"readOnly" },
+		@{PBNativeSectionTitleKey : @"Staged Changes", PBNativeSectionTextKey : staged, PBNativeSectionContextKey : @"readOnly"},
+		@{PBNativeSectionTitleKey : @"Unstaged Changes", PBNativeSectionTextKey : unstaged, PBNativeSectionContextKey : @"readOnly"},
 	];
 }
 
 - (void)changeContentTo:(NSArray<PBGitCommit *> *)commits
 {
-	self.displayedCommits = commits ?: @[];
-	self.presentationControl.superview.hidden = commits.count <= 1;
-	if (commits.count == 0) {
+	NSArray<PBGitCommit *> *requestedCommits = [commits copy] ?: @[];
+	NSUInteger generation = [self beginContentGeneration];
+	self.displayedCommits = requestedCommits;
+	self.presentationControl.superview.hidden = requestedCommits.count <= 1;
+	if (requestedCommits.count == 0) {
+		self.renderedCommits = @[];
+		self->diff = @"";
 		[self.nativeView showMessage:@"No commit selected"];
 		return;
 	}
-	if ([commits.firstObject isKindOfClass:PBUncommittedChanges.class]) {
-		self.renderedCommits = @[];
+	if ([requestedCommits.firstObject isKindOfClass:PBUncommittedChanges.class]) {
 		self.presentationControl.superview.hidden = YES;
-		NSArray *sections = [self workingStateSections];
-		self->diff = [[sections valueForKey:PBNativeSectionTextKey] componentsJoinedByString:@"\n"];
-		[self.nativeView showDiffSections:sections];
+		NSArray<PBChangedFile *> *changes = [historyController.repository.index.indexChanges copy];
+		[self.nativeView showMessage:@"Loading changes…"];
+		dispatch_async(self.renderQueue, ^{
+			NSArray<NSDictionary *> *sections = [self workingStateSectionsForChanges:changes generation:generation];
+			if (!sections) return;
+			dispatch_async(dispatch_get_main_queue(), ^{
+				if (![self isGenerationCurrent:generation]) return;
+				self.renderedCommits = @[];
+				self->diff = [[sections valueForKey:PBNativeSectionTextKey] componentsJoinedByString:@"\n"];
+				[self.nativeView showDiffSections:sections];
+			});
+		});
 		return;
 	}
 
-	NSArray<PBGitCommit *> *ordered = [self oldestFirst:commits];
-	BOOL combinedEnabled = commits.count > 1 && [self commitsShareAncestryPath:ordered];
-	[self.presentationControl setEnabled:combinedEnabled forSegment:PBMultiCommitDiffPresentationCombined];
-	PBMultiCommitDiffPresentation mode = self.presentationControl.selectedSegment;
-	if (mode == PBMultiCommitDiffPresentationCombined && !combinedEnabled) {
-		mode = PBMultiCommitDiffPresentationSequential;
-		self.presentationControl.selectedSegment = mode;
-		self.presentationControl.toolTip = NSLocalizedString(@"Combined Diff requires commits on one ancestry path.", @"Explanation shown when selected commits cannot produce one combined diff");
-	} else {
-		self.presentationControl.toolTip = nil;
-	}
-	NSArray *sections = mode == PBMultiCommitDiffPresentationCombined ? [self combinedSectionsForCommits:ordered] : [self sequentialSectionsForCommits:ordered];
-	self.renderedCommits = mode == PBMultiCommitDiffPresentationCombined ? @[ ordered.lastObject ] : ordered;
-	self->diff = [[sections valueForKey:PBNativeSectionTextKey] componentsJoinedByString:@"\n"];
-	[self.nativeView showDiffSections:sections];
+	NSArray<PBGitCommit *> *ordered = [self oldestFirst:requestedCommits];
+	PBMultiCommitDiffPresentation requestedMode = self.presentationControl.selectedSegment;
+	[self.nativeView showMessage:@"Loading diff…"];
+	dispatch_async(self.renderQueue, ^{
+		BOOL combinedEnabled = requestedCommits.count > 1 && [self commitsShareAncestryPath:ordered generation:generation];
+		if (![self isGenerationCurrent:generation]) return;
+		PBMultiCommitDiffPresentation mode = requestedMode;
+		if (mode == PBMultiCommitDiffPresentationCombined && !combinedEnabled) mode = PBMultiCommitDiffPresentationSequential;
+		NSArray<NSDictionary *> *sections = mode == PBMultiCommitDiffPresentationCombined ? [self combinedSectionsForCommits:ordered generation:generation] : [self sequentialSectionsForCommits:ordered generation:generation];
+		if (!sections || ![self isGenerationCurrent:generation]) return;
+		dispatch_async(dispatch_get_main_queue(), ^{
+			if (![self isGenerationCurrent:generation]) return;
+			[self.presentationControl setEnabled:combinedEnabled forSegment:PBMultiCommitDiffPresentationCombined];
+			self.presentationControl.selectedSegment = mode;
+			self.presentationControl.toolTip = requestedMode == PBMultiCommitDiffPresentationCombined && !combinedEnabled ? NSLocalizedString(@"Combined Diff requires commits on one ancestry path.", @"Explanation shown when selected commits cannot produce one combined diff") : nil;
+			self.renderedCommits = mode == PBMultiCommitDiffPresentationCombined ? @[ ordered.lastObject ] : ordered;
+			self->diff = [[sections valueForKey:PBNativeSectionTextKey] componentsJoinedByString:@"\n"];
+			[self.nativeView showDiffSections:sections];
+		});
+	});
 }
 
 - (nullable NSData *)dataForGitObject:(NSString *)object

--- a/Classes/Controllers/PBWebHistoryController.m
+++ b/Classes/Controllers/PBWebHistoryController.m
@@ -1,20 +1,24 @@
-//
-//  PBWebGitController.m
-//  GitTest
-//
-//  Created by Pieter de Bie on 14-06-08.
-//  Copyright 2008 __MyCompanyName__. All rights reserved.
-//
-
 #import "PBWebHistoryController.h"
-#import "PBGitDefaults.h"
-#import <ObjectiveGit/GTConfiguration.h>
-#import "PBGitRef.h"
-#import "PBGitRevSpecifier.h"
-#import <stdatomic.h>
+#import "PBNativeContentView.h"
+#import "PBUncommittedChanges.h"
+#import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
+#import "PBGitIndex.h"
+#import "PBChangedFile.h"
+#import "PBTask.h"
 
-@interface PBWebHistoryController ()
-@property (nonatomic) atomic_ulong commitSummaryGeneration;
+static NSString *const PBMultiCommitDiffPresentationKey = @"PBMultiCommitDiffPresentation";
+static NSString *const PBEmptyTreeSHA = @"4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
+typedef NS_ENUM(NSInteger, PBMultiCommitDiffPresentation) {
+	PBMultiCommitDiffPresentationSequential = 0,
+	PBMultiCommitDiffPresentationCombined = 1,
+};
+
+@interface PBWebHistoryController () <PBNativeContentViewDelegate>
+@property (nonatomic) NSSegmentedControl *presentationControl;
+@property (nonatomic) NSArray<PBGitCommit *> *displayedCommits;
+@property (nonatomic) NSArray<PBGitCommit *> *renderedCommits;
 @end
 
 @implementation PBWebHistoryController
@@ -26,327 +30,193 @@
 	startFile = @"history";
 	repository = historyController.repository;
 	[super awakeFromNib];
-	[historyController addObserver:self
-						   keyPath:@"webCommits"
-						   options:0
-							 block:^(MAKVONotification *notification) {
-								 [self changeContentTo:self->historyController.webCommits];
-							 }];
-}
+	self.nativeView.delegate = self;
 
-- (void)closeView
-{
-	[[self script] setValue:nil forKey:@"commit"];
+	self.presentationControl = [NSSegmentedControl segmentedControlWithLabels:@[ @"Sequential", @"Combined" ]
+										 trackingMode:NSSegmentSwitchTrackingSelectOne
+											 target:self
+											 action:@selector(presentationChanged:)];
+	self.presentationControl.controlSize = NSControlSizeSmall;
+	self.presentationControl.accessibilityIdentifier = @"MultiCommitDiffPresentation";
+	self.presentationControl.selectedSegment = [[NSUserDefaults standardUserDefaults] integerForKey:PBMultiCommitDiffPresentationKey];
+	NSView *accessory = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 100, 32)];
+	accessory.translatesAutoresizingMaskIntoConstraints = NO;
+	self.presentationControl.translatesAutoresizingMaskIntoConstraints = NO;
+	[accessory addSubview:self.presentationControl];
+	[NSLayoutConstraint activateConstraints:@[
+		[accessory.heightAnchor constraintEqualToConstant:32],
+		[self.presentationControl.centerXAnchor constraintEqualToAnchor:accessory.centerXAnchor],
+		[self.presentationControl.centerYAnchor constraintEqualToAnchor:accessory.centerYAnchor],
+	]];
+	[self.nativeView setAccessoryView:accessory];
+	accessory.hidden = YES;
 
-	[super closeView];
+	[historyController addObserver:self keyPath:@"webCommits" options:0 block:^(MAKVONotification *notification) {
+		[notification.observer changeContentTo:((PBGitHistoryController *)notification.target).webCommits];
+	}];
 }
 
 - (void)didLoad
 {
-	currentOID = nil;
 	[self changeContentTo:historyController.webCommits];
+}
+
+- (NSArray<PBGitCommit *> *)oldestFirst:(NSArray<PBGitCommit *> *)commits
+{
+	// NSArrayController supplies selected commits in visible (newest-first Git
+	// graph) order. Reversing preserves topology even when authored dates lie.
+	return commits.reverseObjectEnumerator.allObjects;
+}
+
+- (NSString *)diffForCommit:(PBGitCommit *)commit
+{
+	NSString *base = commit.parents.firstObject.SHA ?: PBEmptyTreeSHA;
+	NSError *error = nil;
+	return [historyController.repository outputOfTaskWithArguments:@[ @"diff", @"--find-renames", @"--no-ext-diff", base, commit.SHA ] error:&error] ?: @"";
+}
+
+- (BOOL)commitsShareAncestryPath:(NSArray<PBGitCommit *> *)commits
+{
+	for (NSUInteger index = 1; index < commits.count; index++) {
+		NSError *error = nil;
+		NSString *lineage = [historyController.repository outputOfTaskWithArguments:@[ @"rev-list", @"--first-parent", commits[index].SHA ] error:&error];
+		if (!lineage) return NO;
+		NSSet<NSString *> *firstParents = [NSSet setWithArray:[lineage componentsSeparatedByCharactersInSet:NSCharacterSet.newlineCharacterSet]];
+		if (![firstParents containsObject:commits[index - 1].SHA]) return NO;
+	}
+	return YES;
+}
+
+- (NSArray<NSDictionary *> *)sequentialSectionsForCommits:(NSArray<PBGitCommit *> *)commits
+{
+	NSMutableArray *sections = [NSMutableArray array];
+	for (PBGitCommit *commit in commits) {
+		NSString *shortSHA = commit.shortName ?: @"";
+		NSString *title = [NSString stringWithFormat:@"%@  %@\n%@ — %@", shortSHA, commit.subject ?: @"", commit.author ?: @"", commit.authorDate ?: @""];
+		[sections addObject:@{
+			PBNativeSectionTitleKey : title,
+			PBNativeSectionTextKey : [self diffForCommit:commit],
+			PBNativeSectionContextKey : @"readOnly",
+		}];
+	}
+	return sections;
+}
+
+- (NSArray<NSDictionary *> *)combinedSectionsForCommits:(NSArray<PBGitCommit *> *)commits
+{
+	PBGitCommit *oldest = commits.firstObject;
+	PBGitCommit *newest = commits.lastObject;
+	NSString *base = oldest.parents.firstObject.SHA ?: PBEmptyTreeSHA;
+	NSError *error = nil;
+	NSString *combined = [historyController.repository outputOfTaskWithArguments:@[ @"diff", @"--find-renames", @"--no-ext-diff", base, newest.SHA ] error:&error] ?: @"";
+	return @[@{
+		PBNativeSectionTitleKey : [NSString stringWithFormat:@"Combined Diff — %@ through %@", oldest.shortName, newest.shortName],
+		PBNativeSectionTextKey : combined,
+		PBNativeSectionContextKey : @"readOnly",
+	}];
+}
+
+- (NSString *)syntheticUntrackedDiffForFile:(PBChangedFile *)file
+{
+	NSString *contents = [historyController.repository.index diffForFile:file staged:NO contextLines:3] ?: @"";
+	NSMutableArray<NSString *> *lines = [[contents componentsSeparatedByString:@"\n"] mutableCopy];
+	BOOL endsWithNewline = [contents hasSuffix:@"\n"];
+	if (endsWithNewline && [lines.lastObject length] == 0) [lines removeLastObject];
+	if (lines.count == 0 || (lines.count == 1 && [lines.firstObject length] == 0)) return @"";
+	NSMutableString *added = [NSMutableString string];
+	for (NSString *line in lines) [added appendFormat:@"+%@\n", line];
+	if (!endsWithNewline) [added appendString:@"\\ No newline at end of file\n"];
+	return [NSString stringWithFormat:@"diff --git a/%@ b/%@\nnew file mode 100644\n--- /dev/null\n+++ b/%@\n@@ -0,0 +1,%lu @@\n%@", file.path, file.path, file.path, (unsigned long)lines.count, added];
+}
+
+- (NSArray<NSDictionary *> *)workingStateSections
+{
+	NSError *error = nil;
+	NSString *staged = [historyController.repository outputOfTaskWithArguments:@[ @"diff", @"--cached", @"--find-renames", @"--no-ext-diff" ] error:&error] ?: @"";
+	NSMutableString *unstaged = [[historyController.repository outputOfTaskWithArguments:@[ @"diff", @"--find-renames", @"--no-ext-diff" ] error:&error] ?: @"" mutableCopy];
+	for (PBChangedFile *file in historyController.repository.index.indexChanges) {
+		if (file.status == NEW && file.hasUnstagedChanges) [unstaged appendString:[self syntheticUntrackedDiffForFile:file]];
+	}
+	return @[
+		@{ PBNativeSectionTitleKey : @"Staged Changes", PBNativeSectionTextKey : staged, PBNativeSectionContextKey : @"readOnly" },
+		@{ PBNativeSectionTitleKey : @"Unstaged Changes", PBNativeSectionTextKey : unstaged, PBNativeSectionContextKey : @"readOnly" },
+	];
 }
 
 - (void)changeContentTo:(NSArray<PBGitCommit *> *)commits
 {
-	if (commits == nil || commits.count == 0 || !finishedLoading) {
+	self.displayedCommits = commits ?: @[];
+	self.presentationControl.superview.hidden = commits.count <= 1;
+	if (commits.count == 0) {
+		[self.nativeView showMessage:@"No commit selected"];
+		return;
+	}
+	if ([commits.firstObject isKindOfClass:PBUncommittedChanges.class]) {
+		self.renderedCommits = @[];
+		self.presentationControl.superview.hidden = YES;
+		NSArray *sections = [self workingStateSections];
+		self->diff = [[sections valueForKey:PBNativeSectionTextKey] componentsJoinedByString:@"\n"];
+		[self.nativeView showDiffSections:sections];
 		return;
 	}
 
-	if (commits.count == 1) {
-		[self changeContentToCommit:commits.firstObject];
+	NSArray<PBGitCommit *> *ordered = [self oldestFirst:commits];
+	BOOL combinedEnabled = commits.count > 1 && [self commitsShareAncestryPath:ordered];
+	[self.presentationControl setEnabled:combinedEnabled forSegment:PBMultiCommitDiffPresentationCombined];
+	PBMultiCommitDiffPresentation mode = self.presentationControl.selectedSegment;
+	if (mode == PBMultiCommitDiffPresentationCombined && !combinedEnabled) {
+		mode = PBMultiCommitDiffPresentationSequential;
+		self.presentationControl.selectedSegment = mode;
+		self.presentationControl.toolTip = NSLocalizedString(@"Combined Diff requires commits on one ancestry path.", @"Explanation shown when selected commits cannot produce one combined diff");
 	} else {
-		[self changeContentToMultipleSelectionMessage];
+		self.presentationControl.toolTip = nil;
 	}
+	NSArray *sections = mode == PBMultiCommitDiffPresentationCombined ? [self combinedSectionsForCommits:ordered] : [self sequentialSectionsForCommits:ordered];
+	self.renderedCommits = mode == PBMultiCommitDiffPresentationCombined ? @[ ordered.lastObject ] : ordered;
+	self->diff = [[sections valueForKey:PBNativeSectionTextKey] componentsJoinedByString:@"\n"];
+	[self.nativeView showDiffSections:sections];
 }
 
-- (void)changeContentToMultipleSelectionMessage
+- (nullable NSData *)dataForGitObject:(NSString *)object
 {
-	NSArray *arguments = @[
-		@[ NSLocalizedString(@"Multiple commits are selected.", @"Multiple selection Message: Title"),
-		   NSLocalizedString(@"Use the Copy command to copy their information.", @"Multiple selection Message: Copy Command"),
-		   NSLocalizedString(@"Or select a single commit to see its diff.", @"Multiple selection Message: Diff Hint") ]
-	];
-	[[self script] callWebScriptMethod:@"showMultipleSelectionMessage" withArguments:arguments];
+	PBTask *task = [historyController.repository taskWithArguments:@[ @"show", object ]];
+	if (![task launchTask:nil]) return nil;
+	return task.standardOutputData;
 }
 
-static NSString *deltaTypeName(GTDeltaType t)
+- (NSImage *)nativeContentView:(PBNativeContentView *)view imageForPath:(NSString *)path section:(NSUInteger)sectionIndex
 {
-	switch (t) {
-		case GTDeltaTypeUnmodified:
-			return @"unmodified";
-		case GTDeltaTypeAdded:
-			return @"added";
-		case GTDeltaTypeDeleted:
-			return @"removed";
-		case GTDeltaTypeModified:
-			return @"modified";
-		case GTDeltaTypeRenamed:
-			return @"renamed";
-		case GTDeltaTypeCopied:
-			return @"copied";
-		case GTDeltaTypeIgnored:
-			return @"ignored";
-		case GTDeltaTypeUntracked:
-			return @"untracked";
-		case GTDeltaTypeTypeChange:
-			return @"type changed";
-		case GTDeltaTypeUnreadable:
-			return @"unreadable";
-		case GTDeltaTypeConflicted:
-			return @"conflicted";
+	NSData *data = nil;
+	if (sectionIndex < self.renderedCommits.count) {
+		PBGitCommit *commit = self.renderedCommits[sectionIndex];
+		data = [self dataForGitObject:[NSString stringWithFormat:@"%@:%@", commit.SHA, path]];
+		if (!data.length && commit.parents.firstObject) data = [self dataForGitObject:[NSString stringWithFormat:@"%@:%@", commit.parents.firstObject.SHA, path]];
+	} else {
+		data = [NSData dataWithContentsOfURL:[historyController.repository.workingDirectoryURL URLByAppendingPathComponent:path]];
+		if (!data.length) data = [self dataForGitObject:[@":" stringByAppendingString:path]];
 	}
+	return data.length ? [[NSImage alloc] initWithData:data] : nil;
 }
 
-static NSDictionary *loadCommitSummary(GTRepository *repo, GTCommit *commit, BOOL (^isCanceled)(void));
-
-// A GTDiffDelta's GTDiffFile does not always set the file size. See `git_diff_get_delta`.
-static NSUInteger reallyGetFileSize(GTRepository *repo, GTDiffFile *file)
+- (void)presentationChanged:(NSSegmentedControl *)sender
 {
-	GTObjectDatabase *odb = [repo objectDatabaseWithError:nil];
-	if (!odb) return 0;
-	size_t size = 0;
-	git_otype otype;
-	if (git_odb_read_header(&size, &otype, odb.git_odb, file.OID.git_oid) != 0) {
-		return 0;
-	}
-	return size;
+	[[NSUserDefaults standardUserDefaults] setInteger:sender.selectedSegment forKey:PBMultiCommitDiffPresentationKey];
+	[self changeContentTo:self.displayedCommits];
 }
 
-- (void)changeContentToCommit:(PBGitCommit *)commit
-{
-	// The sha is the same, but refs may have changed. reload it lazy
-	if ([currentOID isEqual:commit.OID]) {
-		[[self script] callWebScriptMethod:@"reload" withArguments:nil];
-		return;
-	}
-
-	NSArray *arguments = @[ commit, [[[historyController repository] headRef] simpleRef] ];
-	id scriptResult = [[self script] callWebScriptMethod:@"loadCommit" withArguments:arguments];
-	if (!scriptResult) {
-		// the web view is not really ready for scripting???
-		[self performSelector:_cmd withObject:commit afterDelay:0.05];
-		return;
-	}
-	currentOID = commit.OID;
-
-	unsigned long gen = atomic_fetch_add(&_commitSummaryGeneration, 1) + 1;
-
-	// Open a new repo instance for the background queue
-	NSError *err = nil;
-	GTRepository *repo =
-		[GTRepository repositoryWithURL:[repository gtRepo].gitDirectoryURL
-								  error:&err];
-	if (!repo) {
-		NSLog(@"Failed to open repository: %@", err);
-		return;
-	}
-	GTCommit *queueCommit = [repo lookUpObjectByOID:commit.OID error:&err];
-	if (!queueCommit) {
-		NSLog(@"Failed to find commit: %@", err);
-		return;
-	}
-
-	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-		NSDictionary *summary = loadCommitSummary(repo, queueCommit, ^BOOL {
-			return gen != atomic_load(&self->_commitSummaryGeneration);
-		});
-		if (!summary) return;
-		NSError *err = nil;
-		NSString *summaryJSON =
-			[[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:summary
-																		   options:0
-																			 error:&err]
-								  encoding:NSUTF8StringEncoding];
-		if (!summaryJSON) {
-			NSLog(@"Commit summary JSON error: %@", err);
-			return;
-		}
-		dispatch_async(dispatch_get_main_queue(), ^{
-			[self commitSummaryLoaded:summaryJSON forOID:commit.OID];
-		});
-	});
-}
-
-static NSDictionary *loadCommitSummary(GTRepository *repo, GTCommit *commit, BOOL (^isCanceled)(void))
-{
-	if (isCanceled()) return nil;
-	GTDiffOptionsFlags diffFlags = GTDiffOptionsFlagsNormal;
-	GTDiffFindOptionsFlags findFlags = GTDiffFindOptionsFlagsFindRenames;
-	if (![PBGitDefaults showWhitespaceDifferences]) {
-		diffFlags |= GTDiffOptionsFlagsIgnoreWhitespace;
-		findFlags |= GTDiffFindOptionsFlagsIgnoreWhitespace;
-	}
-	NSError *err = nil;
-	GTDiff *d = [GTDiff diffOldTree:commit.parents.firstObject.tree
-						withNewTree:commit.tree
-					   inRepository:repo
-							options:@{GTDiffOptionsFlagsKey : @(diffFlags)}
-							  error:&err];
-
-	if (!d) {
-		NSLog(@"Commit summary diff error: %@", err);
-		return nil;
-	}
-
-	// Rewrite the diff to display moved files.
-	[d findSimilarWithOptions:
-	 @{GTDiffFindOptionsFlagsKey : @(findFlags),
-	   GTDiffFindOptionsRenameLimitKey : @(2000)
-	 }];
-
-	if (isCanceled()) return nil;
-	NSMutableArray<NSDictionary<NSString *, NSObject *> *> *fileDeltas = [NSMutableArray array];
-	NSMutableString *fullDiff = [NSMutableString string];
-	[d enumerateDeltasUsingBlock:^(GTDiffDelta *_Nonnull delta, BOOL *_Nonnull stop) {
-		if (isCanceled()) {
-			*stop = YES;
-			return;
-		}
-		NSUInteger numLinesAdded = 0;
-		NSUInteger numLinesRemoved = 0;
-		NSError *err = nil;
-		GTDiffPatch *patch = [delta generatePatch:&err];
-		if (isCanceled()) {
-			*stop = YES;
-			return;
-		}
-		if (patch) {
-			numLinesAdded = patch.addedLinesCount;
-			numLinesRemoved = patch.deletedLinesCount;
-			NSData *patchData = patch.patchData;
-			if (patchData) {
-				NSString *patchString =
-					[[NSString alloc] initWithData:patchData
-										  encoding:NSUTF8StringEncoding];
-				if (!patchString) {
-					patchString =
-						[[NSString alloc] initWithData:patchData
-											  encoding:NSISOLatin1StringEncoding];
-				}
-				if (patchString) {
-					[fullDiff appendString:patchString];
-				}
-			}
-			// Use the patch's delta as it may have loaded more file sizes.
-			delta = patch.delta;
-		} else {
-			NSLog(@"generatePatch error: %@", err);
-		}
-		GTDiffFile *oldFile = delta.oldFile;
-		GTDiffFile *newFile = delta.newFile;
-		NSUInteger oldFileSize = oldFile.size;
-		NSUInteger newFileSize = newFile.size;
-		if (oldFileSize == 0 && (oldFile.flags & GIT_DIFF_FLAG_EXISTS)) {
-			oldFileSize = reallyGetFileSize(repo, newFile);
-		}
-		if (newFileSize == 0 && (newFile.flags & GIT_DIFF_FLAG_EXISTS)) {
-			newFileSize = reallyGetFileSize(repo, newFile);
-		}
-		[fileDeltas addObject:@{
-			@"filename" : newFile.path,
-			@"oldFilename" : oldFile.path,
-			@"newFilename" : newFile.path,
-			@"changeType" : deltaTypeName(delta.type),
-			@"oldFileSize" : @(oldFileSize),
-			@"newFileSize" : @(newFileSize),
-			@"numLinesAdded" : @(numLinesAdded),
-			@"numLinesRemoved" : @(numLinesRemoved),
-			@"binary" : [NSNumber numberWithBool:(delta.flags & GTDiffFileFlagBinary) != 0],
-		}];
-	}];
-	if (isCanceled()) return nil;
-	return @{
-		@"filesInfo" : fileDeltas,
-		@"fullDiff" : fullDiff,
-	};
-}
-
-- (void)commitSummaryLoaded:(NSString *)summaryJSON forOID:(GTOID *)summaryOID
-{
-	if (![currentOID isEqual:summaryOID]) {
-		// a different summary finished loading late
-		return;
-	}
-
-	[self.view.windowScriptObject callWebScriptMethod:@"loadCommitDiff" withArguments:@[ summaryJSON ]];
-}
-
-- (void)selectCommit:(NSString *)sha
+- (void)nativeContentView:(PBNativeContentView *)view selectCommit:(NSString *)sha
 {
 	[historyController selectCommit:[GTOID oidWithSHA:sha]];
 }
 
 - (void)sendKey:(NSString *)key
 {
-	id script = self.view.windowScriptObject;
-	[script callWebScriptMethod:@"handleKeyFromCocoa" withArguments:[NSArray arrayWithObject:key]];
+	if ([key isEqualToString:@"j"]) [self.nativeView.textView scrollLineDown:self];
+	else if ([key isEqualToString:@"k"]) [self.nativeView.textView scrollLineUp:self];
 }
 
-- (void)copySource
-{
-	NSString *source = [(DOMHTMLElement *)self.view.mainFrame.DOMDocument.documentElement outerHTML];
-	NSPasteboard *a = [NSPasteboard generalPasteboard];
-	[a declareTypes:[NSArray arrayWithObject:NSPasteboardTypeString] owner:self];
-	[a setString:source forType:NSPasteboardTypeString];
-}
-
-- (NSArray *)webView:(WebView *)sender
-	contextMenuItemsForElement:(NSDictionary *)element
-			  defaultMenuItems:(NSArray *)defaultMenuItems
-{
-	DOMNode *node = [element valueForKey:@"WebElementDOMNode"];
-
-	while (node) {
-		// Every ref has a class name of 'refs' and some other class. We check on that to see if we pressed on a ref.
-		if ([[node className] hasPrefix:@"refs "]) {
-			NSString *selectedRefString = [[[node childNodes] item:0] textContent];
-			for (PBGitRef *ref in historyController.webCommits.firstObject.refs) {
-				if ([[ref shortName] isEqualToString:selectedRefString])
-					return [historyController menuItemsForRef:ref];
-			}
-			NSLog(@"Could not find selected ref!");
-			return defaultMenuItems;
-		}
-		if ([node hasAttributes] && [[node attributes] getNamedItem:@"representedFile"])
-			return [historyController menuItemsForPaths:[NSArray arrayWithObject:[[[node attributes] getNamedItem:@"representedFile"] nodeValue]]];
-		else if ([[node class] isEqual:[DOMHTMLImageElement class]]) {
-			// Copy Image is the only menu item that makes sense here since we don't need
-			// to download the image or open it in a new window (besides with the
-			// current implementation these two entries can crash GitX anyway)
-			for (NSMenuItem *item in defaultMenuItems)
-				if ([item tag] == WebMenuItemTagCopyImageToClipboard)
-					return [NSArray arrayWithObject:item];
-			return nil;
-		}
-
-		node = [node parentNode];
-	}
-
-	return defaultMenuItems;
-}
-
-
-// Open external links in the default browser
-- (void)webView:(WebView *)sender decidePolicyForNewWindowAction:(NSDictionary *)actionInformation
-						   request:(NSURLRequest *)request
-					  newFrameName:(NSString *)frameName
-				  decisionListener:(id<WebPolicyDecisionListener>)listener
-{
-	[[NSWorkspace sharedWorkspace] openURL:[request URL]];
-}
-
-- getConfig:(NSString *)key
-{
-	NSError *error = nil;
-	GTConfiguration *config = [historyController.repository.gtRepo configurationWithError:&error];
-	return [config stringForKey:key];
-}
-
-
-- (void)preferencesChanged
-{
-	[[self script] callWebScriptMethod:@"enableFeatures" withArguments:nil];
-}
+- (void)scrollPageUp { [self.nativeView scrollPageUp]; }
+- (void)scrollPageDown { [self.nativeView scrollPageDown]; }
+- (void)preferencesChanged { [self changeContentTo:self.displayedCommits]; }
 
 @end

--- a/Classes/GitX-Bridging-Header.h
+++ b/Classes/GitX-Bridging-Header.h
@@ -35,3 +35,4 @@
 #import "PBGitHistoryController.h"
 #import "PBGitCommit.h"
 #import "PBGitRef.h"
+#import "PBHighlighting.h"

--- a/Classes/NSAppearance+PBDarkMode.m
+++ b/Classes/NSAppearance+PBDarkMode.m
@@ -2,23 +2,64 @@
 //  NSAppearance+PBDarkMode.m
 //  GitX
 //
-//  Only the global constant definition remains here — the category
-//  implementations have been moved to NSAppearance+PBDarkMode.swift.
-//
 
 #import "NSAppearance+PBDarkMode.h"
 #import <objc/runtime.h>
 
-// This definition satisfies the `extern NSString *const` declaration in the
-// header for all Objective-C callers.  The Swift side imports the same value
-// as a plain Swift String via the bridging header.
 NSString *const PBEffectiveAppearanceChanged = @"PBEffectiveAppearanceChanged";
+
+static void *PBAppearanceObservationContext = &PBAppearanceObservationContext;
+
+@interface PBAppearanceObserver : NSObject
+
+@property (nonatomic, weak) NSApplication *application;
+@property (nonatomic, strong) id notificationObject;
+
+- (instancetype)initWithApplication:(NSApplication *)application notificationObject:(id)notificationObject;
+
+@end
+
+@implementation PBAppearanceObserver
+
+- (instancetype)initWithApplication:(NSApplication *)application notificationObject:(id)notificationObject
+{
+	self = [super init];
+	if (self) {
+		_application = application;
+		_notificationObject = notificationObject;
+		[application addObserver:self
+					  forKeyPath:@"effectiveAppearance"
+						 options:NSKeyValueObservingOptionNew
+						 context:PBAppearanceObservationContext];
+	}
+	return self;
+}
+
+- (void)dealloc
+{
+	[_application removeObserver:self forKeyPath:@"effectiveAppearance" context:PBAppearanceObservationContext];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+					  ofObject:(id)object
+						change:(NSDictionary *)change
+					   context:(void *)context
+{
+	if (context == PBAppearanceObservationContext) {
+		[[NSNotificationCenter defaultCenter] postNotificationName:PBEffectiveAppearanceChanged
+															object:self.notificationObject];
+	} else {
+		[super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+	}
+}
+
+@end
 
 @implementation NSAppearance (PBDarkMode)
 
 - (BOOL)isDarkMode
 {
-	NSAppearanceName bestMatch = [self bestMatchFromAppearancesWithNames:@[NSAppearanceNameDarkAqua, NSAppearanceNameAqua]];
+	NSAppearanceName bestMatch = [self bestMatchFromAppearancesWithNames:@[ NSAppearanceNameDarkAqua, NSAppearanceNameAqua ]];
 	return [bestMatch isEqualToString:NSAppearanceNameDarkAqua];
 }
 
@@ -31,33 +72,16 @@ NSString *const PBEffectiveAppearanceChanged = @"PBEffectiveAppearanceChanged";
 	return self.effectiveAppearance.isDarkMode;
 }
 
-static char kAppearanceObservationKey;
+static char kAppearanceObserverAssociationKey;
 
 - (void)registerObserverForAppearanceChanges:(id)observer
 {
-	// Use traditional KVO addObserver method
-	[self addObserver:self
-		   forKeyPath:@"effectiveAppearance"
-			  options:NSKeyValueObservingOptionNew
-			  context:&kAppearanceObservationKey];
-
-	// Store the observer reference
-	objc_setAssociatedObject(self, &kAppearanceObservationKey, observer, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-- (void)observeValueForKeyPath:(NSString *)keyPath
-					  ofObject:(id)object
-						change:(NSDictionary *)change
-					   context:(void *)context
-{
-	if (context == &kAppearanceObservationKey) {
-		id observer = objc_getAssociatedObject(self, &kAppearanceObservationKey);
-		[[NSNotificationCenter defaultCenter] postNotificationName:PBEffectiveAppearanceChanged
-															object:observer];
-	} else {
-		[super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
-	}
+	PBAppearanceObserver *appearanceObserver = [[PBAppearanceObserver alloc] initWithApplication:self
+																			  notificationObject:observer];
+	objc_setAssociatedObject(self,
+							 &kAppearanceObserverAssociationKey,
+							 appearanceObserver,
+							 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 @end
-

--- a/Classes/PBCommitList.h
+++ b/Classes/PBCommitList.h
@@ -7,14 +7,13 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#import <WebKit/WebView.h>
 
 @class PBGitHistoryController;
 @class PBWebHistoryController;
 @class PBHistorySearchController;
 
 @interface PBCommitList : NSTableView {
-	__weak IBOutlet WebView *webView;
+	__weak IBOutlet NSView *webView;
 	__weak IBOutlet PBWebHistoryController *webController;
 	__weak IBOutlet PBGitHistoryController *controller;
 	__weak IBOutlet PBHistorySearchController *searchController;

--- a/Classes/PBCommitList.swift
+++ b/Classes/PBCommitList.swift
@@ -8,7 +8,6 @@
 import Cocoa
 
 @objc class PBCommitList: NSTableView {
-
     // MARK: - Properties
 
     @IBOutlet weak var webView: NSView!
@@ -28,7 +27,8 @@ import Cocoa
     // MARK: - Drag and Drop
 
     override func draggingSession(_ session: NSDraggingSession,
-                                   sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
+                                  sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation
+    {
         return .copy
     }
 
@@ -36,46 +36,46 @@ import Cocoa
     // This custom drag image implementation may need to be reimplemented using modern APIs
     // For now, using the default implementation
     /*
-    override func dragImageForRowsWithIndexes(_ dragRows: NSIndexSet,
-                                              tableColumns: [NSTableColumn],
-                                              event dragEvent: NSEvent,
-                                              offset dragImageOffset: NSPointPointer) -> NSImage {
-        let location = mouseDownPoint
-        let row = self.row(at: location)
-        let column = self.column(at: location)
+     override func dragImageForRowsWithIndexes(_ dragRows: NSIndexSet,
+                                               tableColumns: [NSTableColumn],
+                                               event dragEvent: NSEvent,
+                                               offset dragImageOffset: NSPointPointer) -> NSImage {
+         let location = mouseDownPoint
+         let row = self.row(at: location)
+         let column = self.column(at: location)
 
-        guard let cell = view(atColumn: column, row: row, makeIfNecessary: false) as? PBGitRevisionCell else {
-            return super.dragImageForRowsWithIndexes(dragRows,
-                                                     tableColumns: tableColumns,
-                                                     event: dragEvent,
-                                                     offset: dragImageOffset)
-        }
+         guard let cell = view(atColumn: column, row: row, makeIfNecessary: false) as? PBGitRevisionCell else {
+             return super.dragImageForRowsWithIndexes(dragRows,
+                                                      tableColumns: tableColumns,
+                                                      event: dragEvent,
+                                                      offset: dragImageOffset)
+         }
 
-        let cellFrame = frameOfCell(atColumn: column, row: row)
-        let index = cell.responds(to: #selector(PBGitRevisionCell.index(atX:)))
-            ? cell.index(atX: location.x - cellFrame.origin.x)
-            : -1
+         let cellFrame = frameOfCell(atColumn: column, row: row)
+         let index = cell.responds(to: #selector(PBGitRevisionCell.index(atX:)))
+             ? cell.index(atX: location.x - cellFrame.origin.x)
+             : -1
 
-        if index == -1 {
-            return super.dragImageForRowsWithIndexes(dragRows,
-                                                     tableColumns: tableColumns,
-                                                     event: dragEvent,
-                                                     offset: dragImageOffset)
-        }
+         if index == -1 {
+             return super.dragImageForRowsWithIndexes(dragRows,
+                                                      tableColumns: tableColumns,
+                                                      event: dragEvent,
+                                                      offset: dragImageOffset)
+         }
 
-        var rect = cell.rectAtIndex(index)
-        let newImage = NSImage(size: NSSize(width: rect.size.width + 3,
-                                            height: rect.size.height + 3))
-        rect.origin = NSPoint(x: 0.5, y: 0.5)
+         var rect = cell.rectAtIndex(index)
+         let newImage = NSImage(size: NSSize(width: rect.size.width + 3,
+                                             height: rect.size.height + 3))
+         rect.origin = NSPoint(x: 0.5, y: 0.5)
 
-        newImage.lockFocus()
-        cell.drawLabelAtIndex(index, inRect: rect)
-        newImage.unlockFocus()
+         newImage.lockFocus()
+         cell.drawLabelAtIndex(index, inRect: rect)
+         newImage.unlockFocus()
 
-        dragImageOffset.pointee = NSPoint(x: rect.size.width / 2 + 10, y: 0)
-        return newImage
-    }
-    */
+         dragImageOffset.pointee = NSPoint(x: rect.size.width / 2 + 10, y: 0)
+         return newImage
+     }
+     */
 
     // MARK: - Keyboard Handling
 
@@ -89,7 +89,8 @@ import Cocoa
 
         // Pass on command-shift up/down to the responder. We want the splitview to capture this.
         if modifiers.contains(.shift) && modifiers.contains(.command) &&
-           (event.keyCode == 0x7E || event.keyCode == 0x7D) {
+            (event.keyCode == 0x7E || event.keyCode == 0x7D)
+        {
             nextResponder?.keyDown(with: event)
             return
         }
@@ -105,10 +106,12 @@ import Cocoa
                 controller.toggleQLPreviewPanel(self)
             }
         } else if let range = character.rangeOfCharacter(from: CharacterSet(charactersIn: "jkcv")),
-                  range.lowerBound == character.startIndex {
+                  range.lowerBound == character.startIndex
+        {
             webController.sendKey(character)
         } else if let firstChar = character.utf16.first,
-                  firstChar == NSDownArrowFunctionKey && modifiers.contains(.control) {
+                  firstChar == NSDownArrowFunctionKey && modifiers.contains(.control)
+        {
             controller.selectParentCommit(self)
         } else {
             super.keyDown(with: event)
@@ -135,14 +138,14 @@ import Cocoa
 
         if sr.origin.y > proposedVisibleRect.origin.y {
             newRect = NSRect(x: newRect.origin.x,
-                           y: newRect.origin.y + CGFloat(adj),
-                           width: newRect.size.width,
-                           height: newRect.size.height)
+                             y: newRect.origin.y + CGFloat(adj),
+                             width: newRect.size.width,
+                             height: newRect.size.height)
         } else if sr.origin.y < proposedVisibleRect.origin.y {
             newRect = NSRect(x: newRect.origin.x,
-                           y: newRect.origin.y - CGFloat(ny),
-                           width: newRect.size.width,
-                           height: newRect.size.height)
+                             y: newRect.origin.y - CGFloat(ny),
+                             width: newRect.size.width,
+                             height: newRect.size.height)
         }
 
         return newRect
@@ -163,21 +166,22 @@ import Cocoa
 
         let column = self.column(withIdentifier: NSUserInterfaceItemIdentifier("SubjectColumn"))
         guard column != -1,
-              let cell = view(atColumn: column, row: index, makeIfNecessary: false) as? PBGitRevisionCell,
-              let commit = cell.objectValue as? PBGitCommit else {
+              let cell = view(atColumn: column, row: index, makeIfNecessary: false) as? PBGitRevisionCell
+        else {
             return nil
         }
-		// The Working State row is a navigation surface, not an immutable
-		// commit, so commit/ref actions do not apply to it.
-		if commit.sha.isEmpty {
-			return nil
-		}
+        let commit = cell.objectValue
+        // The Working State row is a navigation surface, not an immutable
+        // commit, so commit/ref actions do not apply to it.
+        if commit.sha.isEmpty {
+            return nil
+        }
 
         let point = window?.contentView?.convert(event.locationInWindow, to: cell) ?? .zero
         let i = Int(cell.indexAt(x: point.x))
         let clickedRef: PBGitRef? = (i >= 0 && i < commit.refs.count) ? commit.refs[i] as? PBGitRef : nil
 
-        let selectedCommits = controller.selectedCommits as? [PBGitCommit] ?? []
+        let selectedCommits = controller.selectedCommits
         let items: [NSMenuItem]
 
         if let clickedRef = clickedRef {
@@ -197,9 +201,3 @@ import Cocoa
         return menu
     }
 }
-
-
-
-
-
-

--- a/Classes/PBCommitList.swift
+++ b/Classes/PBCommitList.swift
@@ -6,13 +6,12 @@
 //
 
 import Cocoa
-import WebKit
 
 @objc class PBCommitList: NSTableView {
 
     // MARK: - Properties
 
-    @IBOutlet weak var webView: WebView!
+    @IBOutlet weak var webView: NSView!
     @IBOutlet weak var webController: PBWebHistoryController!
     @IBOutlet weak var controller: PBGitHistoryController!
     @IBOutlet weak var searchController: PBHistorySearchController!
@@ -24,7 +23,6 @@ import WebKit
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        webView.drawsBackground = false
     }
 
     // MARK: - Drag and Drop
@@ -99,9 +97,9 @@ import WebKit
         if character == " " {
             if controller.selectedCommitDetailsIndex == 0 {
                 if modifiers.contains(.shift) {
-                    webView.scrollPageUp(self)
+                    webController.scrollPageUp()
                 } else {
-                    webView.scrollPageDown(self)
+                    webController.scrollPageDown()
                 }
             } else {
                 controller.toggleQLPreviewPanel(self)
@@ -169,6 +167,11 @@ import WebKit
               let commit = cell.objectValue as? PBGitCommit else {
             return nil
         }
+		// The Working State row is a navigation surface, not an immutable
+		// commit, so commit/ref actions do not apply to it.
+		if commit.sha.isEmpty {
+			return nil
+		}
 
         let point = window?.contentView?.convert(event.locationInWindow, to: cell) ?? .zero
         let i = Int(cell.indexAt(x: point.x))
@@ -194,8 +197,6 @@ import WebKit
         return menu
     }
 }
-
-
 
 
 

--- a/Classes/PBUnsortableTableHeader.m
+++ b/Classes/PBUnsortableTableHeader.m
@@ -7,12 +7,18 @@
 //
 
 #import "PBUnsortableTableHeader.h"
+#import "PBGitDefaults.h"
 
 
 @implementation PBUnsortableTableHeader
 
 - (void)mouseDown:(NSEvent *)theEvent
 {
+	if (![PBGitDefaults historyColumnSortingEnabled]) {
+		controller.sortDescriptors = @[];
+		[controller rearrangeObjects];
+		return;
+	}
 	NSPoint location = [self convertPoint:[[self window] mouseLocationOutsideOfEventStream] fromView:[[self window] contentView]];
 	NSInteger aColumnIndex = [self columnAtPoint:location];
 

--- a/Classes/Util/PBTask.h
+++ b/Classes/Util/PBTask.h
@@ -64,6 +64,8 @@ typedef NS_ENUM(NSUInteger, PBTaskErrorCode) {
 
 /// The standard output of the command
 @property (readonly, retain) NSData *standardOutputData;
+/// Maximum synchronous execution time in seconds. Defaults to 30; values at or below zero disable the timeout.
+@property NSTimeInterval timeout;
 /// Set this if you want to pass data to the command on its standard input
 @property (retain) NSData *standardInputData;
 @property (retain) NSDictionary *additionalEnvironment;

--- a/Classes/Util/PBTask.m
+++ b/Classes/Util/PBTask.m
@@ -99,6 +99,15 @@ const BOOL PBTaskDebugEnable = NO;
 {
 	NSParameterAssert(terminationHandler != nil);
 
+	// additionalEnvironment is intentionally mutable until launch time. A
+	// number of callers configure a task after creating it, so folding these
+	// values into NSTask's environment in the initializer is too early.
+	if (self.additionalEnvironment.count) {
+		NSMutableDictionary *environment = [self.task.environment mutableCopy] ?: [NSMutableDictionary dictionary];
+		[environment addEntriesFromDictionary:self.additionalEnvironment];
+		self.task.environment = environment;
+	}
+
 	__weak PBTask *weakSelf = self;
 	self.task.terminationHandler = ^(NSTask *task) {
 		NSError *error = nil;

--- a/Classes/Util/PBTask.m
+++ b/Classes/Util/PBTask.m
@@ -24,6 +24,7 @@ const BOOL PBTaskDebugEnable = NO;
 
 @property (retain) NSTask *task;
 @property (retain) NSMutableData *standardOutputData;
+@property BOOL cancellationRequested;
 
 @end
 
@@ -40,6 +41,7 @@ const BOOL PBTaskDebugEnable = NO;
 	if (!self) return nil;
 
 	_task = [[NSTask alloc] init];
+	_timeout = 30.0;
 	[_task setLaunchPath:launchPath];
 	[_task setArguments:args];
 
@@ -168,7 +170,19 @@ const BOOL PBTaskDebugEnable = NO;
 
 	@try {
 		PBTaskLog(@"task %p: launching", self);
-		[self.task launch];
+		__block BOOL cancelled = NO;
+		@synchronized(self) {
+			cancelled = self.cancellationRequested;
+			if (!cancelled) [self.task launch];
+		}
+		if (cancelled) {
+			NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain
+												 code:NSUserCancelledError
+											 userInfo:@{NSLocalizedDescriptionKey : @"Task cancelled before launch"}];
+			dispatch_async(queue, ^{
+				terminationHandler(error);
+			});
+		}
 	}
 	@catch (NSException *exception) {
 		NSString *desc = @"Exception raised while launching task";
@@ -219,7 +233,7 @@ const BOOL PBTaskDebugEnable = NO;
 			   dispatch_semaphore_signal(sem);
 		   }];
 
-	dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC);
+	dispatch_time_t timeout = self.timeout <= 0 ? DISPATCH_TIME_FOREVER : dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.timeout * NSEC_PER_SEC));
 	PBTaskLog(@"task %p: waiting for completion", self);
 	if (dispatch_semaphore_wait(sem, timeout) != 0) {
 		// Timeout !
@@ -247,7 +261,10 @@ const BOOL PBTaskDebugEnable = NO;
 
 - (void)terminate
 {
-	[self.task terminate];
+	@synchronized(self) {
+		self.cancellationRequested = YES;
+		if (self.task.running) [self.task terminate];
+	}
 }
 
 - (NSString *)description

--- a/Classes/Views/GLFileView.h
+++ b/Classes/Views/GLFileView.h
@@ -7,25 +7,18 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#import <MGScopeBar/MGScopeBarDelegateProtocol.h>
 
 #import "PBWebController.h"
 
 @class PBGitHistoryController;
 
-@interface GLFileView : PBWebController <MGScopeBarDelegate> {
+@interface GLFileView : PBWebController {
 	__weak IBOutlet PBGitHistoryController *historyController;
-	__weak IBOutlet MGScopeBar *typeBar;
-	NSMutableArray *groups;
+	__weak IBOutlet NSView *typeBar;
 	__weak IBOutlet NSView *accessoryView;
 	__weak IBOutlet NSSplitView *fileListSplitView;
 }
 
 - (void)showFile;
 - (void)didLoad;
-- (NSString *)parseBlame:(NSString *)txt;
-- (NSString *)escapeHTML:(NSString *)txt;
-
-@property NSMutableArray *groups;
-
 @end

--- a/Classes/Views/GLFileView.m
+++ b/Classes/Views/GLFileView.m
@@ -1,163 +1,59 @@
-//
-//  GLFileView.m
-//  GitX
-//
-//  Created by German Laullon on 14/09/10.
-//  Copyright 2010 __MyCompanyName__. All rights reserved.
-//
-
-#import <MGScopeBar/MGScopeBar.h>
-
 #import "GLFileView.h"
+#import "PBNativeContentView.h"
+#import "PBGitGradientBarView.h"
 #import "PBGitTree.h"
+#import "PBWorkingTree.h"
+#import "PBUncommittedChanges.h"
 #import "PBGitCommit.h"
 #import "PBGitHistoryController.h"
+#import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
+#import "PBGitIndex.h"
+#import "PBChangedFile.h"
+#import "PBTask.h"
 
+static NSString *const PBEmptyTreeSHA = @"4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 
-#define GROUP_LABEL @"Label"				  // string
-#define GROUP_SEPARATOR @"HasSeparator"		  // BOOL as NSNumber
-#define GROUP_SELECTION_MODE @"SelectionMode" // MGScopeBarGroupSelectionMode (int) as NSNumber
-#define GROUP_ITEMS @"Items"				  // array of dictionaries, each containing the following keys:
-#define ITEM_IDENTIFIER @"Identifier"		  // string
-#define ITEM_NAME @"Name"					  // string
+typedef NS_ENUM(NSInteger, PBFileMode) {
+	PBFileModeSource = 0,
+	PBFileModeBlame = 1,
+	PBFileModeHistory = 2,
+	PBFileModeDiff = 3,
+};
 
-#define GROUP_ID_FILEVIEW @"fileview"
-#define GROUP_ID_BLAME @"blame"
-#define GROUP_ID_LOG @"log"
-
-@interface GLFileView ()
-
+@interface GLFileView () <PBNativeContentViewDelegate>
+@property (nonatomic) NSSegmentedControl *modeControl;
 - (void)saveSplitViewPosition;
-
 @end
-
 
 @implementation GLFileView
 
 - (void)awakeFromNib
 {
-	startFile = GROUP_ID_FILEVIEW;
-	//repository = historyController.repository;
+	startFile = @"fileview";
 	[super awakeFromNib];
-	[historyController.treeController addObserver:self
-										  keyPath:@"selection"
-										  options:0
-											block:^(MAKVONotification *notification) {
-												[self showFile];
-											}];
+	self.nativeView.delegate = self;
+	[historyController.treeController addObserver:self keyPath:@"selection" options:0 block:^(MAKVONotification *notification) {
+		[notification.observer showFile];
+	}];
 
-	self.groups = [NSMutableArray arrayWithCapacity:0];
-
-	NSArray *items = [NSArray arrayWithObjects:
-								  [NSDictionary dictionaryWithObjectsAndKeys:
-													startFile, ITEM_IDENTIFIER,
-													@"Source", ITEM_NAME,
-													nil],
-								  [NSDictionary dictionaryWithObjectsAndKeys:
-													GROUP_ID_BLAME, ITEM_IDENTIFIER,
-													@"Blame", ITEM_NAME,
-													nil],
-								  [NSDictionary dictionaryWithObjectsAndKeys:
-													GROUP_ID_LOG, ITEM_IDENTIFIER,
-													@"History", ITEM_NAME,
-													nil],
-								  nil];
-	[self.groups addObject:[NSDictionary dictionaryWithObjectsAndKeys:
-											 [NSNumber numberWithBool:NO], GROUP_SEPARATOR,
-											 [NSNumber numberWithInt:MGScopeBarGroupSelectionModeRadio], GROUP_SELECTION_MODE, // single selection group.
-											 items, GROUP_ITEMS,
-											 nil]];
-	[typeBar reloadData];
+	self.modeControl = [NSSegmentedControl segmentedControlWithLabels:@[ @"Source", @"Blame", @"History", @"Diff" ]
+										 trackingMode:NSSegmentSwitchTrackingSelectOne
+											 target:self
+											 action:@selector(modeChanged:)];
+	self.modeControl.selectedSegment = PBFileModeSource;
+	self.modeControl.segmentStyle = NSSegmentStyleAutomatic;
+	self.modeControl.controlSize = NSControlSizeSmall;
+	self.modeControl.translatesAutoresizingMaskIntoConstraints = NO;
+	[typeBar addSubview:self.modeControl];
+	[(PBGitGradientBarView *)typeBar setTopShade:237/255.0f bottomShade:216/255.0f];
+	[NSLayoutConstraint activateConstraints:@[
+		[self.modeControl.centerXAnchor constraintEqualToAnchor:typeBar.centerXAnchor],
+		[self.modeControl.centerYAnchor constraintEqualToAnchor:typeBar.centerYAnchor],
+	]];
 
 	[fileListSplitView setHidden:YES];
 	[self performSelector:@selector(restoreSplitViewPositiion) withObject:nil afterDelay:0];
-}
-
-- (void)showFile
-{
-	NSArray *files = [historyController.treeController selectedObjects];
-	if ([files count] > 0) {
-		PBGitTree *file = [files objectAtIndex:0];
-
-		NSString *fileTxt = @"";
-		if ([startFile isEqualToString:GROUP_ID_FILEVIEW])
-			fileTxt = [self escapeHTML:[file textContents]];
-		else if ([startFile isEqualToString:GROUP_ID_BLAME])
-			fileTxt = [self parseBlame:[file blame]];
-		else if ([startFile isEqualToString:GROUP_ID_LOG])
-			fileTxt = [self htmlHistory:file];
-
-		id script = self.view.windowScriptObject;
-		NSString *filePath = [file fullPath];
-		[script callWebScriptMethod:@"showFile" withArguments:[NSArray arrayWithObjects:fileTxt, filePath, nil]];
-	}
-
-#if 0
-	NSString *dom=[[[[view mainFrame] DOMDocument] documentElement] outerHTML];
-	NSString *tmpFile=@"~/tmp/test.html";
-	[dom writeToFile:[tmpFile stringByExpandingTildeInPath] atomically:true encoding:NSUTF8StringEncoding error:nil];
-#endif
-}
-
-#pragma mark JavaScript log.js methods
-
-- (void)selectCommit:(NSString *)c
-{
-	[historyController selectCommit:[GTOID oidWithSHA:c]];
-}
-
-#pragma mark MGScopeBarDelegate methods
-
-- (NSInteger)numberOfGroupsInScopeBar:(MGScopeBar *)theScopeBar
-{
-	return [self.groups count];
-}
-
-
-- (NSArray *)scopeBar:(MGScopeBar *)theScopeBar itemIdentifiersForGroup:(NSInteger)groupNumber
-{
-	return [[self.groups objectAtIndex:groupNumber] valueForKeyPath:[NSString stringWithFormat:@"%@.%@", GROUP_ITEMS, ITEM_IDENTIFIER]];
-}
-
-
-- (NSString *)scopeBar:(MGScopeBar *)theScopeBar labelForGroup:(NSInteger)groupNumber
-{
-	return [[self.groups objectAtIndex:groupNumber] objectForKey:GROUP_LABEL]; // might be nil, which is fine (nil means no label).
-}
-
-
-- (NSString *)scopeBar:(MGScopeBar *)theScopeBar titleOfItem:(NSString *)identifier inGroup:(NSInteger)groupNumber
-{
-	NSArray *items = [[self.groups objectAtIndex:groupNumber] objectForKey:GROUP_ITEMS];
-	if (items) {
-		for (NSDictionary *item in items) {
-			if ([[item objectForKey:ITEM_IDENTIFIER] isEqualToString:identifier]) {
-				return [item objectForKey:ITEM_NAME];
-				break;
-			}
-		}
-	}
-	return nil;
-}
-
-
-- (MGScopeBarGroupSelectionMode)scopeBar:(MGScopeBar *)theScopeBar selectionModeForGroup:(NSInteger)groupNumber
-{
-	return [[[self.groups objectAtIndex:groupNumber] objectForKey:GROUP_SELECTION_MODE] intValue];
-}
-
-- (void)scopeBar:(MGScopeBar *)theScopeBar selectedStateChanged:(BOOL)selected forItem:(NSString *)identifier inGroup:(NSInteger)groupNumber
-{
-	startFile = identifier;
-	NSString *path = [NSString stringWithFormat:@"html/views/%@", identifier];
-	NSString *html = [[NSBundle mainBundle] pathForResource:@"index" ofType:@"html" inDirectory:path];
-	NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL fileURLWithPath:html]];
-	[self.view.mainFrame loadRequest:request];
-}
-
-- (NSView *)accessoryViewForScopeBar:(MGScopeBar *)scopeBar
-{
-	return accessoryView;
 }
 
 - (void)didLoad
@@ -165,195 +61,168 @@
 	[self showFile];
 }
 
+- (void)modeChanged:(NSSegmentedControl *)sender
+{
+	[self showFile];
+}
+
+- (NSArray<NSDictionary *> *)historyEntriesForTree:(PBGitTree *)file
+{
+	NSString *separator = NSUUID.UUID.UUIDString;
+	NSString *terminator = NSUUID.UUID.UUIDString;
+	NSString *format = [[@"%h,%s,%aN,%ar,%H" stringByReplacingOccurrencesOfString:@"," withString:separator] stringByAppendingString:terminator];
+	NSString *output = [file log:format] ?: @"";
+	NSMutableArray *entries = [NSMutableArray array];
+	for (NSString *raw in [output componentsSeparatedByString:terminator]) {
+		NSArray<NSString *> *parts = [raw componentsSeparatedByString:separator];
+		if (parts.count < 5) continue;
+		[entries addObject:@{
+			@"subject" : parts[1], @"author" : parts[2], @"date" : parts[3],
+			@"sha" : [parts[4] stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet],
+		}];
+	}
+	return entries;
+}
+
+- (NSString *)syntheticDiffForUntrackedFile:(PBChangedFile *)file
+{
+	NSString *contents = [historyController.repository.index diffForFile:file staged:NO contextLines:3] ?: @"";
+	NSMutableArray<NSString *> *lines = [[contents componentsSeparatedByString:@"\n"] mutableCopy];
+	BOOL endsWithNewline = [contents hasSuffix:@"\n"];
+	if (endsWithNewline && [lines.lastObject length] == 0) [lines removeLastObject];
+	if (lines.count == 0 || (lines.count == 1 && [lines.firstObject length] == 0)) return @"";
+	NSMutableString *added = [NSMutableString string];
+	for (NSString *line in lines) [added appendFormat:@"+%@\n", line];
+	if (!endsWithNewline) [added appendString:@"\\ No newline at end of file\n"];
+	return [NSString stringWithFormat:@"diff --git a/%@ b/%@\nnew file mode 100644\n--- /dev/null\n+++ b/%@\n@@ -0,0 +1,%lu @@\n%@", file.path, file.path, file.path, (unsigned long)lines.count, added];
+}
+
+- (NSArray<NSDictionary *> *)diffSectionsForTrees:(NSArray<PBGitTree *> *)trees
+{
+	NSMutableArray *sections = [NSMutableArray array];
+	PBGitCommit *commit = historyController.selectedCommits.firstObject;
+	BOOL workingState = [commit isKindOfClass:PBUncommittedChanges.class];
+	for (PBGitTree *tree in trees) {
+		if (!tree.leaf) continue;
+		if (workingState) {
+			PBChangedFile *change = nil;
+			for (PBChangedFile *candidate in historyController.repository.index.indexChanges) {
+				if ([candidate.path isEqualToString:tree.fullPath]) { change = candidate; break; }
+			}
+			if (!change) continue;
+			if (change.hasStagedChanges) {
+				[sections addObject:@{ PBNativeSectionTitleKey : [NSString stringWithFormat:@"Staged — %@", tree.fullPath], PBNativeSectionTextKey : [historyController.repository.index diffForFile:change staged:YES contextLines:3] ?: @"", PBNativeSectionContextKey : @"readOnly" }];
+			}
+			if (change.hasUnstagedChanges) {
+				NSString *diffText = change.status == NEW ? [self syntheticDiffForUntrackedFile:change] : [historyController.repository.index diffForFile:change staged:NO contextLines:3];
+				[sections addObject:@{ PBNativeSectionTitleKey : [NSString stringWithFormat:@"Unstaged — %@", tree.fullPath], PBNativeSectionTextKey : diffText ?: @"", PBNativeSectionContextKey : @"readOnly" }];
+			}
+		} else {
+			NSString *base = commit.parents.firstObject.SHA ?: PBEmptyTreeSHA;
+			NSError *error = nil;
+			NSString *patch = [historyController.repository outputOfTaskWithArguments:@[ @"diff", @"--find-renames", @"--no-ext-diff", base, commit.SHA, @"--", tree.fullPath ] error:&error] ?: @"";
+			[sections addObject:@{ PBNativeSectionTitleKey : tree.fullPath, PBNativeSectionTextKey : patch, PBNativeSectionContextKey : @"readOnly" }];
+		}
+	}
+	return sections;
+}
+
+- (void)showFile
+{
+	NSArray<PBGitTree *> *selected = historyController.treeController.selectedObjects;
+	if (selected.count == 0) {
+		[self.nativeView showMessage:@"No file selected"];
+		return;
+	}
+	PBFileMode mode = self.modeControl.selectedSegment;
+	NSMutableArray *sections = [NSMutableArray array];
+	for (PBGitTree *file in selected) {
+		if (!file.leaf) continue;
+		if (mode == PBFileModeSource || mode == PBFileModeBlame) {
+			[sections addObject:@{
+				PBNativeSectionTitleKey : file.fullPath ?: file.path,
+				PBNativeSectionPathKey : file.fullPath ?: file.path,
+				PBNativeSectionTextKey : mode == PBFileModeSource ? (file.textContents ?: @"") : (file.blame ?: @""),
+			}];
+		} else if (mode == PBFileModeHistory) {
+			[sections addObject:@{ PBNativeSectionTitleKey : file.fullPath ?: file.path, PBNativeSectionEntriesKey : [self historyEntriesForTree:file] }];
+		}
+	}
+	if (mode == PBFileModeDiff) sections = [[self diffSectionsForTrees:selected] mutableCopy];
+	if (sections.count == 0) {
+		[self.nativeView showMessage:@"Select one or more files to view this mode."];
+	} else if (mode == PBFileModeSource) {
+		[self.nativeView showSourceSections:sections];
+	} else if (mode == PBFileModeBlame) {
+		[self.nativeView showBlameSections:sections];
+	} else if (mode == PBFileModeHistory) {
+		[self.nativeView showHistorySections:sections];
+	} else {
+		[self.nativeView showDiffSections:sections];
+	}
+}
+
+- (void)nativeContentView:(PBNativeContentView *)view selectCommit:(NSString *)sha
+{
+	[historyController selectCommit:[GTOID oidWithSHA:sha]];
+}
+
+- (NSImage *)nativeContentView:(PBNativeContentView *)view imageForPath:(NSString *)path section:(NSUInteger)sectionIndex
+{
+	PBGitCommit *commit = historyController.selectedCommits.firstObject;
+	NSData *data = nil;
+	if ([commit isKindOfClass:PBUncommittedChanges.class]) {
+		data = [NSData dataWithContentsOfURL:[historyController.repository.workingDirectoryURL URLByAppendingPathComponent:path]];
+	} else if (commit.SHA.length) {
+		PBTask *task = [historyController.repository taskWithArguments:@[ @"show", [NSString stringWithFormat:@"%@:%@", commit.SHA, path] ]];
+		if ([task launchTask:nil]) data = task.standardOutputData;
+	}
+	return data.length ? [[NSImage alloc] initWithData:data] : nil;
+}
+
 - (void)closeView
 {
 	[self saveSplitViewPosition];
-
 	[super closeView];
 }
-
-- (NSString *)escapeHTML:(NSString *)txt
-{
-	CFStringRef escaped = CFXMLCreateStringByEscapingEntities(NULL, (__bridge CFStringRef)txt, NULL);
-	return (__bridge_transfer NSString *)escaped;
-}
-
-- (NSString *)parseBlame:(NSString *)txt
-{
-	txt = [self escapeHTML:txt];
-
-	NSArray *lines = [txt componentsSeparatedByString:@"\n"];
-	NSString *line;
-	NSMutableDictionary *headers = [NSMutableDictionary dictionary];
-	NSMutableString *res = [NSMutableString string];
-
-	[res appendString:@"<table class='blocks'>\n"];
-	int i = 0;
-	while (i < [lines count]) {
-		line = [lines objectAtIndex:i];
-		NSArray *header = [line componentsSeparatedByString:@" "];
-		if ([header count] == 4) {
-			NSString *commitID = (NSString *)[header objectAtIndex:0];
-			int nLines = [(NSString *)[header objectAtIndex:3] intValue];
-			[res appendFormat:@"<tr class='block l%d'>\n", nLines];
-			line = [lines objectAtIndex:++i];
-			if ([[[line componentsSeparatedByString:@" "] objectAtIndex:0] isEqual:@"author"]) {
-				NSString *author = [line stringByReplacingOccurrencesOfString:@"author" withString:@""];
-				NSString *summary = nil;
-				while (summary == nil) {
-					line = [lines objectAtIndex:i++];
-					if ([[[line componentsSeparatedByString:@" "] objectAtIndex:0] isEqual:@"summary"]) {
-						summary = [line stringByReplacingOccurrencesOfString:@"summary" withString:@""];
-					}
-				}
-				NSRange trunc_c = {0, 7};
-				NSString *truncate_c = commitID;
-				if ([commitID length] > 8) {
-					truncate_c = [commitID substringWithRange:trunc_c];
-				}
-				NSRange trunc = {0, 22};
-				NSString *truncate_a = author;
-				if ([author length] > 22) {
-					truncate_a = [author substringWithRange:trunc];
-				}
-				NSString *truncate_s = summary;
-				if ([summary length] > 30) {
-					truncate_s = [summary substringWithRange:trunc];
-				}
-				NSString *block = [NSString stringWithFormat:@"<td><p class='author'><a class='commit-link' href='#' data-commit-id='%@'>%@</a> %@</p><p class='summary'>%@</p></td>\n<td>\n", commitID, truncate_c, truncate_a, truncate_s];
-				[headers setObject:block forKey:[header objectAtIndex:0]];
-			}
-			[res appendString:[headers objectForKey:[header objectAtIndex:0]]];
-
-			NSMutableString *code = [NSMutableString string];
-			do {
-				line = [lines objectAtIndex:i++];
-			} while ([line characterAtIndex:0] != '\t');
-			line = [line substringFromIndex:1];
-			line = [line stringByReplacingOccurrencesOfString:@"\t" withString:@"&nbsp;&nbsp;&nbsp;&nbsp;"];
-			[code appendString:line];
-			[code appendString:@"\n"];
-
-			int n;
-			for (n = 1; n < nLines; n++) {
-				i++;
-				do {
-					line = [lines objectAtIndex:i++];
-				} while ([line characterAtIndex:0] != '\t');
-				line = [line substringFromIndex:1];
-				line = [line stringByReplacingOccurrencesOfString:@"\t" withString:@"&nbsp;&nbsp;&nbsp;&nbsp;"];
-				[code appendString:line];
-				[code appendString:@"\n"];
-			}
-			[res appendFormat:@"<pre class='first-line: %@;brush: objc'>%@</pre>", [header objectAtIndex:2], code];
-			[res appendString:@"</td>\n"];
-		} else {
-			break;
-		}
-		[res appendString:@"</tr>\n"];
-	}
-	[res appendString:@"</table>\n"];
-	//NSLog(@"%@",res);
-
-	return (NSString *)res;
-}
-
-- (NSString *)htmlHistory:(PBGitTree *)file
-{
-	// \0 can't be passed as a shell argument, so use a sufficiently long random seperator instead
-	NSString *seperator = [[NSUUID UUID] UUIDString];
-	NSString *commitTerminator = [[NSUUID UUID] UUIDString];
-	NSString *logFormat = [[@"%h,%s,%aN,%ar,%H" stringByReplacingOccurrencesOfString:@"," withString:seperator] stringByAppendingString:commitTerminator];
-	NSString *output = [file log:logFormat];
-	NSArray<NSString *> *rawCommits = [output componentsSeparatedByString:commitTerminator];
-	rawCommits = [rawCommits subarrayWithRange:(NSRange){0, rawCommits.count - 1}];
-
-	NSCharacterSet *whitespaceSet = [NSCharacterSet whitespaceCharacterSet];
-
-	NSMutableString *html = [NSMutableString string];
-	for (NSString *rawCommit in rawCommits) {
-		NSArray<NSString *> *parts = [rawCommit componentsSeparatedByString:seperator];
-		[html appendFormat:
-				  @"<div id='%@' class='commit'>"
-				   "<p class='title'>%@</p>"
-				   "<table>"
-				   "<tr><td>Author:</td><td>%@</td></tr>"
-				   "<tr><td>Date:</td><td>%@</td></tr>"
-				   "<tr><td>Commit:</td><td><a class='commit-link' href='#'>%@</a></td></tr>"
-				   "</table>"
-				   "</div>",
-				  [self escapeHTML:[parts[0] stringByTrimmingCharactersInSet:whitespaceSet]], // trim leading newline from split
-				  [self escapeHTML:parts[1]],
-				  [self escapeHTML:parts[2]],
-				  [self escapeHTML:parts[3]],
-				  [self escapeHTML:parts[4]]];
-	}
-	return html;
-}
-
-
-#pragma mark NSSplitView delegate methods
 
 #define kFileListSplitViewLeftMin 120
 #define kFileListSplitViewRightMin 180
 #define kHFileListSplitViewPositionDefault @"File List SplitView Position"
 
-- (CGFloat)splitView:(NSSplitView *)splitView constrainMinCoordinate:(CGFloat)proposedMin ofSubviewAt:(NSInteger)dividerIndex
-{
-	return kFileListSplitViewLeftMin;
-}
+- (CGFloat)splitView:(NSSplitView *)splitView constrainMinCoordinate:(CGFloat)proposedMin ofSubviewAt:(NSInteger)dividerIndex { return kFileListSplitViewLeftMin; }
+- (CGFloat)splitView:(NSSplitView *)splitView constrainMaxCoordinate:(CGFloat)proposedMax ofSubviewAt:(NSInteger)dividerIndex { return splitView.frame.size.width - splitView.dividerThickness - kFileListSplitViewRightMin; }
 
-- (CGFloat)splitView:(NSSplitView *)splitView constrainMaxCoordinate:(CGFloat)proposedMax ofSubviewAt:(NSInteger)dividerIndex
-{
-	return [splitView frame].size.width - [splitView dividerThickness] - kFileListSplitViewRightMin;
-}
-
-// while the user resizes the window keep the left (file list) view constant and just resize the right view
-// unless the right view gets too small
 - (void)splitView:(NSSplitView *)splitView resizeSubviewsWithOldSize:(NSSize)oldSize
 {
-	NSRect newFrame = [splitView frame];
-
-	CGFloat dividerThickness = [splitView dividerThickness];
-
-	NSView *leftView = [[splitView subviews] objectAtIndex:0];
-	NSRect leftFrame = [leftView frame];
+	NSRect newFrame = splitView.frame;
+	CGFloat dividerThickness = splitView.dividerThickness;
+	NSView *leftView = splitView.subviews[0];
+	NSRect leftFrame = leftView.frame;
 	leftFrame.size.height = newFrame.size.height;
-
-	if ((newFrame.size.width - leftFrame.size.width - dividerThickness) < kFileListSplitViewRightMin) {
+	if (newFrame.size.width - leftFrame.size.width - dividerThickness < kFileListSplitViewRightMin)
 		leftFrame.size.width = newFrame.size.width - kFileListSplitViewRightMin - dividerThickness;
-	}
-
-	NSView *rightView = [[splitView subviews] objectAtIndex:1];
-	NSRect rightFrame = [rightView frame];
+	NSView *rightView = splitView.subviews[1];
+	NSRect rightFrame = rightView.frame;
 	rightFrame.origin.x = leftFrame.size.width + dividerThickness;
 	rightFrame.size.width = newFrame.size.width - rightFrame.origin.x;
 	rightFrame.size.height = newFrame.size.height;
-
-	[leftView setFrame:leftFrame];
-	[rightView setFrame:rightFrame];
+	leftView.frame = leftFrame;
+	rightView.frame = rightFrame;
 }
 
-// NSSplitView does not save and restore the position of the SplitView correctly so do it manually
 - (void)saveSplitViewPosition
 {
-	CGFloat position = [[[fileListSplitView subviews] objectAtIndex:0] frame].size.width;
+	CGFloat position = [fileListSplitView.subviews[0] frame].size.width;
 	[[NSUserDefaults standardUserDefaults] setDouble:position forKey:kHFileListSplitViewPositionDefault];
-	[[NSUserDefaults standardUserDefaults] synchronize];
 }
 
-// make sure this happens after awakeFromNib
 - (void)restoreSplitViewPositiion
 {
 	CGFloat position = [[NSUserDefaults standardUserDefaults] doubleForKey:kHFileListSplitViewPositionDefault];
-	if (position < 1.0)
-		position = 200;
-
+	if (position < 1.0) position = 200;
 	[fileListSplitView setPosition:position ofDividerAtIndex:0];
 	[fileListSplitView setHidden:NO];
 }
-
-
-@synthesize groups;
 
 @end

--- a/Classes/Views/GLFileView.m
+++ b/Classes/Views/GLFileView.m
@@ -23,6 +23,8 @@ typedef NS_ENUM(NSInteger, PBFileMode) {
 
 @interface GLFileView () <PBNativeContentViewDelegate>
 @property (nonatomic) NSSegmentedControl *modeControl;
+@property (nonatomic) dispatch_queue_t fileLoadQueue;
+@property (nonatomic) NSUInteger fileLoadGeneration;
 - (void)saveSplitViewPosition;
 @end
 
@@ -33,20 +35,24 @@ typedef NS_ENUM(NSInteger, PBFileMode) {
 	startFile = @"fileview";
 	[super awakeFromNib];
 	self.nativeView.delegate = self;
-	[historyController.treeController addObserver:self keyPath:@"selection" options:0 block:^(MAKVONotification *notification) {
-		[notification.observer showFile];
-	}];
+	self.fileLoadQueue = dispatch_queue_create("com.gitx.file-load", DISPATCH_QUEUE_CONCURRENT);
+	[historyController.treeController addObserver:self
+										  keyPath:@"selection"
+										  options:0
+											block:^(MAKVONotification *notification) {
+												[notification.observer showFile];
+											}];
 
 	self.modeControl = [NSSegmentedControl segmentedControlWithLabels:@[ @"Source", @"Blame", @"History", @"Diff" ]
-										 trackingMode:NSSegmentSwitchTrackingSelectOne
-											 target:self
-											 action:@selector(modeChanged:)];
+														 trackingMode:NSSegmentSwitchTrackingSelectOne
+															   target:self
+															   action:@selector(modeChanged:)];
 	self.modeControl.selectedSegment = PBFileModeSource;
 	self.modeControl.segmentStyle = NSSegmentStyleAutomatic;
 	self.modeControl.controlSize = NSControlSizeSmall;
 	self.modeControl.translatesAutoresizingMaskIntoConstraints = NO;
 	[typeBar addSubview:self.modeControl];
-	[(PBGitGradientBarView *)typeBar setTopShade:237/255.0f bottomShade:216/255.0f];
+	[(PBGitGradientBarView *)typeBar setTopShade:237 / 255.0f bottomShade:216 / 255.0f];
 	[NSLayoutConstraint activateConstraints:@[
 		[self.modeControl.centerXAnchor constraintEqualToAnchor:typeBar.centerXAnchor],
 		[self.modeControl.centerYAnchor constraintEqualToAnchor:typeBar.centerYAnchor],
@@ -77,7 +83,9 @@ typedef NS_ENUM(NSInteger, PBFileMode) {
 		NSArray<NSString *> *parts = [raw componentsSeparatedByString:separator];
 		if (parts.count < 5) continue;
 		[entries addObject:@{
-			@"subject" : parts[1], @"author" : parts[2], @"date" : parts[3],
+			@"subject" : parts[1],
+			@"author" : parts[2],
+			@"date" : parts[3],
 			@"sha" : [parts[4] stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet],
 		}];
 	}
@@ -97,31 +105,44 @@ typedef NS_ENUM(NSInteger, PBFileMode) {
 	return [NSString stringWithFormat:@"diff --git a/%@ b/%@\nnew file mode 100644\n--- /dev/null\n+++ b/%@\n@@ -0,0 +1,%lu @@\n%@", file.path, file.path, file.path, (unsigned long)lines.count, added];
 }
 
+- (BOOL)isFileLoadGenerationCurrent:(NSUInteger)generation
+{
+	@synchronized(self) {
+		return generation == self.fileLoadGeneration;
+	}
+}
+
 - (NSArray<NSDictionary *> *)diffSectionsForTrees:(NSArray<PBGitTree *> *)trees
+										   commit:(PBGitCommit *)commit
+										  changes:(NSArray<PBChangedFile *> *)changes
+									   generation:(NSUInteger)generation
 {
 	NSMutableArray *sections = [NSMutableArray array];
-	PBGitCommit *commit = historyController.selectedCommits.firstObject;
 	BOOL workingState = [commit isKindOfClass:PBUncommittedChanges.class];
 	for (PBGitTree *tree in trees) {
+		if (![self isFileLoadGenerationCurrent:generation]) return @[];
 		if (!tree.leaf) continue;
 		if (workingState) {
 			PBChangedFile *change = nil;
-			for (PBChangedFile *candidate in historyController.repository.index.indexChanges) {
-				if ([candidate.path isEqualToString:tree.fullPath]) { change = candidate; break; }
+			for (PBChangedFile *candidate in changes) {
+				if ([candidate.path isEqualToString:tree.fullPath]) {
+					change = candidate;
+					break;
+				}
 			}
 			if (!change) continue;
 			if (change.hasStagedChanges) {
-				[sections addObject:@{ PBNativeSectionTitleKey : [NSString stringWithFormat:@"Staged — %@", tree.fullPath], PBNativeSectionTextKey : [historyController.repository.index diffForFile:change staged:YES contextLines:3] ?: @"", PBNativeSectionContextKey : @"readOnly" }];
+				[sections addObject:@{PBNativeSectionTitleKey : [NSString stringWithFormat:@"Staged — %@", tree.fullPath], PBNativeSectionTextKey : [historyController.repository.index diffForFile:change staged:YES contextLines:3] ?: @"", PBNativeSectionContextKey : @"readOnly"}];
 			}
 			if (change.hasUnstagedChanges) {
 				NSString *diffText = change.status == NEW ? [self syntheticDiffForUntrackedFile:change] : [historyController.repository.index diffForFile:change staged:NO contextLines:3];
-				[sections addObject:@{ PBNativeSectionTitleKey : [NSString stringWithFormat:@"Unstaged — %@", tree.fullPath], PBNativeSectionTextKey : diffText ?: @"", PBNativeSectionContextKey : @"readOnly" }];
+				[sections addObject:@{PBNativeSectionTitleKey : [NSString stringWithFormat:@"Unstaged — %@", tree.fullPath], PBNativeSectionTextKey : diffText ?: @"", PBNativeSectionContextKey : @"readOnly"}];
 			}
 		} else {
 			NSString *base = commit.parents.firstObject.SHA ?: PBEmptyTreeSHA;
 			NSError *error = nil;
 			NSString *patch = [historyController.repository outputOfTaskWithArguments:@[ @"diff", @"--find-renames", @"--no-ext-diff", base, commit.SHA, @"--", tree.fullPath ] error:&error] ?: @"";
-			[sections addObject:@{ PBNativeSectionTitleKey : tree.fullPath, PBNativeSectionTextKey : patch, PBNativeSectionContextKey : @"readOnly" }];
+			[sections addObject:@{PBNativeSectionTitleKey : tree.fullPath, PBNativeSectionTextKey : patch, PBNativeSectionContextKey : @"readOnly"}];
 		}
 	}
 	return sections;
@@ -129,37 +150,52 @@ typedef NS_ENUM(NSInteger, PBFileMode) {
 
 - (void)showFile
 {
-	NSArray<PBGitTree *> *selected = historyController.treeController.selectedObjects;
+	NSArray<PBGitTree *> *selected = [historyController.treeController.selectedObjects copy];
+	NSUInteger generation;
+	@synchronized(self) {
+		generation = ++self.fileLoadGeneration;
+	}
 	if (selected.count == 0) {
 		[self.nativeView showMessage:@"No file selected"];
 		return;
 	}
 	PBFileMode mode = self.modeControl.selectedSegment;
-	NSMutableArray *sections = [NSMutableArray array];
-	for (PBGitTree *file in selected) {
-		if (!file.leaf) continue;
-		if (mode == PBFileModeSource || mode == PBFileModeBlame) {
-			[sections addObject:@{
-				PBNativeSectionTitleKey : file.fullPath ?: file.path,
-				PBNativeSectionPathKey : file.fullPath ?: file.path,
-				PBNativeSectionTextKey : mode == PBFileModeSource ? (file.textContents ?: @"") : (file.blame ?: @""),
-			}];
-		} else if (mode == PBFileModeHistory) {
-			[sections addObject:@{ PBNativeSectionTitleKey : file.fullPath ?: file.path, PBNativeSectionEntriesKey : [self historyEntriesForTree:file] }];
+	PBGitCommit *commit = historyController.selectedCommits.firstObject;
+	NSArray<PBChangedFile *> *changes = [historyController.repository.index.indexChanges copy];
+	[self.nativeView showMessage:@"Loading file…"];
+	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)), self.fileLoadQueue, ^{
+		if (![self isFileLoadGenerationCurrent:generation]) return;
+		NSMutableArray *sections = [NSMutableArray array];
+		for (PBGitTree *file in selected) {
+			if (![self isFileLoadGenerationCurrent:generation]) return;
+			if (!file.leaf) continue;
+			if (mode == PBFileModeSource || mode == PBFileModeBlame) {
+				[sections addObject:@{
+					PBNativeSectionTitleKey : file.fullPath ?: file.path,
+					PBNativeSectionPathKey : file.fullPath ?: file.path,
+					PBNativeSectionTextKey : mode == PBFileModeSource ? (file.textContents ?: @"") : (file.blame ?: @""),
+				}];
+			} else if (mode == PBFileModeHistory) {
+				[sections addObject:@{PBNativeSectionTitleKey : file.fullPath ?: file.path, PBNativeSectionEntriesKey : [self historyEntriesForTree:file]}];
+			}
 		}
-	}
-	if (mode == PBFileModeDiff) sections = [[self diffSectionsForTrees:selected] mutableCopy];
-	if (sections.count == 0) {
-		[self.nativeView showMessage:@"Select one or more files to view this mode."];
-	} else if (mode == PBFileModeSource) {
-		[self.nativeView showSourceSections:sections];
-	} else if (mode == PBFileModeBlame) {
-		[self.nativeView showBlameSections:sections];
-	} else if (mode == PBFileModeHistory) {
-		[self.nativeView showHistorySections:sections];
-	} else {
-		[self.nativeView showDiffSections:sections];
-	}
+		if (mode == PBFileModeDiff) sections = [[self diffSectionsForTrees:selected commit:commit changes:changes generation:generation] mutableCopy];
+		if (![self isFileLoadGenerationCurrent:generation]) return;
+		dispatch_async(dispatch_get_main_queue(), ^{
+			if (![self isFileLoadGenerationCurrent:generation]) return;
+			if (sections.count == 0) {
+				[self.nativeView showMessage:@"Select one or more files to view this mode."];
+			} else if (mode == PBFileModeSource) {
+				[self.nativeView showSourceSections:sections];
+			} else if (mode == PBFileModeBlame) {
+				[self.nativeView showBlameSections:sections];
+			} else if (mode == PBFileModeHistory) {
+				[self.nativeView showHistorySections:sections];
+			} else {
+				[self.nativeView showDiffSections:sections];
+			}
+		});
+	});
 }
 
 - (void)nativeContentView:(PBNativeContentView *)view selectCommit:(NSString *)sha
@@ -182,6 +218,9 @@ typedef NS_ENUM(NSInteger, PBFileMode) {
 
 - (void)closeView
 {
+	@synchronized(self) {
+		self.fileLoadGeneration++;
+	}
 	[self saveSplitViewPosition];
 	[super closeView];
 }
@@ -190,8 +229,14 @@ typedef NS_ENUM(NSInteger, PBFileMode) {
 #define kFileListSplitViewRightMin 180
 #define kHFileListSplitViewPositionDefault @"File List SplitView Position"
 
-- (CGFloat)splitView:(NSSplitView *)splitView constrainMinCoordinate:(CGFloat)proposedMin ofSubviewAt:(NSInteger)dividerIndex { return kFileListSplitViewLeftMin; }
-- (CGFloat)splitView:(NSSplitView *)splitView constrainMaxCoordinate:(CGFloat)proposedMax ofSubviewAt:(NSInteger)dividerIndex { return splitView.frame.size.width - splitView.dividerThickness - kFileListSplitViewRightMin; }
+- (CGFloat)splitView:(NSSplitView *)splitView constrainMinCoordinate:(CGFloat)proposedMin ofSubviewAt:(NSInteger)dividerIndex
+{
+	return kFileListSplitViewLeftMin;
+}
+- (CGFloat)splitView:(NSSplitView *)splitView constrainMaxCoordinate:(CGFloat)proposedMax ofSubviewAt:(NSInteger)dividerIndex
+{
+	return splitView.frame.size.width - splitView.dividerThickness - kFileListSplitViewRightMin;
+}
 
 - (void)splitView:(NSSplitView *)splitView resizeSubviewsWithOldSize:(NSSize)oldSize
 {

--- a/Classes/Views/PBCommitMessageView.m
+++ b/Classes/Views/PBCommitMessageView.m
@@ -35,7 +35,7 @@
 
 	if ([PBGitDefaults commitMessageViewHasVerticalLine]) {
 		CGFloat characterWidth = [@" " sizeWithAttributes:[self typingAttributes]].width;
-		CGFloat lineWidth = characterWidth * [PBGitDefaults commitMessageViewVerticalLineLength];
+		CGFloat lineWidth = characterWidth * (CGFloat)[PBGitDefaults commitMessageViewVerticalLineLength];
 		NSRect line;
 		CGFloat padding;
 		CGFloat textViewHeight = [self bounds].size.height;
@@ -51,7 +51,7 @@
 		NSRectFill(line);
 
 		// and one for the body of the commit message
-		lineWidth = characterWidth * [PBGitDefaults commitMessageViewVerticalBodyLineLength];
+		lineWidth = characterWidth * (CGFloat)[PBGitDefaults commitMessageViewVerticalBodyLineLength];
 		[[NSColor darkGrayColor] set];
 		padding = [[self textContainer] lineFragmentPadding];
 		line.origin.x = padding + lineWidth;

--- a/Classes/Views/PBGitCommitTableViewCell.m
+++ b/Classes/Views/PBGitCommitTableViewCell.m
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle
 {
 	switch (backgroundStyle) {
-		case NSBackgroundStyleDark:
+		case NSBackgroundStyleEmphasized:
 			self.textField.textColor = NSColor.whiteColor;
 			break;
 		default:

--- a/Classes/Views/PBGitGradientBarView.m
+++ b/Classes/Views/PBGitGradientBarView.m
@@ -26,8 +26,18 @@
 
 - (void)drawRect:(NSRect)dirtyRect
 {
-	if (![NSApp isDarkMode])
-		[gradient drawInRect:[self bounds] angle:90];
+	if ([NSApp isDarkMode]) {
+		[NSColor.controlBackgroundColor setFill];
+		NSRectFill(self.bounds);
+	} else {
+		[gradient drawInRect:self.bounds angle:90];
+	}
+}
+
+- (void)viewDidChangeEffectiveAppearance
+{
+	[super viewDidChangeEffectiveAppearance];
+	self.needsDisplay = YES;
 }
 
 

--- a/Classes/Views/PBGitRevisionCell.m
+++ b/Classes/Views/PBGitRevisionCell.m
@@ -36,10 +36,10 @@ const BOOL SHUFFLE_COLORS = NO;
 	static const size_t colorCount = 8;
 	static NSArray *laneColors = nil;
 	if (!laneColors) {
-		float segment = 1.0f / colorCount;
+		CGFloat segment = 1.0 / (CGFloat)colorCount;
 		NSMutableArray *colors = [NSMutableArray new];
 		for (size_t i = 0; i < colorCount; ++i) {
-			NSColor *newColor = [NSColor colorWithCalibratedHue:(segment * i) saturation:0.7f brightness:0.8f alpha:1.0f];
+			NSColor *newColor = [NSColor colorWithCalibratedHue:(segment * (CGFloat)i) saturation:0.7f brightness:0.8f alpha:1.0f];
 			[colors addObject:newColor];
 		}
 		if (SHUFFLE_COLORS) {
@@ -95,7 +95,7 @@ const BOOL SHUFFLE_COLORS = NO;
 	} else {
 		NSBezierPath *path = [NSBezierPath bezierPath];
 		[path setLineWidth:2];
-		[path setLineCapStyle:NSRoundLineCapStyle];
+		[path setLineCapStyle:NSLineCapStyleRound];
 		[path moveToPoint:source];
 		[path lineToPoint:center];
 		[path stroke];
@@ -156,7 +156,7 @@ const BOOL SHUFFLE_COLORS = NO;
 
 	long c = cellInfo.position;
 	NSPoint origin = r.origin;
-	NSPoint columnOrigin = {origin.x + COLUMN_WIDTH * c, origin.y};
+	NSPoint columnOrigin = {origin.x + COLUMN_WIDTH * (CGFloat)c, origin.y};
 	NSRect oval = {columnOrigin.x - 5, columnOrigin.y + r.size.height * 0.5 - 5, 10, 10};
 
 	if ([self isCurrentCommit]) {
@@ -174,9 +174,9 @@ const BOOL SHUFFLE_COLORS = NO;
 
 	NSPoint top;
 	if (sign == '<')
-		top.x = round(r.origin.x) + 10 * c + 4;
+		top.x = round(r.origin.x) + 10.0 * (CGFloat)c + 4.0;
 	else {
-		top.x = round(r.origin.x) + 10 * c - 4;
+		top.x = round(r.origin.x) + 10.0 * (CGFloat)c - 4.0;
 		columnWidth *= -1;
 	}
 	top.y = r.origin.y + (r.size.height - columnHeight) / 2;
@@ -203,7 +203,7 @@ const BOOL SHUFFLE_COLORS = NO;
 	NSMutableDictionary *attributes = [[NSMutableDictionary alloc] initWithCapacity:2];
 	NSMutableParagraphStyle *style = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
 
-	[style setAlignment:NSCenterTextAlignment];
+	[style setAlignment:NSTextAlignmentCenter];
 	[attributes setObject:style forKey:NSParagraphStyleAttributeName];
 
 	[attributes setObject:[NSFont systemFontOfSize:10] forKey:NSFontAttributeName];
@@ -295,7 +295,7 @@ const BOOL SHUFFLE_COLORS = NO;
 	cellInfo = [self.objectValue lineInfo];
 
 	if (cellInfo && ![controller hasNonlinearPath]) {
-		float pathWidth = 10 + COLUMN_WIDTH * cellInfo.numColumns;
+		CGFloat pathWidth = 10.0 + COLUMN_WIDTH * (CGFloat)cellInfo.numColumns;
 
 		NSRect ownRect;
 		NSDivideRect(rect, &ownRect, &rect, pathWidth, NSMinXEdge);
@@ -335,10 +335,10 @@ const BOOL SHUFFLE_COLORS = NO;
 	cellInfo = [self.objectValue lineInfo];
 
 	if (cellInfo) {
-		float pathWidth = 0;
+		CGFloat pathWidth = 0;
 
 		if (!controller.hasNonlinearPath) {
-			pathWidth = 10 + COLUMN_WIDTH * cellInfo.numColumns;
+			pathWidth = 10.0 + COLUMN_WIDTH * (CGFloat)cellInfo.numColumns;
 		}
 
 		NSRect ownRect;
@@ -372,9 +372,9 @@ const BOOL SHUFFLE_COLORS = NO;
 - (int)indexAtX:(CGFloat)x
 {
 	cellInfo = [self.objectValue lineInfo];
-	float pathWidth = 0;
+	CGFloat pathWidth = 0;
 	if (cellInfo && ![controller hasNonlinearPath])
-		pathWidth = 10 + 10 * cellInfo.numColumns;
+		pathWidth = 10.0 + 10.0 * (CGFloat)cellInfo.numColumns;
 
 	int index = 0;
 	NSRect refRect = NSMakeRect(pathWidth, 0, 1000, 10000);
@@ -391,9 +391,9 @@ const BOOL SHUFFLE_COLORS = NO;
 - (NSRect)rectAtIndex:(int)index
 {
 	cellInfo = [self.objectValue lineInfo];
-	float pathWidth = 0;
+	CGFloat pathWidth = 0;
 	if (cellInfo && ![controller hasNonlinearPath])
-		pathWidth = 10 + 10 * cellInfo.numColumns;
+		pathWidth = 10.0 + 10.0 * (CGFloat)cellInfo.numColumns;
 	NSRect refRect = NSMakeRect(pathWidth, 0, 1000, 10000);
 
 	return [[[self rectsForRefsinRect:refRect] objectAtIndex:index] rectValue];

--- a/Classes/Views/PBGitRevisionRow.m
+++ b/Classes/Views/PBGitRevisionRow.m
@@ -22,11 +22,11 @@ NS_ASSUME_NONNULL_BEGIN
 	if ([self isSelected]) {
 		if ([[self window] isKeyWindow]) {
 			if ([[self window] firstResponder] == (NSTableView *)self.controller.commitList) {
-				return [NSColor alternateSelectedControlColor];
+				return [NSColor selectedContentBackgroundColor];
 			}
 			return [NSColor selectedControlColor];
 		}
-		return [NSColor secondarySelectedControlColor];
+		return [NSColor unemphasizedSelectedContentBackgroundColor];
 	}
 
 	// light blue color highlighting search results

--- a/Classes/Views/PBHighlighting.h
+++ b/Classes/Views/PBHighlighting.h
@@ -1,0 +1,11 @@
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Swift facade around HighlightKit used by the Objective-C native viewers.
+@interface PBHighlighting : NSObject
++ (NSAttributedString *)highlightedStringForText:(NSString *)text path:(NSString *)path;
++ (nullable NSString *)languageNameForPath:(NSString *)path;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Views/PBHighlighting.swift
+++ b/Classes/Views/PBHighlighting.swift
@@ -1,0 +1,62 @@
+import Cocoa
+import HighlightKit
+
+@objc(PBHighlighting)
+final class PBHighlighting: NSObject {
+    private static let extensionLanguages: [String: String] = [
+        "ada": "ada", "adb": "ada", "ads": "ada",
+        "applescript": "applescript", "s": "armasm", "asm": "armasm",
+        "sh": "bash", "bash": "bash", "zsh": "bash", "fish": "bash",
+        "c": "c", "h": "objectivec", "cc": "cpp", "cp": "cpp",
+        "cpp": "cpp", "cxx": "cpp", "hh": "cpp", "hpp": "cpp",
+        "cs": "csharp", "css": "css", "scss": "scss", "less": "less",
+        "dart": "dart", "diff": "diff", "patch": "diff",
+        "ex": "elixir", "exs": "elixir", "erl": "erlang", "hrl": "erlang",
+        "fs": "fsharp", "fsi": "fsharp", "fsx": "fsharp",
+        "f": "fortran", "f90": "fortran", "f95": "fortran",
+        "go": "go", "groovy": "groovy", "hs": "haskell",
+        "html": "xml", "htm": "xml", "xml": "xml", "svg": "xml",
+        "ini": "ini", "toml": "ini", "java": "java",
+        "js": "javascript", "mjs": "javascript", "cjs": "javascript",
+        "json": "json", "json5": "json", "kt": "kotlin", "kts": "kotlin",
+        "lua": "lua", "md": "markdown", "markdown": "markdown",
+        "m": "objectivec", "mm": "objectivec", "ml": "ocaml", "mli": "ocaml",
+        "pl": "perl", "pm": "perl", "php": "php", "ps1": "powershell",
+        "pro": "prolog", "properties": "properties", "py": "python",
+        "r": "r", "rb": "ruby", "rs": "rust", "scala": "scala",
+        "scm": "scheme", "sql": "sql", "swift": "swift",
+        "ts": "typescript", "tsx": "typescript", "vim": "vim",
+        "yaml": "yaml", "yml": "yaml"
+    ]
+
+    @objc(languageNameForPath:)
+    static func languageName(forPath path: String) -> String? {
+        let name = (path as NSString).lastPathComponent.lowercased()
+        switch name {
+        case "dockerfile": return "dockerfile"
+        case "makefile", "gnumakefile": return "makefile"
+        case "cmakelists.txt": return "cmake"
+        default: break
+        }
+        return extensionLanguages[(name as NSString).pathExtension]
+    }
+
+    @objc(highlightedStringForText:path:)
+    static func highlightedString(forText text: String, path: String) -> NSAttributedString {
+        let language = languageName(forPath: path)
+        let attributed = Highlighter.shared.attributedString(
+            for: text,
+            language: language,
+            theme: .xcode
+        ).mutableCopy() as! NSMutableAttributedString
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.tabStops = []
+        paragraph.defaultTabInterval = 32
+        paragraph.lineBreakMode = .byClipping
+        attributed.addAttribute(.paragraphStyle,
+                                value: paragraph,
+                                range: NSRange(location: 0, length: attributed.length))
+        return attributed
+    }
+}

--- a/Classes/Views/PBNativeContentView.h
+++ b/Classes/Views/PBNativeContentView.h
@@ -1,0 +1,37 @@
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const PBNativeSectionTitleKey;
+extern NSString *const PBNativeSectionTextKey;
+extern NSString *const PBNativeSectionPathKey;
+extern NSString *const PBNativeSectionContextKey;
+extern NSString *const PBNativeSectionEntriesKey;
+
+@class PBNativeContentView;
+
+@protocol PBNativeContentViewDelegate <NSObject>
+@optional
+- (void)nativeContentView:(PBNativeContentView *)view performDiffAction:(NSString *)action patch:(NSString *)patch;
+- (void)nativeContentView:(PBNativeContentView *)view selectCommit:(NSString *)sha;
+- (nullable NSImage *)nativeContentView:(PBNativeContentView *)view imageForPath:(NSString *)path section:(NSUInteger)sectionIndex;
+@end
+
+/// Shared, selectable AppKit renderer for source, blame, history, and diff content.
+@interface PBNativeContentView : NSView <NSTextViewDelegate>
+
+@property (nonatomic, weak, nullable) id<PBNativeContentViewDelegate> delegate;
+@property (nonatomic, readonly) NSTextView *textView;
+
+- (void)setAccessoryView:(nullable NSView *)accessoryView;
+- (void)showMessage:(NSString *)message;
+- (void)showSourceSections:(NSArray<NSDictionary *> *)sections;
+- (void)showBlameSections:(NSArray<NSDictionary *> *)sections;
+- (void)showHistorySections:(NSArray<NSDictionary *> *)sections;
+- (void)showDiffSections:(NSArray<NSDictionary *> *)sections;
+- (void)scrollPageUp;
+- (void)scrollPageDown;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Views/PBNativeContentView.m
+++ b/Classes/Views/PBNativeContentView.m
@@ -110,9 +110,12 @@ static const NSUInteger PBNativeLargePatchThreshold = 200 * 1024;
 	[accessoryView.widthAnchor constraintEqualToAnchor:_rootStack.widthAnchor].active = YES;
 }
 
-- (void)setRenderedString:(NSAttributedString *)string generation:(NSUInteger)generation
+- (void)setRenderedString:(NSAttributedString *)string
+			   generation:(NSUInteger)generation
+			 linkPayloads:(nullable NSDictionary<NSString *, NSDictionary *> *)linkPayloads
 {
 	if (generation != self.renderGeneration) return;
+	self.linkPayloads = linkPayloads ? [linkPayloads mutableCopy] : [NSMutableDictionary dictionary];
 	[self.textView.textStorage setAttributedString:string];
 	[self.textView scrollRangeToVisible:NSMakeRange(0, 0)];
 }
@@ -120,12 +123,12 @@ static const NSUInteger PBNativeLargePatchThreshold = 200 * 1024;
 - (void)showMessage:(NSString *)message
 {
 	self.renderGeneration++;
-	[self.linkPayloads removeAllObjects];
-	NSAttributedString *string = [[NSAttributedString alloc] initWithString:message ?: @"" attributes:@{
-		NSFontAttributeName : [NSFont systemFontOfSize:13],
-		NSForegroundColorAttributeName : NSColor.secondaryLabelColor,
-	}];
-	[self setRenderedString:string generation:self.renderGeneration];
+	NSAttributedString *string = [[NSAttributedString alloc] initWithString:message ?: @""
+																 attributes:@{
+																	 NSFontAttributeName : [NSFont systemFontOfSize:13],
+																	 NSForegroundColorAttributeName : NSColor.secondaryLabelColor,
+																 }];
+	[self setRenderedString:string generation:self.renderGeneration linkPayloads:nil];
 }
 
 - (void)appendSectionTitle:(NSString *)title toString:(NSMutableAttributedString *)result
@@ -138,7 +141,6 @@ static const NSUInteger PBNativeLargePatchThreshold = 200 * 1024;
 - (void)showSourceSections:(NSArray<NSDictionary *> *)sections
 {
 	NSUInteger generation = ++self.renderGeneration;
-	[self.linkPayloads removeAllObjects];
 	NSArray *copiedSections = [sections copy];
 	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
 		NSMutableAttributedString *rendered = [[NSMutableAttributedString alloc] init];
@@ -150,7 +152,7 @@ static const NSUInteger PBNativeLargePatchThreshold = 200 * 1024;
 			[rendered appendAttributedString:[PBHighlighting highlightedStringForText:text path:path]];
 		}
 		dispatch_async(dispatch_get_main_queue(), ^{
-			[self setRenderedString:rendered generation:generation];
+			[self setRenderedString:rendered generation:generation linkPayloads:nil];
 		});
 	});
 }
@@ -187,7 +189,6 @@ static const NSUInteger PBNativeLargePatchThreshold = 200 * 1024;
 - (void)showBlameSections:(NSArray<NSDictionary *> *)sections
 {
 	NSUInteger generation = ++self.renderGeneration;
-	[self.linkPayloads removeAllObjects];
 	NSArray *copiedSections = [sections copy];
 	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
 		NSMutableAttributedString *rendered = [[NSMutableAttributedString alloc] init];
@@ -206,12 +207,15 @@ static const NSUInteger PBNativeLargePatchThreshold = 200 * 1024;
 				NSString *shortSHA = fullSHA.length >= 8 ? [fullSHA substringToIndex:8] : fullSHA;
 				NSString *author = record[@"author"] ?: @"";
 				if (author.length > 18) author = [[author substringToIndex:17] stringByAppendingString:@"…"];
-				NSString *gutter = [NSString stringWithFormat:@"%-8@  %-18@ │ ", shortSHA, author];
-				[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:gutter attributes:@{
-					NSFontAttributeName : [NSFont monospacedSystemFontOfSize:11 weight:NSFontWeightRegular],
-					NSForegroundColorAttributeName : NSColor.secondaryLabelColor,
-					NSBackgroundColorAttributeName : NSColor.controlBackgroundColor,
-				}]];
+				shortSHA = [shortSHA stringByPaddingToLength:8 withString:@" " startingAtIndex:0];
+				author = [author stringByPaddingToLength:18 withString:@" " startingAtIndex:0];
+				NSString *gutter = [NSString stringWithFormat:@"%@  %@ │ ", shortSHA, author];
+				[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:gutter
+																				 attributes:@{
+																					 NSFontAttributeName : [NSFont monospacedSystemFontOfSize:11 weight:NSFontWeightRegular],
+																					 NSForegroundColorAttributeName : NSColor.secondaryLabelColor,
+																					 NSBackgroundColorAttributeName : NSColor.controlBackgroundColor,
+																				 }]];
 				if (codeLocation + line.length <= highlighted.length) {
 					[rendered appendAttributedString:[highlighted attributedSubstringFromRange:NSMakeRange(codeLocation, line.length)]];
 				} else {
@@ -221,57 +225,93 @@ static const NSUInteger PBNativeLargePatchThreshold = 200 * 1024;
 			}
 		}
 		dispatch_async(dispatch_get_main_queue(), ^{
-			[self setRenderedString:rendered generation:generation];
+			[self setRenderedString:rendered generation:generation linkPayloads:nil];
 		});
 	});
 }
 
-- (NSURL *)appendLinkWithTitle:(NSString *)title payload:(NSDictionary *)payload toString:(NSMutableAttributedString *)result
+- (NSURL *)appendLinkWithTitle:(NSString *)title
+					   payload:(NSDictionary *)payload
+				  linkPayloads:(NSMutableDictionary<NSString *, NSDictionary *> *)linkPayloads
+					  toString:(NSMutableAttributedString *)result
 {
 	NSString *token = NSUUID.UUID.UUIDString;
 	NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"gitx-action://%@", token]];
-	self.linkPayloads[URL.absoluteString] = payload;
-	NSMutableAttributedString *link = [[NSMutableAttributedString alloc] initWithString:title attributes:@{
-		NSFontAttributeName : [NSFont systemFontOfSize:11 weight:NSFontWeightMedium],
-		NSLinkAttributeName : URL,
-		NSForegroundColorAttributeName : NSColor.linkColor,
-		NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle),
-	}];
+	linkPayloads[URL.absoluteString] = payload;
+	NSString *localizedTitle = NSLocalizedString(title, @"Native content action title");
+	NSMutableAttributedString *link = [[NSMutableAttributedString alloc] initWithString:localizedTitle
+																			 attributes:@{
+																				 NSFontAttributeName : [NSFont systemFontOfSize:11 weight:NSFontWeightMedium],
+																				 NSLinkAttributeName : URL,
+																				 NSForegroundColorAttributeName : NSColor.linkColor,
+																				 NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle),
+																			 }];
 	[result appendAttributedString:link];
 	return URL;
 }
 
 - (void)showHistorySections:(NSArray<NSDictionary *> *)sections
 {
-	self.renderGeneration++;
-	[self.linkPayloads removeAllObjects];
-	NSMutableAttributedString *rendered = [[NSMutableAttributedString alloc] init];
-	for (NSDictionary *section in sections) {
-		[self appendSectionTitle:section[PBNativeSectionTitleKey] ?: section[PBNativeSectionPathKey] ?: @"" toString:rendered];
-		for (NSDictionary *entry in section[PBNativeSectionEntriesKey] ?: @[]) {
-			NSString *subject = entry[@"subject"] ?: @"";
-			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:[subject stringByAppendingString:@"\n"] attributes:self.titleAttributes]];
-			NSString *detail = [NSString stringWithFormat:@"%@  •  %@  •  ", entry[@"author"] ?: @"", entry[@"date"] ?: @""];
-			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:detail attributes:@{
-				NSFontAttributeName : [NSFont systemFontOfSize:11],
-				NSForegroundColorAttributeName : NSColor.secondaryLabelColor,
-			}]];
-			NSString *sha = entry[@"sha"] ?: @"";
-			[self appendLinkWithTitle:(sha.length > 12 ? [sha substringToIndex:12] : sha)
-						  payload:@{ @"type" : @"commit", @"sha" : sha }
-						 toString:rendered];
-			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n\n"]];
+	NSUInteger generation = ++self.renderGeneration;
+	NSArray *copiedSections = [sections copy];
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		NSMutableAttributedString *rendered = [[NSMutableAttributedString alloc] init];
+		NSMutableDictionary<NSString *, NSDictionary *> *linkPayloads = [NSMutableDictionary dictionary];
+		for (NSDictionary *section in copiedSections) {
+			[self appendSectionTitle:section[PBNativeSectionTitleKey] ?: section[PBNativeSectionPathKey] ?:
+																										   @""
+							toString:rendered];
+			for (NSDictionary *entry in section[PBNativeSectionEntriesKey] ?: @[]) {
+				NSString *subject = entry[@"subject"] ?: @"";
+				[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:[subject stringByAppendingString:@"\n"] attributes:self.titleAttributes]];
+				NSString *detail = [NSString stringWithFormat:@"%@  •  %@  •  ", entry[@"author"] ?: @"", entry[@"date"] ?: @""];
+				[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:detail
+																				 attributes:@{
+																					 NSFontAttributeName : [NSFont systemFontOfSize:11],
+																					 NSForegroundColorAttributeName : NSColor.secondaryLabelColor,
+																				 }]];
+				NSString *sha = entry[@"sha"] ?: @"";
+				[self appendLinkWithTitle:(sha.length > 12 ? [sha substringToIndex:12] : sha)
+								  payload:@{@"type" : @"commit", @"sha" : sha}
+							 linkPayloads:linkPayloads
+								 toString:rendered];
+				[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n\n"]];
+			}
 		}
-	}
-	[self setRenderedString:rendered generation:self.renderGeneration];
+		dispatch_async(dispatch_get_main_queue(), ^{
+			[self setRenderedString:rendered generation:generation linkPayloads:linkPayloads];
+		});
+	});
 }
 
-- (NSString *)fileKeyForLine:(NSString *)line section:(NSUInteger)sectionIndex
+- (NSString *)normalizedDiffPath:(NSString *)path
 {
-	NSArray<NSString *> *parts = [line componentsSeparatedByString:@" "];
-	NSString *path = parts.count >= 4 ? parts[3] : line;
-	if ([path hasPrefix:@"b/"]) path = [path substringFromIndex:2];
-	return [NSString stringWithFormat:@"%lu:%@", (unsigned long)sectionIndex, path];
+	if ([path hasPrefix:@"\""] && [path hasSuffix:@"\""] && path.length >= 2)
+		path = [path substringWithRange:NSMakeRange(1, path.length - 2)];
+	path = [path stringByReplacingOccurrencesOfString:@"\\\"" withString:@"\""];
+	path = [path stringByReplacingOccurrencesOfString:@"\\\\" withString:@"\\"];
+	if ([path hasPrefix:@"a/"] || [path hasPrefix:@"b/"]) path = [path substringFromIndex:2];
+	return path;
+}
+
+- (NSString *)pathForDiffHeaderAtIndex:(NSUInteger)headerIndex lines:(NSArray<NSString *> *)lines
+{
+	NSString *oldPath = nil;
+	for (NSUInteger index = headerIndex + 1; index < lines.count && ![lines[index] hasPrefix:@"diff --git "]; index++) {
+		NSString *line = lines[index];
+		if ([line hasPrefix:@"rename to "]) return [self normalizedDiffPath:[line substringFromIndex:10]];
+		if ([line hasPrefix:@"copy to "]) return [self normalizedDiffPath:[line substringFromIndex:8]];
+		if ([line hasPrefix:@"+++ "] && ![line isEqualToString:@"+++ /dev/null"])
+			return [self normalizedDiffPath:[line substringFromIndex:4]];
+		if ([line hasPrefix:@"--- "] && ![line isEqualToString:@"--- /dev/null"])
+			oldPath = [self normalizedDiffPath:[line substringFromIndex:4]];
+	}
+	if (oldPath.length) return oldPath;
+	NSString *header = lines[headerIndex];
+	NSRange destination = [header rangeOfString:@" b/" options:NSBackwardsSearch];
+	if (destination.location != NSNotFound)
+		return [self normalizedDiffPath:[header substringFromIndex:NSMaxRange(destination) - 2]];
+	return header;
 }
 
 - (NSMutableAttributedString *)attributedDiffLine:(NSString *)line counterpart:(nullable NSString *)counterpart
@@ -336,27 +376,41 @@ static const NSUInteger PBNativeLargePatchThreshold = 200 * 1024;
 	NSMutableArray<NSString *> *body = [NSMutableArray array];
 	NSUInteger oldCount = 0;
 	NSUInteger newCount = 0;
+	BOOL previousLineWasEmittedVerbatim = NO;
 	for (NSUInteger index = 1; index < hunkLines.count; index++) {
 		NSString *line = hunkLines[index];
 		if (!line.length) continue;
 		unichar prefix = [line characterAtIndex:0];
 		BOOL marker = prefix == '\\';
+		if (marker) {
+			if (previousLineWasEmittedVerbatim) [body addObject:line];
+			continue;
+		}
 		BOOL selected = [selectedIndexes containsIndex:index];
-		if (marker && index > 0 && [selectedIndexes containsIndex:index - 1]) selected = YES;
+		BOOL emittedVerbatim = YES;
 		if (!selected) {
 			unichar contextualChange = reverse ? '+' : '-';
 			unichar omittedChange = reverse ? '-' : '+';
 			if (prefix == contextualChange) {
 				line = [@" " stringByAppendingString:[line substringFromIndex:1]];
 				prefix = ' ';
+				emittedVerbatim = NO;
 			}
-			if (prefix == omittedChange) continue;
+			if (prefix == omittedChange) {
+				previousLineWasEmittedVerbatim = NO;
+				continue;
+			}
 		}
 		[body addObject:line];
-		if (marker) continue;
-		if (prefix == '-') oldCount++;
-		else if (prefix == '+') newCount++;
-		else { oldCount++; newCount++; }
+		previousLineWasEmittedVerbatim = emittedVerbatim;
+		if (prefix == '-')
+			oldCount++;
+		else if (prefix == '+')
+			newCount++;
+		else {
+			oldCount++;
+			newCount++;
+		}
 	}
 	if (!oldCount && !newCount) return nil;
 	NSMutableArray<NSString *> *patch = [fileHeader mutableCopy];
@@ -366,51 +420,56 @@ static const NSUInteger PBNativeLargePatchThreshold = 200 * 1024;
 }
 
 - (void)renderDiffText:(NSString *)diff
-				 context:(NSString *)context
-			 section:(NSUInteger)sectionIndex
+			   context:(NSString *)context
+			   section:(NSUInteger)sectionIndex
+		collapsedFiles:(NSSet<NSString *> *)collapsedFiles
+		expandedImages:(NSSet<NSString *> *)expandedImages
+		  linkPayloads:(NSMutableDictionary<NSString *, NSDictionary *> *)linkPayloads
 			  toString:(NSMutableAttributedString *)rendered
 {
 	NSArray<NSString *> *lines = [diff componentsSeparatedByString:@"\n"];
 	NSMutableArray<NSString *> *fileHeader = [NSMutableArray array];
-	NSString *fileKey = [NSString stringWithFormat:@"%lu:patch", (unsigned long)sectionIndex];
+	NSString *fileKey;
 	NSString *currentPath = @"";
 	BOOL collapsed = NO;
 	NSUInteger currentHunkStart = NSNotFound;
 	NSUInteger currentHunkEnd = NSNotFound;
+	NSArray<NSString *> *currentHunkLines = nil;
+	NSArray<NSString *> *currentFileHeader = nil;
 	for (NSUInteger index = 0; index < lines.count; index++) {
 		NSString *line = lines[index];
 		if ([line hasPrefix:@"diff --git "]) {
 			[fileHeader removeAllObjects];
 			[fileHeader addObject:line];
-			fileKey = [self fileKeyForLine:line section:sectionIndex];
-			collapsed = [self.collapsedFiles containsObject:fileKey];
+			currentPath = [self pathForDiffHeaderAtIndex:index lines:lines];
+			fileKey = [NSString stringWithFormat:@"%lu:%@", (unsigned long)sectionIndex, currentPath];
+			collapsed = [collapsedFiles containsObject:fileKey];
 			[self appendLinkWithTitle:(collapsed ? @"▸ " : @"▾ ")
-						  payload:@{ @"type" : @"collapse", @"key" : fileKey }
-						 toString:rendered];
-			NSArray *parts = [line componentsSeparatedByString:@" "];
-			NSString *path = parts.count >= 4 ? parts[3] : line;
-			if ([path hasPrefix:@"b/"]) path = [path substringFromIndex:2];
-			currentPath = path;
-			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:[path stringByAppendingString:@"\n"] attributes:self.titleAttributes]];
+							  payload:@{@"type" : @"collapse", @"key" : fileKey}
+						 linkPayloads:linkPayloads
+							 toString:rendered];
+			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:[currentPath stringByAppendingString:@"\n"] attributes:self.titleAttributes]];
 			continue;
 		}
 		if (collapsed) continue;
 		if ([line hasPrefix:@"@@"]) {
 			NSUInteger end = index + 1;
 			while (end < lines.count && ![lines[end] hasPrefix:@"@@"] && ![lines[end] hasPrefix:@"diff --git "]) end++;
-			NSMutableArray<NSString *> *patchLines = [fileHeader mutableCopy];
-			[patchLines addObjectsFromArray:[lines subarrayWithRange:NSMakeRange(index, end - index)]];
+			currentHunkLines = [lines subarrayWithRange:NSMakeRange(index, end - index)];
+			currentFileHeader = [fileHeader copy];
+			NSMutableArray<NSString *> *patchLines = [currentFileHeader mutableCopy];
+			[patchLines addObjectsFromArray:currentHunkLines];
 			NSString *patch = [[patchLines componentsJoinedByString:@"\n"] stringByAppendingString:@"\n"];
 			currentHunkStart = index;
 			currentHunkEnd = end;
 			[self appendDiffLine:line toString:rendered];
 			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"  "]];
 			if ([context isEqualToString:@"staged"]) {
-				[self appendLinkWithTitle:@"Unstage hunk" payload:@{ @"type" : @"diff", @"action" : @"unstage", @"patch" : patch } toString:rendered];
+				[self appendLinkWithTitle:@"Unstage hunk" payload:@{@"type" : @"diff", @"action" : @"unstage", @"patch" : patch} linkPayloads:linkPayloads toString:rendered];
 			} else if ([context isEqualToString:@"unstaged"]) {
-				[self appendLinkWithTitle:@"Stage hunk" payload:@{ @"type" : @"diff", @"action" : @"stage", @"patch" : patch } toString:rendered];
+				[self appendLinkWithTitle:@"Stage hunk" payload:@{@"type" : @"diff", @"action" : @"stage", @"patch" : patch} linkPayloads:linkPayloads toString:rendered];
 				[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"   "]];
-				[self appendLinkWithTitle:@"Discard hunk" payload:@{ @"type" : @"diff", @"action" : @"discard", @"patch" : patch } toString:rendered];
+				[self appendLinkWithTitle:@"Discard hunk" payload:@{@"type" : @"diff", @"action" : @"discard", @"patch" : patch} linkPayloads:linkPayloads toString:rendered];
 			}
 			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n"]];
 			continue;
@@ -418,13 +477,12 @@ static const NSUInteger PBNativeLargePatchThreshold = 200 * 1024;
 		if (fileHeader.count && ([line hasPrefix:@"index "] || [line hasPrefix:@"new file "] || [line hasPrefix:@"deleted file "] || [line hasPrefix:@"--- "] || [line hasPrefix:@"+++ "])) {
 			[fileHeader addObject:line];
 		}
-		BOOL binaryImage = ([line hasPrefix:@"Binary files "] || [line isEqualToString:@"GIT binary patch"])
-			&& [@[ @"png", @"jpg", @"jpeg", @"gif", @"tiff", @"tif", @"bmp", @"icns", @"webp" ] containsObject:currentPath.pathExtension.lowercaseString];
+		BOOL binaryImage = ([line hasPrefix:@"Binary files "] || [line isEqualToString:@"GIT binary patch"]) && [@[ @"png", @"jpg", @"jpeg", @"gif", @"tiff", @"tif", @"bmp", @"icns", @"webp" ] containsObject:currentPath.pathExtension.lowercaseString];
 		if (binaryImage && currentPath.length) {
 			[self appendDiffLine:line toString:rendered];
 			NSString *imageKey = [NSString stringWithFormat:@"%lu:%@", (unsigned long)sectionIndex, currentPath];
-			if (![self.expandedImages containsObject:imageKey]) {
-				[self appendLinkWithTitle:@"Show image" payload:@{ @"type" : @"image", @"key" : imageKey, @"path" : currentPath, @"section" : @(sectionIndex) } toString:rendered];
+			if (![expandedImages containsObject:imageKey]) {
+				[self appendLinkWithTitle:@"Show image" payload:@{@"type" : @"image", @"key" : imageKey, @"path" : currentPath, @"section" : @(sectionIndex)} linkPayloads:linkPayloads toString:rendered];
 				[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n" attributes:self.baseAttributes]];
 			} else if ([self.delegate respondsToSelector:@selector(nativeContentView:imageForPath:section:)]) {
 				NSImage *image = [self.delegate nativeContentView:self imageForPath:currentPath section:sectionIndex];
@@ -451,12 +509,20 @@ static const NSUInteger PBNativeLargePatchThreshold = 200 * 1024;
 
 		[self appendDiffLine:line counterpart:counterpart newline:NO toString:rendered];
 		[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"   " attributes:self.baseAttributes]];
-		NSArray *hunkLines = [lines subarrayWithRange:NSMakeRange(currentHunkStart, currentHunkEnd - currentHunkStart)];
 		NSUInteger relativeIndex = index - currentHunkStart;
-		NSString *linePatch = [self patchWithFileHeader:fileHeader hunkLines:hunkLines selectedIndexes:[NSIndexSet indexSetWithIndex:relativeIndex] reverse:[context isEqualToString:@"staged"]];
+		NSIndexSet *lineIndexes = [NSIndexSet indexSetWithIndex:relativeIndex];
+		NSDictionary *linePayload = @{
+			@"type" : @"diff",
+			@"fileHeader" : currentFileHeader,
+			@"hunkLines" : currentHunkLines,
+			@"selectedIndexes" : lineIndexes,
+			@"reverse" : @([context isEqualToString:@"staged"]),
+		};
 		NSString *primaryTitle = [context isEqualToString:@"staged"] ? @"Unstage line" : @"Stage line";
 		NSString *primaryAction = [context isEqualToString:@"staged"] ? @"unstage" : @"stage";
-		if (linePatch) [self appendLinkWithTitle:primaryTitle payload:@{ @"type" : @"diff", @"action" : primaryAction, @"patch" : linePatch } toString:rendered];
+		NSMutableDictionary *primaryPayload = [linePayload mutableCopy];
+		primaryPayload[@"action"] = primaryAction;
+		[self appendLinkWithTitle:primaryTitle payload:primaryPayload linkPayloads:linkPayloads toString:rendered];
 
 		BOOL blockStart = index == currentHunkStart + 1;
 		if (!blockStart && index > currentHunkStart + 1) {
@@ -468,15 +534,17 @@ static const NSUInteger PBNativeLargePatchThreshold = 200 * 1024;
 			while (blockEnd + 1 < currentHunkEnd && ([lines[blockEnd + 1] hasPrefix:@"+"] || [lines[blockEnd + 1] hasPrefix:@"-"] || [lines[blockEnd + 1] hasPrefix:@"\\"])) blockEnd++;
 			NSMutableIndexSet *blockIndexes = [NSMutableIndexSet indexSet];
 			for (NSUInteger absolute = index; absolute <= blockEnd; absolute++) [blockIndexes addIndex:absolute - currentHunkStart];
-			NSString *blockPatch = [self patchWithFileHeader:fileHeader hunkLines:hunkLines selectedIndexes:blockIndexes reverse:[context isEqualToString:@"staged"]];
-			if (blockPatch) {
-				[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"   " attributes:self.baseAttributes]];
-				[self appendLinkWithTitle:[context isEqualToString:@"staged"] ? @"Unstage block" : @"Stage block" payload:@{ @"type" : @"diff", @"action" : primaryAction, @"patch" : blockPatch } toString:rendered];
-			}
-		}
-		if ([context isEqualToString:@"unstaged"] && linePatch) {
+			NSMutableDictionary *blockPayload = [linePayload mutableCopy];
+			blockPayload[@"action"] = primaryAction;
+			blockPayload[@"selectedIndexes"] = [blockIndexes copy];
 			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"   " attributes:self.baseAttributes]];
-			[self appendLinkWithTitle:@"Discard line" payload:@{ @"type" : @"diff", @"action" : @"discard", @"patch" : linePatch } toString:rendered];
+			[self appendLinkWithTitle:[context isEqualToString:@"staged"] ? @"Unstage block" : @"Stage block" payload:blockPayload linkPayloads:linkPayloads toString:rendered];
+		}
+		if ([context isEqualToString:@"unstaged"]) {
+			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"   " attributes:self.baseAttributes]];
+			NSMutableDictionary *discardPayload = [linePayload mutableCopy];
+			discardPayload[@"action"] = @"discard";
+			[self appendLinkWithTitle:@"Discard line" payload:discardPayload linkPayloads:linkPayloads toString:rendered];
 		}
 		[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n" attributes:self.baseAttributes]];
 	}
@@ -485,28 +553,40 @@ static const NSUInteger PBNativeLargePatchThreshold = 200 * 1024;
 - (void)showDiffSections:(NSArray<NSDictionary *> *)sections
 {
 	self.currentDiffSections = [sections copy];
-	self.renderGeneration++;
-	[self.linkPayloads removeAllObjects];
-	NSMutableAttributedString *rendered = [[NSMutableAttributedString alloc] init];
-	NSUInteger sectionIndex = 0;
-	for (NSDictionary *section in sections) {
-		NSString *title = section[PBNativeSectionTitleKey] ?: @"";
-		NSString *diff = section[PBNativeSectionTextKey] ?: @"";
-		[self appendSectionTitle:title toString:rendered];
-		NSString *largeKey = [NSString stringWithFormat:@"%lu:%lu", (unsigned long)sectionIndex, (unsigned long)diff.length];
-		if ([diff lengthOfBytesUsingEncoding:NSUTF8StringEncoding] > PBNativeLargePatchThreshold && ![self.approvedLargeSections containsObject:largeKey]) {
-			NSString *size = [NSByteCountFormatter stringFromByteCount:[diff lengthOfBytesUsingEncoding:NSUTF8StringEncoding] countStyle:NSByteCountFormatterCountStyleFile];
-			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"Patch is %@. ", size] attributes:self.baseAttributes]];
-			[self appendLinkWithTitle:@"Render patch…" payload:@{ @"type" : @"large", @"key" : largeKey } toString:rendered];
-			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n"]];
-		} else if (diff.length == 0) {
-			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"There are no differences.\n" attributes:@{ NSForegroundColorAttributeName : NSColor.secondaryLabelColor }]];
-		} else {
-			[self renderDiffText:diff context:section[PBNativeSectionContextKey] ?: @"readOnly" section:sectionIndex toString:rendered];
+	NSUInteger generation = ++self.renderGeneration;
+	NSArray *copiedSections = [sections copy];
+	NSSet<NSString *> *collapsedFiles = [self.collapsedFiles copy];
+	NSSet<NSString *> *approvedLargeSections = [self.approvedLargeSections copy];
+	NSSet<NSString *> *expandedImages = [self.expandedImages copy];
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		NSMutableAttributedString *rendered = [[NSMutableAttributedString alloc] init];
+		NSMutableDictionary<NSString *, NSDictionary *> *linkPayloads = [NSMutableDictionary dictionary];
+		NSUInteger cumulativeBytes = 0;
+		NSUInteger sectionIndex = 0;
+		for (NSDictionary *section in copiedSections) {
+			NSString *title = section[PBNativeSectionTitleKey] ?: @"";
+			NSString *diff = section[PBNativeSectionTextKey] ?: @"";
+			NSUInteger bytes = [diff lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+			[self appendSectionTitle:title toString:rendered];
+			NSString *largeKey = [NSString stringWithFormat:@"%lu:%lu", (unsigned long)sectionIndex, (unsigned long)bytes];
+			BOOL approved = [approvedLargeSections containsObject:largeKey];
+			if (!approved && cumulativeBytes + bytes > PBNativeLargePatchThreshold) {
+				NSString *size = [NSByteCountFormatter stringFromByteCount:bytes countStyle:NSByteCountFormatterCountStyleFile];
+				[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"Patch is %@ (%@ total). ", size, [NSByteCountFormatter stringFromByteCount:cumulativeBytes + bytes countStyle:NSByteCountFormatterCountStyleFile]] attributes:self.baseAttributes]];
+				[self appendLinkWithTitle:@"Render patch…" payload:@{@"type" : @"large", @"key" : largeKey} linkPayloads:linkPayloads toString:rendered];
+				[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n"]];
+			} else if (diff.length == 0) {
+				[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"There are no differences.\n" attributes:@{NSForegroundColorAttributeName : NSColor.secondaryLabelColor}]];
+			} else {
+				[self renderDiffText:diff context:section[PBNativeSectionContextKey] ?: @"readOnly" section:sectionIndex collapsedFiles:collapsedFiles expandedImages:expandedImages linkPayloads:linkPayloads toString:rendered];
+			}
+			cumulativeBytes += bytes;
+			sectionIndex++;
 		}
-		sectionIndex++;
-	}
-	[self setRenderedString:rendered generation:self.renderGeneration];
+		dispatch_async(dispatch_get_main_queue(), ^{
+			[self setRenderedString:rendered generation:generation linkPayloads:linkPayloads];
+		});
+	});
 }
 
 - (BOOL)textView:(NSTextView *)textView clickedOnLink:(id)link atIndex:(NSUInteger)charIndex
@@ -516,22 +596,31 @@ static const NSUInteger PBNativeLargePatchThreshold = 200 * 1024;
 	if (!payload) return NO;
 	NSString *type = payload[@"type"];
 	if ([type isEqualToString:@"diff"]) {
-		if ([self.delegate respondsToSelector:@selector(nativeContentView:performDiffAction:patch:)])
-			[self.delegate nativeContentView:self performDiffAction:payload[@"action"] patch:payload[@"patch"]];
+		NSString *patch = payload[@"patch"];
+		if (!patch) {
+			patch = [self patchWithFileHeader:payload[@"fileHeader"]
+									hunkLines:payload[@"hunkLines"]
+							  selectedIndexes:payload[@"selectedIndexes"]
+									  reverse:[payload[@"reverse"] boolValue]];
+		}
+		if (patch && [self.delegate respondsToSelector:@selector(nativeContentView:performDiffAction:patch:)])
+			[self.delegate nativeContentView:self performDiffAction:payload[@"action"] patch:patch];
 	} else if ([type isEqualToString:@"commit"]) {
 		if ([self.delegate respondsToSelector:@selector(nativeContentView:selectCommit:)])
 			[self.delegate nativeContentView:self selectCommit:payload[@"sha"]];
 	} else if ([type isEqualToString:@"collapse"]) {
 		NSString *fileKey = payload[@"key"];
-		if ([self.collapsedFiles containsObject:fileKey]) [self.collapsedFiles removeObject:fileKey];
-		else [self.collapsedFiles addObject:fileKey];
+		if ([self.collapsedFiles containsObject:fileKey])
+			[self.collapsedFiles removeObject:fileKey];
+		else
+			[self.collapsedFiles addObject:fileKey];
 		[self showDiffSections:self.currentDiffSections];
 	} else if ([type isEqualToString:@"large"]) {
 		NSAlert *alert = [[NSAlert alloc] init];
-		alert.messageText = @"Render large patch?";
-		alert.informativeText = @"Rendering a large patch can briefly make GitX less responsive.";
-		[alert addButtonWithTitle:@"Render"];
-		[alert addButtonWithTitle:@"Cancel"];
+		alert.messageText = NSLocalizedString(@"Render large patch?", @"Large patch confirmation title");
+		alert.informativeText = NSLocalizedString(@"Rendering a large patch can briefly make GitX less responsive.", @"Large patch confirmation detail");
+		[alert addButtonWithTitle:NSLocalizedString(@"Render", @"Render a large patch button")];
+		[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"Cancel button")];
 		void (^completion)(NSModalResponse) = ^(NSModalResponse response) {
 			if (response == NSAlertFirstButtonReturn) {
 				[self.approvedLargeSections addObject:payload[@"key"]];

--- a/Classes/Views/PBNativeContentView.m
+++ b/Classes/Views/PBNativeContentView.m
@@ -1,0 +1,560 @@
+#import "PBNativeContentView.h"
+#import "PBHighlighting.h"
+
+NSString *const PBNativeSectionTitleKey = @"title";
+NSString *const PBNativeSectionTextKey = @"text";
+NSString *const PBNativeSectionPathKey = @"path";
+NSString *const PBNativeSectionContextKey = @"context";
+NSString *const PBNativeSectionEntriesKey = @"entries";
+
+static const NSUInteger PBNativeLargePatchThreshold = 200 * 1024;
+
+@interface PBNativeContentView ()
+@property (nonatomic) NSStackView *rootStack;
+@property (nonatomic) NSScrollView *scrollView;
+@property (nonatomic, readwrite) NSTextView *textView;
+@property (nonatomic) NSView *accessoryView;
+@property (nonatomic) NSMutableDictionary<NSString *, NSDictionary *> *linkPayloads;
+@property (nonatomic) NSMutableSet<NSString *> *collapsedFiles;
+@property (nonatomic) NSMutableSet<NSString *> *approvedLargeSections;
+@property (nonatomic) NSMutableSet<NSString *> *expandedImages;
+@property (nonatomic) NSArray<NSDictionary *> *currentDiffSections;
+@property (nonatomic) NSUInteger renderGeneration;
+@end
+
+@implementation PBNativeContentView
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+	self = [super initWithFrame:frameRect];
+	if (!self) return nil;
+
+	self.translatesAutoresizingMaskIntoConstraints = NO;
+	_linkPayloads = [NSMutableDictionary dictionary];
+	_collapsedFiles = [NSMutableSet set];
+	_approvedLargeSections = [NSMutableSet set];
+	_expandedImages = [NSMutableSet set];
+
+	_rootStack = [[NSStackView alloc] initWithFrame:NSZeroRect];
+	_rootStack.translatesAutoresizingMaskIntoConstraints = NO;
+	_rootStack.orientation = NSUserInterfaceLayoutOrientationVertical;
+	_rootStack.alignment = NSLayoutAttributeLeading;
+	_rootStack.spacing = 0;
+	[self addSubview:_rootStack];
+
+	_scrollView = [[NSScrollView alloc] initWithFrame:NSZeroRect];
+	_scrollView.translatesAutoresizingMaskIntoConstraints = NO;
+	_scrollView.hasVerticalScroller = YES;
+	_scrollView.hasHorizontalScroller = YES;
+	_scrollView.autohidesScrollers = YES;
+	_scrollView.borderType = NSNoBorder;
+	_scrollView.drawsBackground = YES;
+	_scrollView.backgroundColor = NSColor.textBackgroundColor;
+
+	NSTextStorage *storage = [[NSTextStorage alloc] init];
+	NSLayoutManager *layout = [[NSLayoutManager alloc] init];
+	[storage addLayoutManager:layout];
+	NSTextContainer *container = [[NSTextContainer alloc] initWithContainerSize:NSMakeSize(CGFLOAT_MAX, CGFLOAT_MAX)];
+	container.widthTracksTextView = NO;
+	container.heightTracksTextView = NO;
+	[layout addTextContainer:container];
+	_textView = [[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, 1000, 1000) textContainer:container];
+	_textView.minSize = NSMakeSize(0, 0);
+	_textView.maxSize = NSMakeSize(CGFLOAT_MAX, CGFLOAT_MAX);
+	_textView.verticallyResizable = YES;
+	_textView.horizontallyResizable = YES;
+	_textView.autoresizingMask = NSViewWidthSizable;
+	_textView.textContainerInset = NSMakeSize(12, 12);
+	_textView.editable = NO;
+	_textView.selectable = YES;
+	_textView.richText = YES;
+	_textView.automaticLinkDetectionEnabled = NO;
+	_textView.delegate = self;
+	_textView.backgroundColor = NSColor.textBackgroundColor;
+	_textView.textColor = NSColor.textColor;
+	_scrollView.documentView = _textView;
+	[_rootStack addArrangedSubview:_scrollView];
+
+	[NSLayoutConstraint activateConstraints:@[
+		[_rootStack.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+		[_rootStack.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+		[_rootStack.topAnchor constraintEqualToAnchor:self.topAnchor],
+		[_rootStack.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
+		[_scrollView.widthAnchor constraintEqualToAnchor:_rootStack.widthAnchor],
+	]];
+
+	return self;
+}
+
+- (NSDictionary *)baseAttributes
+{
+	return @{ NSFontAttributeName : [NSFont monospacedSystemFontOfSize:12 weight:NSFontWeightRegular],
+			  NSForegroundColorAttributeName : NSColor.textColor };
+}
+
+- (NSDictionary *)titleAttributes
+{
+	return @{ NSFontAttributeName : [NSFont systemFontOfSize:13 weight:NSFontWeightSemibold],
+			  NSForegroundColorAttributeName : NSColor.labelColor };
+}
+
+- (void)setAccessoryView:(NSView *)accessoryView
+{
+	if (_accessoryView == accessoryView) return;
+	if (_accessoryView) [_rootStack removeArrangedSubview:_accessoryView];
+	[_accessoryView removeFromSuperview];
+	_accessoryView = accessoryView;
+	if (!accessoryView) return;
+	accessoryView.translatesAutoresizingMaskIntoConstraints = NO;
+	[_rootStack insertArrangedSubview:accessoryView atIndex:0];
+	[accessoryView.widthAnchor constraintEqualToAnchor:_rootStack.widthAnchor].active = YES;
+}
+
+- (void)setRenderedString:(NSAttributedString *)string generation:(NSUInteger)generation
+{
+	if (generation != self.renderGeneration) return;
+	[self.textView.textStorage setAttributedString:string];
+	[self.textView scrollRangeToVisible:NSMakeRange(0, 0)];
+}
+
+- (void)showMessage:(NSString *)message
+{
+	self.renderGeneration++;
+	[self.linkPayloads removeAllObjects];
+	NSAttributedString *string = [[NSAttributedString alloc] initWithString:message ?: @"" attributes:@{
+		NSFontAttributeName : [NSFont systemFontOfSize:13],
+		NSForegroundColorAttributeName : NSColor.secondaryLabelColor,
+	}];
+	[self setRenderedString:string generation:self.renderGeneration];
+}
+
+- (void)appendSectionTitle:(NSString *)title toString:(NSMutableAttributedString *)result
+{
+	if (title.length == 0) return;
+	if (result.length) [result appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n\n"]];
+	[result appendAttributedString:[[NSAttributedString alloc] initWithString:[title stringByAppendingString:@"\n"] attributes:self.titleAttributes]];
+}
+
+- (void)showSourceSections:(NSArray<NSDictionary *> *)sections
+{
+	NSUInteger generation = ++self.renderGeneration;
+	[self.linkPayloads removeAllObjects];
+	NSArray *copiedSections = [sections copy];
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		NSMutableAttributedString *rendered = [[NSMutableAttributedString alloc] init];
+		for (NSDictionary *section in copiedSections) {
+			NSString *title = section[PBNativeSectionTitleKey] ?: section[PBNativeSectionPathKey] ?: @"";
+			NSString *path = section[PBNativeSectionPathKey] ?: title;
+			NSString *text = section[PBNativeSectionTextKey] ?: @"";
+			[self appendSectionTitle:title toString:rendered];
+			[rendered appendAttributedString:[PBHighlighting highlightedStringForText:text path:path]];
+		}
+		dispatch_async(dispatch_get_main_queue(), ^{
+			[self setRenderedString:rendered generation:generation];
+		});
+	});
+}
+
+- (NSArray<NSDictionary *> *)blameLinesFromPorcelain:(NSString *)porcelain
+{
+	NSArray<NSString *> *lines = [porcelain componentsSeparatedByString:@"\n"];
+	NSMutableDictionary<NSString *, NSDictionary *> *metadata = [NSMutableDictionary dictionary];
+	NSMutableArray<NSDictionary *> *result = [NSMutableArray array];
+	NSString *sha = @"";
+	NSString *author = @"";
+	NSString *summary = @"";
+	for (NSString *line in lines) {
+		NSArray<NSString *> *parts = [line componentsSeparatedByString:@" "];
+		if (parts.count >= 3 && [parts.firstObject length] == 40) {
+			sha = parts.firstObject;
+			NSDictionary *cached = metadata[sha];
+			if (cached) {
+				author = cached[@"author"] ?: @"";
+				summary = cached[@"summary"] ?: @"";
+			}
+		} else if ([line hasPrefix:@"author "]) {
+			author = [line substringFromIndex:7];
+		} else if ([line hasPrefix:@"summary "]) {
+			summary = [line substringFromIndex:8];
+			if (sha.length) metadata[sha] = @{ @"author" : author ?: @"", @"summary" : summary ?: @"" };
+		} else if ([line hasPrefix:@"\t"]) {
+			[result addObject:@{ @"sha" : sha ?: @"", @"author" : author ?: @"", @"summary" : summary ?: @"", @"code" : [line substringFromIndex:1] }];
+		}
+	}
+	return result;
+}
+
+- (void)showBlameSections:(NSArray<NSDictionary *> *)sections
+{
+	NSUInteger generation = ++self.renderGeneration;
+	[self.linkPayloads removeAllObjects];
+	NSArray *copiedSections = [sections copy];
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		NSMutableAttributedString *rendered = [[NSMutableAttributedString alloc] init];
+		for (NSDictionary *section in copiedSections) {
+			NSString *title = section[PBNativeSectionTitleKey] ?: section[PBNativeSectionPathKey] ?: @"";
+			NSString *path = section[PBNativeSectionPathKey] ?: title;
+			NSArray<NSDictionary *> *records = [self blameLinesFromPorcelain:section[PBNativeSectionTextKey] ?: @""];
+			NSMutableString *code = [NSMutableString string];
+			for (NSDictionary *record in records) [code appendFormat:@"%@\n", record[@"code"] ?: @""];
+			NSAttributedString *highlighted = [PBHighlighting highlightedStringForText:code path:path];
+			[self appendSectionTitle:title toString:rendered];
+			NSUInteger codeLocation = 0;
+			for (NSDictionary *record in records) {
+				NSString *line = [NSString stringWithFormat:@"%@\n", record[@"code"] ?: @""];
+				NSString *fullSHA = record[@"sha"] ?: @"";
+				NSString *shortSHA = fullSHA.length >= 8 ? [fullSHA substringToIndex:8] : fullSHA;
+				NSString *author = record[@"author"] ?: @"";
+				if (author.length > 18) author = [[author substringToIndex:17] stringByAppendingString:@"…"];
+				NSString *gutter = [NSString stringWithFormat:@"%-8@  %-18@ │ ", shortSHA, author];
+				[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:gutter attributes:@{
+					NSFontAttributeName : [NSFont monospacedSystemFontOfSize:11 weight:NSFontWeightRegular],
+					NSForegroundColorAttributeName : NSColor.secondaryLabelColor,
+					NSBackgroundColorAttributeName : NSColor.controlBackgroundColor,
+				}]];
+				if (codeLocation + line.length <= highlighted.length) {
+					[rendered appendAttributedString:[highlighted attributedSubstringFromRange:NSMakeRange(codeLocation, line.length)]];
+				} else {
+					[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:line attributes:self.baseAttributes]];
+				}
+				codeLocation += line.length;
+			}
+		}
+		dispatch_async(dispatch_get_main_queue(), ^{
+			[self setRenderedString:rendered generation:generation];
+		});
+	});
+}
+
+- (NSURL *)appendLinkWithTitle:(NSString *)title payload:(NSDictionary *)payload toString:(NSMutableAttributedString *)result
+{
+	NSString *token = NSUUID.UUID.UUIDString;
+	NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"gitx-action://%@", token]];
+	self.linkPayloads[URL.absoluteString] = payload;
+	NSMutableAttributedString *link = [[NSMutableAttributedString alloc] initWithString:title attributes:@{
+		NSFontAttributeName : [NSFont systemFontOfSize:11 weight:NSFontWeightMedium],
+		NSLinkAttributeName : URL,
+		NSForegroundColorAttributeName : NSColor.linkColor,
+		NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle),
+	}];
+	[result appendAttributedString:link];
+	return URL;
+}
+
+- (void)showHistorySections:(NSArray<NSDictionary *> *)sections
+{
+	self.renderGeneration++;
+	[self.linkPayloads removeAllObjects];
+	NSMutableAttributedString *rendered = [[NSMutableAttributedString alloc] init];
+	for (NSDictionary *section in sections) {
+		[self appendSectionTitle:section[PBNativeSectionTitleKey] ?: section[PBNativeSectionPathKey] ?: @"" toString:rendered];
+		for (NSDictionary *entry in section[PBNativeSectionEntriesKey] ?: @[]) {
+			NSString *subject = entry[@"subject"] ?: @"";
+			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:[subject stringByAppendingString:@"\n"] attributes:self.titleAttributes]];
+			NSString *detail = [NSString stringWithFormat:@"%@  •  %@  •  ", entry[@"author"] ?: @"", entry[@"date"] ?: @""];
+			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:detail attributes:@{
+				NSFontAttributeName : [NSFont systemFontOfSize:11],
+				NSForegroundColorAttributeName : NSColor.secondaryLabelColor,
+			}]];
+			NSString *sha = entry[@"sha"] ?: @"";
+			[self appendLinkWithTitle:(sha.length > 12 ? [sha substringToIndex:12] : sha)
+						  payload:@{ @"type" : @"commit", @"sha" : sha }
+						 toString:rendered];
+			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n\n"]];
+		}
+	}
+	[self setRenderedString:rendered generation:self.renderGeneration];
+}
+
+- (NSString *)fileKeyForLine:(NSString *)line section:(NSUInteger)sectionIndex
+{
+	NSArray<NSString *> *parts = [line componentsSeparatedByString:@" "];
+	NSString *path = parts.count >= 4 ? parts[3] : line;
+	if ([path hasPrefix:@"b/"]) path = [path substringFromIndex:2];
+	return [NSString stringWithFormat:@"%lu:%@", (unsigned long)sectionIndex, path];
+}
+
+- (NSMutableAttributedString *)attributedDiffLine:(NSString *)line counterpart:(nullable NSString *)counterpart
+{
+	NSMutableDictionary *attributes = [self.baseAttributes mutableCopy];
+	if ([line hasPrefix:@"+"] && ![line hasPrefix:@"+++"]) {
+		attributes[NSForegroundColorAttributeName] = [NSColor colorWithRed:0.08 green:0.46 blue:0.18 alpha:1];
+		attributes[NSBackgroundColorAttributeName] = [NSColor colorWithRed:0.20 green:0.70 blue:0.30 alpha:0.13];
+	} else if ([line hasPrefix:@"-"] && ![line hasPrefix:@"---"]) {
+		attributes[NSForegroundColorAttributeName] = [NSColor colorWithRed:0.72 green:0.12 blue:0.13 alpha:1];
+		attributes[NSBackgroundColorAttributeName] = [NSColor colorWithRed:0.90 green:0.20 blue:0.20 alpha:0.12];
+	} else if ([line hasPrefix:@"@@"]) {
+		attributes[NSForegroundColorAttributeName] = NSColor.systemBlueColor;
+		attributes[NSBackgroundColorAttributeName] = [NSColor colorWithRed:0.20 green:0.45 blue:0.90 alpha:0.10];
+	} else if ([line hasPrefix:@"index "] || [line hasPrefix:@"--- "] || [line hasPrefix:@"+++ "]) {
+		attributes[NSForegroundColorAttributeName] = NSColor.secondaryLabelColor;
+	}
+	NSMutableAttributedString *result = [[NSMutableAttributedString alloc] initWithString:line attributes:attributes];
+	if (counterpart.length > 1 && line.length > 1) {
+		NSString *left = [line substringFromIndex:1];
+		NSString *right = [counterpart substringFromIndex:1];
+		NSUInteger prefix = 0;
+		NSUInteger limit = MIN(left.length, right.length);
+		while (prefix < limit && [left characterAtIndex:prefix] == [right characterAtIndex:prefix]) prefix++;
+		NSUInteger suffix = 0;
+		while (suffix < limit - prefix && [left characterAtIndex:left.length - 1 - suffix] == [right characterAtIndex:right.length - 1 - suffix]) suffix++;
+		NSUInteger changedLength = left.length - prefix - suffix;
+		if (changedLength) {
+			NSColor *emphasis = [line hasPrefix:@"+"]
+				? [NSColor colorWithRed:0.15 green:0.66 blue:0.25 alpha:0.30]
+				: [NSColor colorWithRed:0.90 green:0.18 blue:0.18 alpha:0.27];
+			[result addAttribute:NSBackgroundColorAttributeName value:emphasis range:NSMakeRange(1 + prefix, changedLength)];
+		}
+	}
+	return result;
+}
+
+- (void)appendDiffLine:(NSString *)line counterpart:(nullable NSString *)counterpart newline:(BOOL)newline toString:(NSMutableAttributedString *)rendered
+{
+	[rendered appendAttributedString:[self attributedDiffLine:line counterpart:counterpart]];
+	if (newline) [rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n" attributes:self.baseAttributes]];
+}
+
+- (void)appendDiffLine:(NSString *)line toString:(NSMutableAttributedString *)rendered
+{
+	[self appendDiffLine:line counterpart:nil newline:YES toString:rendered];
+}
+
+- (nullable NSString *)patchWithFileHeader:(NSArray<NSString *> *)fileHeader
+							 hunkLines:(NSArray<NSString *> *)hunkLines
+						selectedIndexes:(NSIndexSet *)selectedIndexes
+							   reverse:(BOOL)reverse
+{
+	if (hunkLines.count < 2 || ![hunkLines.firstObject hasPrefix:@"@@"]) return nil;
+	NSRegularExpression *expression = [NSRegularExpression regularExpressionWithPattern:@"^@@ -(\\d+)(?:,\\d+)? \\+(\\d+)(?:,\\d+)? @@(.*)$" options:0 error:nil];
+	NSTextCheckingResult *match = [expression firstMatchInString:hunkLines.firstObject options:0 range:NSMakeRange(0, hunkLines.firstObject.length)];
+	if (!match || match.numberOfRanges < 4) return nil;
+	NSString *oldStart = [hunkLines.firstObject substringWithRange:[match rangeAtIndex:1]];
+	NSString *newStart = [hunkLines.firstObject substringWithRange:[match rangeAtIndex:2]];
+	NSString *suffix = [hunkLines.firstObject substringWithRange:[match rangeAtIndex:3]];
+
+	NSMutableArray<NSString *> *body = [NSMutableArray array];
+	NSUInteger oldCount = 0;
+	NSUInteger newCount = 0;
+	for (NSUInteger index = 1; index < hunkLines.count; index++) {
+		NSString *line = hunkLines[index];
+		if (!line.length) continue;
+		unichar prefix = [line characterAtIndex:0];
+		BOOL marker = prefix == '\\';
+		BOOL selected = [selectedIndexes containsIndex:index];
+		if (marker && index > 0 && [selectedIndexes containsIndex:index - 1]) selected = YES;
+		if (!selected) {
+			unichar contextualChange = reverse ? '+' : '-';
+			unichar omittedChange = reverse ? '-' : '+';
+			if (prefix == contextualChange) {
+				line = [@" " stringByAppendingString:[line substringFromIndex:1]];
+				prefix = ' ';
+			}
+			if (prefix == omittedChange) continue;
+		}
+		[body addObject:line];
+		if (marker) continue;
+		if (prefix == '-') oldCount++;
+		else if (prefix == '+') newCount++;
+		else { oldCount++; newCount++; }
+	}
+	if (!oldCount && !newCount) return nil;
+	NSMutableArray<NSString *> *patch = [fileHeader mutableCopy];
+	[patch addObject:[NSString stringWithFormat:@"@@ -%@,%lu +%@,%lu @@%@", oldStart, (unsigned long)oldCount, newStart, (unsigned long)newCount, suffix]];
+	[patch addObjectsFromArray:body];
+	return [[[patch componentsJoinedByString:@"\n"] stringByAppendingString:@"\n"] copy];
+}
+
+- (void)renderDiffText:(NSString *)diff
+				 context:(NSString *)context
+			 section:(NSUInteger)sectionIndex
+			  toString:(NSMutableAttributedString *)rendered
+{
+	NSArray<NSString *> *lines = [diff componentsSeparatedByString:@"\n"];
+	NSMutableArray<NSString *> *fileHeader = [NSMutableArray array];
+	NSString *fileKey = [NSString stringWithFormat:@"%lu:patch", (unsigned long)sectionIndex];
+	NSString *currentPath = @"";
+	BOOL collapsed = NO;
+	NSUInteger currentHunkStart = NSNotFound;
+	NSUInteger currentHunkEnd = NSNotFound;
+	for (NSUInteger index = 0; index < lines.count; index++) {
+		NSString *line = lines[index];
+		if ([line hasPrefix:@"diff --git "]) {
+			[fileHeader removeAllObjects];
+			[fileHeader addObject:line];
+			fileKey = [self fileKeyForLine:line section:sectionIndex];
+			collapsed = [self.collapsedFiles containsObject:fileKey];
+			[self appendLinkWithTitle:(collapsed ? @"▸ " : @"▾ ")
+						  payload:@{ @"type" : @"collapse", @"key" : fileKey }
+						 toString:rendered];
+			NSArray *parts = [line componentsSeparatedByString:@" "];
+			NSString *path = parts.count >= 4 ? parts[3] : line;
+			if ([path hasPrefix:@"b/"]) path = [path substringFromIndex:2];
+			currentPath = path;
+			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:[path stringByAppendingString:@"\n"] attributes:self.titleAttributes]];
+			continue;
+		}
+		if (collapsed) continue;
+		if ([line hasPrefix:@"@@"]) {
+			NSUInteger end = index + 1;
+			while (end < lines.count && ![lines[end] hasPrefix:@"@@"] && ![lines[end] hasPrefix:@"diff --git "]) end++;
+			NSMutableArray<NSString *> *patchLines = [fileHeader mutableCopy];
+			[patchLines addObjectsFromArray:[lines subarrayWithRange:NSMakeRange(index, end - index)]];
+			NSString *patch = [[patchLines componentsJoinedByString:@"\n"] stringByAppendingString:@"\n"];
+			currentHunkStart = index;
+			currentHunkEnd = end;
+			[self appendDiffLine:line toString:rendered];
+			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"  "]];
+			if ([context isEqualToString:@"staged"]) {
+				[self appendLinkWithTitle:@"Unstage hunk" payload:@{ @"type" : @"diff", @"action" : @"unstage", @"patch" : patch } toString:rendered];
+			} else if ([context isEqualToString:@"unstaged"]) {
+				[self appendLinkWithTitle:@"Stage hunk" payload:@{ @"type" : @"diff", @"action" : @"stage", @"patch" : patch } toString:rendered];
+				[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"   "]];
+				[self appendLinkWithTitle:@"Discard hunk" payload:@{ @"type" : @"diff", @"action" : @"discard", @"patch" : patch } toString:rendered];
+			}
+			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n"]];
+			continue;
+		}
+		if (fileHeader.count && ([line hasPrefix:@"index "] || [line hasPrefix:@"new file "] || [line hasPrefix:@"deleted file "] || [line hasPrefix:@"--- "] || [line hasPrefix:@"+++ "])) {
+			[fileHeader addObject:line];
+		}
+		BOOL binaryImage = ([line hasPrefix:@"Binary files "] || [line isEqualToString:@"GIT binary patch"])
+			&& [@[ @"png", @"jpg", @"jpeg", @"gif", @"tiff", @"tif", @"bmp", @"icns", @"webp" ] containsObject:currentPath.pathExtension.lowercaseString];
+		if (binaryImage && currentPath.length) {
+			[self appendDiffLine:line toString:rendered];
+			NSString *imageKey = [NSString stringWithFormat:@"%lu:%@", (unsigned long)sectionIndex, currentPath];
+			if (![self.expandedImages containsObject:imageKey]) {
+				[self appendLinkWithTitle:@"Show image" payload:@{ @"type" : @"image", @"key" : imageKey, @"path" : currentPath, @"section" : @(sectionIndex) } toString:rendered];
+				[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n" attributes:self.baseAttributes]];
+			} else if ([self.delegate respondsToSelector:@selector(nativeContentView:imageForPath:section:)]) {
+				NSImage *image = [self.delegate nativeContentView:self imageForPath:currentPath section:sectionIndex];
+				if (image) {
+					NSSize size = image.size;
+					CGFloat scale = MIN(1.0, MIN(800.0 / MAX(1.0, size.width), 500.0 / MAX(1.0, size.height)));
+					image.size = NSMakeSize(size.width * scale, size.height * scale);
+					NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
+					attachment.image = image;
+					[rendered appendAttributedString:[NSAttributedString attributedStringWithAttachment:attachment]];
+					[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n" attributes:self.baseAttributes]];
+				}
+			}
+			continue;
+		}
+		BOOL changedLine = ([line hasPrefix:@"+"] && ![line hasPrefix:@"+++"]) || ([line hasPrefix:@"-"] && ![line hasPrefix:@"---"]);
+		NSString *counterpart = nil;
+		if ([line hasPrefix:@"-"] && index + 1 < lines.count && [lines[index + 1] hasPrefix:@"+"]) counterpart = lines[index + 1];
+		else if ([line hasPrefix:@"+"] && index > 0 && [lines[index - 1] hasPrefix:@"-"]) counterpart = lines[index - 1];
+		if (!changedLine || [context isEqualToString:@"readOnly"] || currentHunkStart == NSNotFound) {
+			[self appendDiffLine:line counterpart:counterpart newline:YES toString:rendered];
+			continue;
+		}
+
+		[self appendDiffLine:line counterpart:counterpart newline:NO toString:rendered];
+		[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"   " attributes:self.baseAttributes]];
+		NSArray *hunkLines = [lines subarrayWithRange:NSMakeRange(currentHunkStart, currentHunkEnd - currentHunkStart)];
+		NSUInteger relativeIndex = index - currentHunkStart;
+		NSString *linePatch = [self patchWithFileHeader:fileHeader hunkLines:hunkLines selectedIndexes:[NSIndexSet indexSetWithIndex:relativeIndex] reverse:[context isEqualToString:@"staged"]];
+		NSString *primaryTitle = [context isEqualToString:@"staged"] ? @"Unstage line" : @"Stage line";
+		NSString *primaryAction = [context isEqualToString:@"staged"] ? @"unstage" : @"stage";
+		if (linePatch) [self appendLinkWithTitle:primaryTitle payload:@{ @"type" : @"diff", @"action" : primaryAction, @"patch" : linePatch } toString:rendered];
+
+		BOOL blockStart = index == currentHunkStart + 1;
+		if (!blockStart && index > currentHunkStart + 1) {
+			NSString *previous = lines[index - 1];
+			blockStart = ![previous hasPrefix:@"+"] && ![previous hasPrefix:@"-"];
+		}
+		if (blockStart) {
+			NSUInteger blockEnd = index;
+			while (blockEnd + 1 < currentHunkEnd && ([lines[blockEnd + 1] hasPrefix:@"+"] || [lines[blockEnd + 1] hasPrefix:@"-"] || [lines[blockEnd + 1] hasPrefix:@"\\"])) blockEnd++;
+			NSMutableIndexSet *blockIndexes = [NSMutableIndexSet indexSet];
+			for (NSUInteger absolute = index; absolute <= blockEnd; absolute++) [blockIndexes addIndex:absolute - currentHunkStart];
+			NSString *blockPatch = [self patchWithFileHeader:fileHeader hunkLines:hunkLines selectedIndexes:blockIndexes reverse:[context isEqualToString:@"staged"]];
+			if (blockPatch) {
+				[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"   " attributes:self.baseAttributes]];
+				[self appendLinkWithTitle:[context isEqualToString:@"staged"] ? @"Unstage block" : @"Stage block" payload:@{ @"type" : @"diff", @"action" : primaryAction, @"patch" : blockPatch } toString:rendered];
+			}
+		}
+		if ([context isEqualToString:@"unstaged"] && linePatch) {
+			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"   " attributes:self.baseAttributes]];
+			[self appendLinkWithTitle:@"Discard line" payload:@{ @"type" : @"diff", @"action" : @"discard", @"patch" : linePatch } toString:rendered];
+		}
+		[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n" attributes:self.baseAttributes]];
+	}
+}
+
+- (void)showDiffSections:(NSArray<NSDictionary *> *)sections
+{
+	self.currentDiffSections = [sections copy];
+	self.renderGeneration++;
+	[self.linkPayloads removeAllObjects];
+	NSMutableAttributedString *rendered = [[NSMutableAttributedString alloc] init];
+	NSUInteger sectionIndex = 0;
+	for (NSDictionary *section in sections) {
+		NSString *title = section[PBNativeSectionTitleKey] ?: @"";
+		NSString *diff = section[PBNativeSectionTextKey] ?: @"";
+		[self appendSectionTitle:title toString:rendered];
+		NSString *largeKey = [NSString stringWithFormat:@"%lu:%lu", (unsigned long)sectionIndex, (unsigned long)diff.length];
+		if ([diff lengthOfBytesUsingEncoding:NSUTF8StringEncoding] > PBNativeLargePatchThreshold && ![self.approvedLargeSections containsObject:largeKey]) {
+			NSString *size = [NSByteCountFormatter stringFromByteCount:[diff lengthOfBytesUsingEncoding:NSUTF8StringEncoding] countStyle:NSByteCountFormatterCountStyleFile];
+			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"Patch is %@. ", size] attributes:self.baseAttributes]];
+			[self appendLinkWithTitle:@"Render patch…" payload:@{ @"type" : @"large", @"key" : largeKey } toString:rendered];
+			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n"]];
+		} else if (diff.length == 0) {
+			[rendered appendAttributedString:[[NSAttributedString alloc] initWithString:@"There are no differences.\n" attributes:@{ NSForegroundColorAttributeName : NSColor.secondaryLabelColor }]];
+		} else {
+			[self renderDiffText:diff context:section[PBNativeSectionContextKey] ?: @"readOnly" section:sectionIndex toString:rendered];
+		}
+		sectionIndex++;
+	}
+	[self setRenderedString:rendered generation:self.renderGeneration];
+}
+
+- (BOOL)textView:(NSTextView *)textView clickedOnLink:(id)link atIndex:(NSUInteger)charIndex
+{
+	NSString *key = [link isKindOfClass:NSURL.class] ? [link absoluteString] : [link description];
+	NSDictionary *payload = self.linkPayloads[key];
+	if (!payload) return NO;
+	NSString *type = payload[@"type"];
+	if ([type isEqualToString:@"diff"]) {
+		if ([self.delegate respondsToSelector:@selector(nativeContentView:performDiffAction:patch:)])
+			[self.delegate nativeContentView:self performDiffAction:payload[@"action"] patch:payload[@"patch"]];
+	} else if ([type isEqualToString:@"commit"]) {
+		if ([self.delegate respondsToSelector:@selector(nativeContentView:selectCommit:)])
+			[self.delegate nativeContentView:self selectCommit:payload[@"sha"]];
+	} else if ([type isEqualToString:@"collapse"]) {
+		NSString *fileKey = payload[@"key"];
+		if ([self.collapsedFiles containsObject:fileKey]) [self.collapsedFiles removeObject:fileKey];
+		else [self.collapsedFiles addObject:fileKey];
+		[self showDiffSections:self.currentDiffSections];
+	} else if ([type isEqualToString:@"large"]) {
+		NSAlert *alert = [[NSAlert alloc] init];
+		alert.messageText = @"Render large patch?";
+		alert.informativeText = @"Rendering a large patch can briefly make GitX less responsive.";
+		[alert addButtonWithTitle:@"Render"];
+		[alert addButtonWithTitle:@"Cancel"];
+		void (^completion)(NSModalResponse) = ^(NSModalResponse response) {
+			if (response == NSAlertFirstButtonReturn) {
+				[self.approvedLargeSections addObject:payload[@"key"]];
+				[self showDiffSections:self.currentDiffSections];
+			}
+		};
+		if (self.window) [alert beginSheetModalForWindow:self.window completionHandler:completion];
+		else completion([alert runModal]);
+	} else if ([type isEqualToString:@"image"]) {
+		[self.expandedImages addObject:payload[@"key"]];
+		[self showDiffSections:self.currentDiffSections];
+	}
+	return YES;
+}
+
+- (void)scrollPageUp
+{
+	[self.textView scrollPageUp:self];
+}
+
+- (void)scrollPageDown
+{
+	[self.textView scrollPageDown:self];
+}
+
+@end

--- a/Classes/git/PBGitBinary.m
+++ b/Classes/git/PBGitBinary.m
@@ -50,7 +50,7 @@ static NSString *gitPath = nil;
 	if (!version)
 		return NO;
 
-	int c = [version compare:@"" MIN_GIT_VERSION options:NSNumericSearch];
+	NSComparisonResult c = [version compare:@"" MIN_GIT_VERSION options:NSNumericSearch];
 	if (c == NSOrderedSame || c == NSOrderedDescending) {
 		gitPath = path;
 		return YES;

--- a/Classes/git/PBGitCommit.h
+++ b/Classes/git/PBGitCommit.h
@@ -35,7 +35,7 @@ extern NSString *const kGitXCommitType;
 @property (nonatomic, strong, readonly) NSString *committerEmail;
 @property (nonatomic, strong, readonly) NSString *committerDate;
 @property (nonatomic, strong, readonly) NSString *details;
-@property (nonatomic, strong, readonly) NSString *patch;
+@property (nonatomic, strong, readonly, nullable) NSString *patch;
 @property (nonatomic, strong, readonly) NSString *SHA;
 @property (nonatomic, strong, readonly, nullable) NSString *SVNRevision;
 

--- a/Classes/git/PBGitDefaults.h
+++ b/Classes/git/PBGitDefaults.h
@@ -7,6 +7,17 @@
 //
 
 #define kDialogAcceptDroppedRef @"Accept Dropped Ref"
+
+typedef NS_ENUM(NSInteger, PBAutoFetchScope) {
+	PBAutoFetchScopeNone = 0,
+	PBAutoFetchScopeActiveRepository = 1,
+	PBAutoFetchScopeOpenRepositories = 2,
+	PBAutoFetchScopeOpenAndRecentRepositories = 3,
+};
+
+extern NSString *const PBGitHistorySortingPreferenceDidChangeNotification;
+extern NSString *const PBAutoFetchPreferencesDidChangeNotification;
+
 @interface PBGitDefaults : NSObject {
 }
 
@@ -30,6 +41,14 @@
 + (void)setHistorySearchMode:(NSInteger)mode;
 + (BOOL)useRepositoryWatcher;
 + (NSString *)terminalHandler;
++ (BOOL)historyColumnSortingEnabled;
++ (void)setHistoryColumnSortingEnabled:(BOOL)enabled;
++ (PBAutoFetchScope)autoFetchScope;
++ (void)setAutoFetchScope:(PBAutoFetchScope)scope;
++ (NSInteger)autoFetchIntervalMinutes;
++ (void)setAutoFetchIntervalMinutes:(NSInteger)minutes;
++ (BOOL)notifyAboutFetchedCommitsForRepositoryURL:(NSURL *)repositoryURL;
++ (void)setNotifyAboutFetchedCommits:(BOOL)enabled forRepositoryURL:(NSURL *)repositoryURL;
 
 
 // Suppressed Dialog Warnings

--- a/Classes/git/PBGitDefaults.h
+++ b/Classes/git/PBGitDefaults.h
@@ -15,8 +15,15 @@ typedef NS_ENUM(NSInteger, PBAutoFetchScope) {
 	PBAutoFetchScopeOpenAndRecentRepositories = 3,
 };
 
+typedef NS_ENUM(NSInteger, PBAppearancePreference) {
+	PBAppearancePreferenceAutomatic = 0,
+	PBAppearancePreferenceLight = 1,
+	PBAppearancePreferenceDark = 2,
+};
+
 extern NSString *const PBGitHistorySortingPreferenceDidChangeNotification;
 extern NSString *const PBAutoFetchPreferencesDidChangeNotification;
+extern NSString *const PBAppearancePreferenceDidChangeNotification;
 
 @interface PBGitDefaults : NSObject {
 }
@@ -41,6 +48,8 @@ extern NSString *const PBAutoFetchPreferencesDidChangeNotification;
 + (void)setHistorySearchMode:(NSInteger)mode;
 + (BOOL)useRepositoryWatcher;
 + (NSString *)terminalHandler;
++ (PBAppearancePreference)appearancePreference;
++ (void)setAppearancePreference:(PBAppearancePreference)preference;
 + (BOOL)historyColumnSortingEnabled;
 + (void)setHistoryColumnSortingEnabled:(BOOL)enabled;
 + (PBAutoFetchScope)autoFetchScope;

--- a/Classes/git/PBGitDefaults.m
+++ b/Classes/git/PBGitDefaults.m
@@ -31,6 +31,13 @@
 #define kSuppressedDialogWarnings @"Suppressed Dialog Warnings"
 #define kUseRepositoryWatcher @"PBUseRepositoryWatcher"
 #define kTerminalHandler @"PBTerminalHandler"
+#define kHistoryColumnSortingEnabled @"PBHistoryColumnSortingEnabled"
+#define kAutoFetchScope @"PBAutoFetchScope"
+#define kAutoFetchIntervalMinutes @"PBAutoFetchIntervalMinutes"
+#define kAutoFetchRepositoryNotifications @"PBAutoFetchRepositoryNotifications"
+
+NSString *const PBGitHistorySortingPreferenceDidChangeNotification = @"PBGitHistorySortingPreferenceDidChangeNotification";
+NSString *const PBAutoFetchPreferencesDidChangeNotification = @"PBAutoFetchPreferencesDidChangeNotification";
 
 @implementation PBGitDefaults
 
@@ -67,6 +74,10 @@
 					  forKey:kUseRepositoryWatcher];
 	[defaultValues setObject:@"com.apple.Terminal"
 					  forKey:kTerminalHandler];
+	[defaultValues setObject:@YES forKey:kHistoryColumnSortingEnabled];
+	[defaultValues setObject:@(PBAutoFetchScopeNone) forKey:kAutoFetchScope];
+	[defaultValues setObject:@15 forKey:kAutoFetchIntervalMinutes];
+	[defaultValues setObject:@{} forKey:kAutoFetchRepositoryNotifications];
 	[[NSUserDefaults standardUserDefaults] registerDefaults:defaultValues];
 }
 
@@ -231,6 +242,60 @@
 + (NSString *)terminalHandler
 {
 	return [[NSUserDefaults standardUserDefaults] stringForKey:kTerminalHandler];
+}
+
++ (BOOL)historyColumnSortingEnabled
+{
+	return [[NSUserDefaults standardUserDefaults] boolForKey:kHistoryColumnSortingEnabled];
+}
+
++ (void)setHistoryColumnSortingEnabled:(BOOL)enabled
+{
+	[[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kHistoryColumnSortingEnabled];
+	[[NSNotificationCenter defaultCenter] postNotificationName:PBGitHistorySortingPreferenceDidChangeNotification object:nil];
+}
+
++ (PBAutoFetchScope)autoFetchScope
+{
+	NSInteger scope = [[NSUserDefaults standardUserDefaults] integerForKey:kAutoFetchScope];
+	return (scope >= PBAutoFetchScopeNone && scope <= PBAutoFetchScopeOpenAndRecentRepositories) ? scope : PBAutoFetchScopeNone;
+}
+
++ (void)setAutoFetchScope:(PBAutoFetchScope)scope
+{
+	[[NSUserDefaults standardUserDefaults] setInteger:scope forKey:kAutoFetchScope];
+	[[NSNotificationCenter defaultCenter] postNotificationName:PBAutoFetchPreferencesDidChangeNotification object:nil];
+}
+
++ (NSInteger)autoFetchIntervalMinutes
+{
+	NSInteger interval = [[NSUserDefaults standardUserDefaults] integerForKey:kAutoFetchIntervalMinutes];
+	return MAX(1, MIN(1440, interval));
+}
+
++ (void)setAutoFetchIntervalMinutes:(NSInteger)minutes
+{
+	[[NSUserDefaults standardUserDefaults] setInteger:MAX(1, MIN(1440, minutes)) forKey:kAutoFetchIntervalMinutes];
+	[[NSNotificationCenter defaultCenter] postNotificationName:PBAutoFetchPreferencesDidChangeNotification object:nil];
+}
+
++ (NSString *)repositoryDefaultsKeyForURL:(NSURL *)repositoryURL
+{
+	return repositoryURL.URLByStandardizingPath.path ?: repositoryURL.path ?: @"";
+}
+
++ (BOOL)notifyAboutFetchedCommitsForRepositoryURL:(NSURL *)repositoryURL
+{
+	NSDictionary *settings = [[NSUserDefaults standardUserDefaults] dictionaryForKey:kAutoFetchRepositoryNotifications];
+	return [settings[[self repositoryDefaultsKeyForURL:repositoryURL]] boolValue];
+}
+
++ (void)setNotifyAboutFetchedCommits:(BOOL)enabled forRepositoryURL:(NSURL *)repositoryURL
+{
+	NSMutableDictionary *settings = [[[NSUserDefaults standardUserDefaults] dictionaryForKey:kAutoFetchRepositoryNotifications] mutableCopy] ?: [NSMutableDictionary dictionary];
+	NSString *key = [self repositoryDefaultsKeyForURL:repositoryURL];
+	if (key.length) settings[key] = @(enabled);
+	[[NSUserDefaults standardUserDefaults] setObject:settings forKey:kAutoFetchRepositoryNotifications];
 }
 
 @end

--- a/Classes/git/PBGitDefaults.m
+++ b/Classes/git/PBGitDefaults.m
@@ -31,6 +31,7 @@
 #define kSuppressedDialogWarnings @"Suppressed Dialog Warnings"
 #define kUseRepositoryWatcher @"PBUseRepositoryWatcher"
 #define kTerminalHandler @"PBTerminalHandler"
+#define kAppearancePreference @"PBAppearancePreference"
 #define kHistoryColumnSortingEnabled @"PBHistoryColumnSortingEnabled"
 #define kAutoFetchScope @"PBAutoFetchScope"
 #define kAutoFetchIntervalMinutes @"PBAutoFetchIntervalMinutes"
@@ -38,6 +39,7 @@
 
 NSString *const PBGitHistorySortingPreferenceDidChangeNotification = @"PBGitHistorySortingPreferenceDidChangeNotification";
 NSString *const PBAutoFetchPreferencesDidChangeNotification = @"PBAutoFetchPreferencesDidChangeNotification";
+NSString *const PBAppearancePreferenceDidChangeNotification = @"PBAppearancePreferenceDidChangeNotification";
 
 @implementation PBGitDefaults
 
@@ -74,6 +76,7 @@ NSString *const PBAutoFetchPreferencesDidChangeNotification = @"PBAutoFetchPrefe
 					  forKey:kUseRepositoryWatcher];
 	[defaultValues setObject:@"com.apple.Terminal"
 					  forKey:kTerminalHandler];
+	[defaultValues setObject:@(PBAppearancePreferenceAutomatic) forKey:kAppearancePreference];
 	[defaultValues setObject:@YES forKey:kHistoryColumnSortingEnabled];
 	[defaultValues setObject:@(PBAutoFetchScopeNone) forKey:kAutoFetchScope];
 	[defaultValues setObject:@15 forKey:kAutoFetchIntervalMinutes];
@@ -242,6 +245,20 @@ NSString *const PBAutoFetchPreferencesDidChangeNotification = @"PBAutoFetchPrefe
 + (NSString *)terminalHandler
 {
 	return [[NSUserDefaults standardUserDefaults] stringForKey:kTerminalHandler];
+}
+
++ (PBAppearancePreference)appearancePreference
+{
+	NSInteger preference = [[NSUserDefaults standardUserDefaults] integerForKey:kAppearancePreference];
+	return (preference >= PBAppearancePreferenceAutomatic && preference <= PBAppearancePreferenceDark) ? preference : PBAppearancePreferenceAutomatic;
+}
+
++ (void)setAppearancePreference:(PBAppearancePreference)preference
+{
+	PBAppearancePreference validatedPreference =
+		(preference >= PBAppearancePreferenceAutomatic && preference <= PBAppearancePreferenceDark) ? preference : PBAppearancePreferenceAutomatic;
+	[[NSUserDefaults standardUserDefaults] setInteger:validatedPreference forKey:kAppearancePreference];
+	[[NSNotificationCenter defaultCenter] postNotificationName:PBAppearancePreferenceDidChangeNotification object:nil];
 }
 
 + (BOOL)historyColumnSortingEnabled

--- a/Classes/git/PBGitIndex.h
+++ b/Classes/git/PBGitIndex.h
@@ -75,7 +75,7 @@ extern NSString *PBGitIndexOperationFailed;
 
 // Intra-file changes
 - (BOOL)applyPatch:(NSString *)hunk stage:(BOOL)stage reverse:(BOOL)reverse;
-- (NSString *)diffForFile:(PBChangedFile *)file staged:(BOOL)staged contextLines:(NSUInteger)context;
+- (nullable NSString *)diffForFile:(PBChangedFile *)file staged:(BOOL)staged contextLines:(NSUInteger)context;
 
 @end
 

--- a/Classes/git/PBGitIndex.m
+++ b/Classes/git/PBGitIndex.m
@@ -620,6 +620,9 @@ NS_ENUM(NSUInteger, PBGitIndexOperation){
 
 - (BOOL)applyPatch:(NSString *)hunk stage:(BOOL)stage reverse:(BOOL)reverse;
 {
+	if (![hunk hasSuffix:@"\n"])
+		hunk = [hunk stringByAppendingString:@"\n"];
+
 	NSMutableArray *array = [NSMutableArray arrayWithObjects:@"apply", @"--unidiff-zero", nil];
 	if (stage)
 		[array addObject:@"--cached"];

--- a/Classes/git/PBGitIndex.m
+++ b/Classes/git/PBGitIndex.m
@@ -643,7 +643,7 @@ NS_ENUM(NSUInteger, PBGitIndexOperation){
 }
 
 
-- (NSString *)diffForFile:(PBChangedFile *)file staged:(BOOL)staged contextLines:(NSUInteger)context
+- (nullable NSString *)diffForFile:(PBChangedFile *)file staged:(BOOL)staged contextLines:(NSUInteger)context
 {
 	NSString *parameter = [NSString stringWithFormat:@"-U%lu", context];
 	if (staged) {
@@ -681,13 +681,6 @@ NS_ENUM(NSUInteger, PBGitIndexOperation){
 		PBLogError(error);
 	}
 	return output;
-}
-
-#pragma mark WebKit Accessibility
-
-+ (BOOL)isSelectorExcludedFromWebScript:(SEL)aSelector
-{
-	return NO;
 }
 
 @end

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -7,6 +7,7 @@
 //
 
 #import <Cocoa/Cocoa.h>
+#import <ObjectiveGit/GTRepository+Reset.h>
 
 @class PBGitHistoryList;
 @class PBGitRevSpecifier;

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -296,6 +296,8 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	} else if (self.gtRepo.isHEADUnborn) {
 		branchRef = headRef;
 	}
+	if (!branchRef)
+		return nil;
 
 	_headRef = [[PBGitRevSpecifier alloc] initWithRef:[PBGitRef refFromString:branchRef.name]];
 	_headOID = branchRef.OID;
@@ -420,6 +422,9 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 
 - (BOOL)refExists:(PBGitRef *)ref
 {
+	if (!ref.ref.length)
+		return NO;
+
 	NSError *gtError = nil;
 	GTReference *gtRef = [self.gtRepo lookUpReferenceWithName:ref.ref error:&gtError];
 	if (gtRef) {
@@ -438,12 +443,20 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 
 	NSError *taskError = nil;
 	NSString *output = [self outputOfTaskWithArguments:@[ @"show-ref", name ] error:&taskError];
+	if (!output.length)
+		return nil;
 
 	// the output is in the format: <SHA-1 ID> <space> <reference name>
 	// with potentially multiple lines if there are multiple matching refs (ex: refs/remotes/origin/master)
 	// here we only care about the first match
-	NSArray *refList = [output componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-	if (refList.count != 1) return nil;
+	NSArray<NSString *> *parts = [output componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+	NSMutableArray<NSString *> *refList = [NSMutableArray arrayWithCapacity:parts.count];
+	for (NSString *part in parts) {
+		if (part.length)
+			[refList addObject:part];
+	}
+	if (refList.count < 2)
+		return nil;
 
 	NSString *refName = [refList objectAtIndex:1];
 	return [PBGitRef refFromString:refName];
@@ -631,17 +644,19 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 - (NSArray<NSString *> *)remotes
 {
 	NSError *error = nil;
-	NSArray *remotes = [self.gtRepo remoteNamesWithError:&error];
-	if (!remotes) {
+	NSString *output = [self outputOfTaskWithArguments:@[ @"remote" ] error:&error];
+	if (!output) {
 		PBLogError(error);
 		return nil;
 	}
-	return remotes;
+	if (!output.length)
+		return @[];
+	return [output componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
 }
 
 - (BOOL)hasRemotes
 {
-	return ([self remotes] != nil);
+	return self.remotes.count > 0;
 }
 
 - (PBGitRef *)remoteRefForBranch:(PBGitRef *)branch error:(NSError **)error

--- a/Classes/git/PBGitRepositoryWatcher.m
+++ b/Classes/git/PBGitRepositoryWatcher.m
@@ -290,7 +290,7 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 
 	if (!eventStream) return;
 
-	FSEventStreamScheduleWithRunLoop(eventStream, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+	FSEventStreamSetDispatchQueue(eventStream, dispatch_get_main_queue());
 	FSEventStreamStart(eventStream);
 
 	_running = YES;
@@ -303,7 +303,6 @@ void PBGitRepositoryWatcherCallback(ConstFSEventStreamRef streamRef,
 
 	if (eventStream) {
 		FSEventStreamStop(eventStream);
-		FSEventStreamUnscheduleFromRunLoop(eventStream, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
 	}
 
 	_running = NO;

--- a/Classes/git/PBGitRepository_PBGitBinarySupport.m
+++ b/Classes/git/PBGitRepository_PBGitBinarySupport.m
@@ -18,7 +18,7 @@
 	NSArray *realArgs = @[ [@"--git-dir=" stringByAppendingString:self.gitURL.path] ];
 
 	// Prepend a --git-dir argument in case we're running against a bare repository
-	realArgs = [realArgs arrayByAddingObjectsFromArray:arguments];
+	realArgs = [realArgs arrayByAddingObjectsFromArray:arguments ?: @[]];
 
 	return [PBTask taskWithLaunchPath:[PBGitBinary path] arguments:realArgs inDirectory:self.workingDirectory];
 }
@@ -26,7 +26,8 @@
 - (BOOL)launchTaskWithArguments:(NSArray *)arguments input:(NSString *)inputString error:(NSError **)error
 {
 	PBTask *task = [self taskWithArguments:arguments];
-	task.standardInputData = [inputString dataUsingEncoding:NSUTF8StringEncoding];
+	if (inputString)
+		task.standardInputData = [inputString dataUsingEncoding:NSUTF8StringEncoding];
 	return [task launchTask:error];
 }
 
@@ -38,7 +39,8 @@
 - (NSString *)outputOfTaskWithArguments:(NSArray *)arguments input:(NSString *)inputString error:(NSError **)error
 {
 	PBTask *task = [self taskWithArguments:arguments];
-	task.standardInputData = [inputString dataUsingEncoding:NSUTF8StringEncoding];
+	if (inputString)
+		task.standardInputData = [inputString dataUsingEncoding:NSUTF8StringEncoding];
 	BOOL success = [task launchTask:error];
 	if (!success) return nil;
 

--- a/Classes/git/PBGitTree.h
+++ b/Classes/git/PBGitTree.h
@@ -41,5 +41,6 @@
 @property (readonly) NSArray *children;
 @property (readonly) NSString *fullPath;
 @property (readonly) NSString *contents;
+@property (readonly) NSString *displayPath;
 
 @end

--- a/Classes/git/PBGitTree.m
+++ b/Classes/git/PBGitTree.m
@@ -343,6 +343,11 @@
 	return [parent.fullPath stringByAppendingPathComponent:self.path];
 }
 
+- (NSString *)displayPath
+{
+	return self.path;
+}
+
 - (void)dealloc
 {
 	if (localFileName) {

--- a/Classes/git/PBHistoryArrayController.h
+++ b/Classes/git/PBHistoryArrayController.h
@@ -1,0 +1,10 @@
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Keeps the mutable Working State row pinned above the arranged commit list.
+@interface PBHistoryArrayController : NSArrayController
+@property (nonatomic, nullable) id pinnedObject;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/git/PBHistoryArrayController.m
+++ b/Classes/git/PBHistoryArrayController.m
@@ -1,0 +1,27 @@
+#import "PBHistoryArrayController.h"
+#import "PBGitDefaults.h"
+
+@implementation PBHistoryArrayController
+
+- (id)arrangeObjects:(id)objects
+{
+	id arranged = [super arrangeObjects:objects];
+	if (!self.pinnedObject) return arranged;
+	NSMutableArray *result = [NSMutableArray arrayWithObject:self.pinnedObject];
+	if ([arranged isKindOfClass:NSArray.class]) [result addObjectsFromArray:arranged];
+	return result;
+}
+
+- (void)setPinnedObject:(id)pinnedObject
+{
+	if (_pinnedObject == pinnedObject) return;
+	_pinnedObject = pinnedObject;
+	[self rearrangeObjects];
+}
+
+- (void)setSortDescriptors:(NSArray<NSSortDescriptor *> *)sortDescriptors
+{
+	[super setSortDescriptors:[PBGitDefaults historyColumnSortingEnabled] ? sortDescriptors : @[]];
+}
+
+@end

--- a/Classes/git/PBUncommittedChanges.h
+++ b/Classes/git/PBUncommittedChanges.h
@@ -1,0 +1,16 @@
+#import "PBGitCommit.h"
+
+@class PBGitRepository;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// PBGitCommit-compatible row model for the repository's mutable Working State.
+@interface PBUncommittedChanges : PBGitCommit
+- (instancetype)initWithRepository:(PBGitRepository *)repository;
+@property (nonatomic, readonly) NSUInteger stagedCount;
+@property (nonatomic, readonly) NSUInteger unstagedCount;
+@property (nonatomic, readonly) NSUInteger untrackedCount;
+@property (nonatomic, readonly) BOOL isWorkingState;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/git/PBUncommittedChanges.m
+++ b/Classes/git/PBUncommittedChanges.m
@@ -1,0 +1,68 @@
+#import "PBUncommittedChanges.h"
+#import "PBWorkingTree.h"
+#import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
+#import "PBGitIndex.h"
+#import "PBChangedFile.h"
+
+@interface PBUncommittedChanges ()
+@property (nonatomic, weak) PBGitRepository *workingRepository;
+@property (nonatomic) NSUInteger stagedCount;
+@property (nonatomic) NSUInteger unstagedCount;
+@property (nonatomic) NSUInteger untrackedCount;
+@end
+
+@implementation PBUncommittedChanges
+
+- (instancetype)initWithRepository:(PBGitRepository *)repository
+{
+	self = [super init];
+	if (!self) return nil;
+	_workingRepository = repository;
+	for (PBChangedFile *file in repository.index.indexChanges) {
+		if (file.hasStagedChanges) _stagedCount++;
+		if (file.hasUnstagedChanges && file.status != NEW) _unstagedCount++;
+		if (file.hasUnstagedChanges && file.status == NEW) _untrackedCount++;
+	}
+	return self;
+}
+
+- (BOOL)isWorkingState { return YES; }
+- (PBGitRepository *)repository { return self.workingRepository; }
+- (NSString *)subject
+{
+	return [NSString stringWithFormat:@"Uncommitted Changes — %lu staged, %lu unstaged, %lu untracked",
+		(unsigned long)self.stagedCount, (unsigned long)self.unstagedCount, (unsigned long)self.untrackedCount];
+}
+- (NSString *)message { return self.subject; }
+- (NSString *)details { return self.subject; }
+- (NSString *)author { return @""; }
+- (NSString *)authorEmail { return @""; }
+- (NSString *)authorDate { return @""; }
+- (NSString *)committer { return @""; }
+- (NSString *)committerEmail { return @""; }
+- (NSString *)committerDate { return @""; }
+- (NSString *)SHA { return @""; }
+- (NSString *)shortName { return @""; }
+- (NSString *)SVNRevision { return nil; }
+- (NSDate *)date { return [super date]; }
+- (GTOID *)OID { return [super OID]; }
+- (GTCommit *)gtCommit { return [super gtCommit]; }
+- (NSArray<GTOID *> *)parents { return @[]; }
+- (NSMutableArray *)refs { return [NSMutableArray array]; }
+- (PBGraphCellInfo *)lineInfo { return [super lineInfo]; }
+- (PBGitTree *)tree { return [PBWorkingTree rootForRepository:self.workingRepository]; }
+- (NSArray *)treeContents { return self.tree.children; }
+- (BOOL)isOnHeadBranch { return NO; }
+- (NSString *)refishName { return @"WORKING_STATE"; }
+- (NSString *)refishType { return @"working-state"; }
+
+- (NSString *)patch
+{
+	NSError *error = nil;
+	NSString *staged = [self.workingRepository outputOfTaskWithArguments:@[ @"diff", @"--cached", @"--no-ext-diff" ] error:&error] ?: @"";
+	NSString *unstaged = [self.workingRepository outputOfTaskWithArguments:@[ @"diff", @"--no-ext-diff" ] error:&error] ?: @"";
+	return [NSString stringWithFormat:@"%@%@%@", staged, staged.length && unstaged.length ? @"\n" : @"", unstaged];
+}
+
+@end

--- a/Classes/git/PBUncommittedChanges.m
+++ b/Classes/git/PBUncommittedChanges.m
@@ -10,6 +10,7 @@
 @property (nonatomic) NSUInteger stagedCount;
 @property (nonatomic) NSUInteger unstagedCount;
 @property (nonatomic) NSUInteger untrackedCount;
+@property (nonatomic) PBGitTree *workingTree;
 @end
 
 @implementation PBUncommittedChanges
@@ -27,35 +28,108 @@
 	return self;
 }
 
-- (BOOL)isWorkingState { return YES; }
-- (PBGitRepository *)repository { return self.workingRepository; }
+- (BOOL)isWorkingState
+{
+	return YES;
+}
+- (PBGitRepository *)repository
+{
+	return self.workingRepository;
+}
 - (NSString *)subject
 {
 	return [NSString stringWithFormat:@"Uncommitted Changes — %lu staged, %lu unstaged, %lu untracked",
-		(unsigned long)self.stagedCount, (unsigned long)self.unstagedCount, (unsigned long)self.untrackedCount];
+									  (unsigned long)self.stagedCount, (unsigned long)self.unstagedCount, (unsigned long)self.untrackedCount];
 }
-- (NSString *)message { return self.subject; }
-- (NSString *)details { return self.subject; }
-- (NSString *)author { return @""; }
-- (NSString *)authorEmail { return @""; }
-- (NSString *)authorDate { return @""; }
-- (NSString *)committer { return @""; }
-- (NSString *)committerEmail { return @""; }
-- (NSString *)committerDate { return @""; }
-- (NSString *)SHA { return @""; }
-- (NSString *)shortName { return @""; }
-- (NSString *)SVNRevision { return nil; }
-- (NSDate *)date { return [super date]; }
-- (GTOID *)OID { return [super OID]; }
-- (GTCommit *)gtCommit { return [super gtCommit]; }
-- (NSArray<GTOID *> *)parents { return @[]; }
-- (NSMutableArray *)refs { return [NSMutableArray array]; }
-- (PBGraphCellInfo *)lineInfo { return [super lineInfo]; }
-- (PBGitTree *)tree { return [PBWorkingTree rootForRepository:self.workingRepository]; }
-- (NSArray *)treeContents { return self.tree.children; }
-- (BOOL)isOnHeadBranch { return NO; }
-- (NSString *)refishName { return @"WORKING_STATE"; }
-- (NSString *)refishType { return @"working-state"; }
+- (NSString *)message
+{
+	return self.subject;
+}
+- (NSString *)details
+{
+	return self.subject;
+}
+- (NSString *)author
+{
+	return @"";
+}
+- (NSString *)authorEmail
+{
+	return @"";
+}
+- (NSString *)authorDate
+{
+	return @"";
+}
+- (NSString *)committer
+{
+	return @"";
+}
+- (NSString *)committerEmail
+{
+	return @"";
+}
+- (NSString *)committerDate
+{
+	return @"";
+}
+- (NSString *)SHA
+{
+	return @"";
+}
+- (NSString *)shortName
+{
+	return @"";
+}
+- (NSString *)SVNRevision
+{
+	return nil;
+}
+- (NSDate *)date
+{
+	return [super date];
+}
+- (GTOID *)OID
+{
+	return [super OID];
+}
+- (GTCommit *)gtCommit
+{
+	return [super gtCommit];
+}
+- (NSArray<GTOID *> *)parents
+{
+	return @[];
+}
+- (NSMutableArray *)refs
+{
+	return [NSMutableArray array];
+}
+- (PBGraphCellInfo *)lineInfo
+{
+	return [super lineInfo];
+}
+- (PBGitTree *)tree
+{
+	if (!self.workingTree) self.workingTree = [PBWorkingTree rootForRepository:self.workingRepository];
+	return self.workingTree;
+}
+- (NSArray *)treeContents
+{
+	return self.tree.children;
+}
+- (BOOL)isOnHeadBranch
+{
+	return NO;
+}
+- (NSString *)refishName
+{
+	return @"WORKING_STATE";
+}
+- (NSString *)refishType
+{
+	return @"working-state";
+}
 
 - (NSString *)patch
 {

--- a/Classes/git/PBWorkingTree.h
+++ b/Classes/git/PBWorkingTree.h
@@ -1,0 +1,14 @@
+#import "PBGitTree.h"
+
+@class PBGitRepository;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A tree assembled from the non-ignored checkout rather than a commit tree.
+@interface PBWorkingTree : PBGitTree
++ (instancetype)rootForRepository:(PBGitRepository *)repository;
+@property (nonatomic, readonly) NSString *displayPath;
+@property (nonatomic, readonly, nullable) NSString *workingStatus;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/git/PBWorkingTree.m
+++ b/Classes/git/PBWorkingTree.m
@@ -1,0 +1,153 @@
+#import "PBWorkingTree.h"
+#import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
+#import "PBGitIndex.h"
+#import "PBChangedFile.h"
+
+@interface PBWorkingTree ()
+@property (nonatomic) NSArray<PBWorkingTree *> *workingChildren;
+@property (nonatomic) NSString *workingStatus;
+@end
+
+@implementation PBWorkingTree
+
++ (instancetype)rootForRepository:(PBGitRepository *)repository
+{
+	PBWorkingTree *root = [[self alloc] init];
+	root.repository = repository;
+	root.path = @"";
+	root.leaf = NO;
+	root.workingChildren = @[];
+
+	NSMutableDictionary<NSString *, PBChangedFile *> *changes = [NSMutableDictionary dictionary];
+	for (PBChangedFile *file in repository.index.indexChanges) changes[file.path] = file;
+
+	NSMutableOrderedSet<NSString *> *paths = [NSMutableOrderedSet orderedSet];
+	NSError *error = nil;
+	NSString *trackedAndUntracked = [repository outputOfTaskWithArguments:@[ @"ls-files", @"-co", @"--exclude-standard", @"-z" ] error:&error];
+	for (NSString *path in [trackedAndUntracked componentsSeparatedByString:@"\0"]) if (path.length) [paths addObject:path];
+	NSString *deleted = [repository outputOfTaskWithArguments:@[ @"ls-files", @"--deleted", @"-z" ] error:nil];
+	for (NSString *path in [deleted componentsSeparatedByString:@"\0"]) if (path.length) [paths addObject:path];
+
+	NSMutableDictionary<NSString *, PBWorkingTree *> *nodes = [NSMutableDictionary dictionaryWithObject:root forKey:@""];
+	for (NSString *filePath in paths) {
+		NSArray<NSString *> *components = [filePath pathComponents];
+		NSMutableString *accumulated = [NSMutableString string];
+		PBWorkingTree *parent = root;
+		for (NSUInteger index = 0; index < components.count; index++) {
+			NSString *component = components[index];
+			if (accumulated.length) [accumulated appendString:@"/"];
+			[accumulated appendString:component];
+			PBWorkingTree *node = nodes[accumulated];
+			if (!node) {
+				node = [[PBWorkingTree alloc] init];
+				node.repository = repository;
+				node.parent = parent;
+				node.path = component;
+				node.leaf = index == components.count - 1;
+				node.workingChildren = @[];
+				nodes[accumulated] = node;
+				parent.workingChildren = [parent.workingChildren arrayByAddingObject:node];
+			}
+			parent = node;
+		}
+
+		PBChangedFile *change = changes[filePath];
+		if (change) {
+			NSMutableArray *states = [NSMutableArray array];
+			if (change.hasStagedChanges) [states addObject:@"staged"];
+			if (change.hasUnstagedChanges) [states addObject:(change.status == NEW ? @"untracked" : @"unstaged")];
+			if (change.status == DELETED) [states addObject:@"deleted"];
+			parent.workingStatus = [states componentsJoinedByString:@", "];
+		}
+	}
+
+	for (PBWorkingTree *node in nodes.allValues) {
+		node.workingChildren = [node.workingChildren sortedArrayUsingComparator:^NSComparisonResult(PBWorkingTree *left, PBWorkingTree *right) {
+			if (left.leaf != right.leaf) return left.leaf ? NSOrderedDescending : NSOrderedAscending;
+			return [left.path localizedStandardCompare:right.path];
+		}];
+	}
+	return root;
+}
+
+- (NSArray *)children
+{
+	return self.workingChildren;
+}
+
+- (NSString *)displayPath
+{
+	if (self.workingStatus.length == 0) return self.path;
+	NSString *symbol = @"M";
+	if ([self.workingStatus containsString:@"untracked"]) symbol = @"?";
+	else if ([self.workingStatus containsString:@"deleted"]) symbol = @"D";
+	else if ([self.workingStatus containsString:@"staged"] && ![self.workingStatus containsString:@"unstaged"]) symbol = @"S";
+	return [NSString stringWithFormat:@"%@  [%@]", self.path, symbol];
+}
+
+- (NSURL *)workingFileURL
+{
+	return [self.repository.workingDirectoryURL URLByAppendingPathComponent:self.fullPath];
+}
+
+- (NSString *)contents
+{
+	if (!self.leaf) return @"";
+	NSData *data = [NSData dataWithContentsOfURL:self.workingFileURL];
+	if (!data) {
+		NSError *error = nil;
+		NSString *indexed = [self.repository outputOfTaskWithArguments:@[ @"show", [@":" stringByAppendingString:self.fullPath] ] error:&error];
+		return indexed ?: error.localizedDescription ?: @"";
+	}
+	NSString *string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+	return string ?: [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding] ?: @"This file cannot be displayed as text.";
+}
+
+- (NSString *)textContents
+{
+	return self.contents;
+}
+
+- (NSString *)porcelainForUntrackedContents:(NSString *)contents
+{
+	NSArray<NSString *> *lines = [contents componentsSeparatedByString:@"\n"];
+	NSMutableString *result = [NSMutableString string];
+	NSString *zero = @"0000000000000000000000000000000000000000";
+	NSUInteger lineNumber = 1;
+	for (NSString *line in lines) {
+		[result appendFormat:@"%@ %lu %lu 1\nauthor Not Committed Yet\nsummary Uncommitted line\n\t%@\n", zero, (unsigned long)lineNumber, (unsigned long)lineNumber, line];
+		lineNumber++;
+	}
+	return result;
+}
+
+- (NSString *)blame
+{
+	if (!self.leaf) return @"";
+	NSError *error = nil;
+	NSString *blame = [self.repository outputOfTaskWithArguments:@[ @"blame", @"-p", @"--", self.fullPath ] error:&error];
+	return blame ?: [self porcelainForUntrackedContents:self.contents];
+}
+
+- (NSString *)log:(NSString *)format
+{
+	if (!self.leaf) return @"";
+	NSError *error = nil;
+	return [self.repository outputOfTaskWithArguments:@[ @"log", [NSString stringWithFormat:@"--pretty=format:%@", format], @"--follow", @"--", self.fullPath ] error:&error] ?: @"";
+}
+
+- (long long)fileSize
+{
+	NSNumber *size = nil;
+	[self.workingFileURL getResourceValue:&size forKey:NSURLFileSizeKey error:nil];
+	return size.longLongValue;
+}
+
+- (NSString *)tmpFileNameForContents
+{
+	if ([[NSFileManager defaultManager] fileExistsAtPath:self.workingFileURL.path]) return self.workingFileURL.path;
+	return [super tmpFileNameForContents];
+}
+
+@end

--- a/Classes/git/PBWorkingTree.m
+++ b/Classes/git/PBWorkingTree.m
@@ -3,9 +3,10 @@
 #import "PBGitRepository_PBGitBinarySupport.h"
 #import "PBGitIndex.h"
 #import "PBChangedFile.h"
+#include <string.h>
 
 @interface PBWorkingTree ()
-@property (nonatomic) NSArray<PBWorkingTree *> *workingChildren;
+@property (nonatomic) NSMutableArray<PBWorkingTree *> *workingChildren;
 @property (nonatomic) NSString *workingStatus;
 @end
 
@@ -17,7 +18,7 @@
 	root.repository = repository;
 	root.path = @"";
 	root.leaf = NO;
-	root.workingChildren = @[];
+	root.workingChildren = [NSMutableArray array];
 
 	NSMutableDictionary<NSString *, PBChangedFile *> *changes = [NSMutableDictionary dictionary];
 	for (PBChangedFile *file in repository.index.indexChanges) changes[file.path] = file;
@@ -45,9 +46,9 @@
 				node.parent = parent;
 				node.path = component;
 				node.leaf = index == components.count - 1;
-				node.workingChildren = @[];
+				node.workingChildren = [NSMutableArray array];
 				nodes[accumulated] = node;
-				parent.workingChildren = [parent.workingChildren arrayByAddingObject:node];
+				[parent.workingChildren addObject:node];
 			}
 			parent = node;
 		}
@@ -63,7 +64,7 @@
 	}
 
 	for (PBWorkingTree *node in nodes.allValues) {
-		node.workingChildren = [node.workingChildren sortedArrayUsingComparator:^NSComparisonResult(PBWorkingTree *left, PBWorkingTree *right) {
+		[node.workingChildren sortUsingComparator:^NSComparisonResult(PBWorkingTree *left, PBWorkingTree *right) {
 			if (left.leaf != right.leaf) return left.leaf ? NSOrderedDescending : NSOrderedAscending;
 			return [left.path localizedStandardCompare:right.path];
 		}];
@@ -98,10 +99,14 @@
 	if (!data) {
 		NSError *error = nil;
 		NSString *indexed = [self.repository outputOfTaskWithArguments:@[ @"show", [@":" stringByAppendingString:self.fullPath] ] error:&error];
-		return indexed ?: error.localizedDescription ?: @"";
+		return indexed ?: error.localizedDescription ?:
+													   @"";
 	}
+	if (data.length && memchr(data.bytes, 0, MIN(data.length, (NSUInteger)8000)))
+		return @"This file cannot be displayed as text.";
 	NSString *string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-	return string ?: [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding] ?: @"This file cannot be displayed as text.";
+	return string ?: [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding] ?:
+																							   @"This file cannot be displayed as text.";
 }
 
 - (NSString *)textContents

--- a/Classes/gitx.m
+++ b/Classes/gitx.m
@@ -326,7 +326,7 @@ int main(int argc, const char **argv)
 		}
 
 		// gitx can be used to pipe diff output to be displayed in GitX
-		if (!isatty(STDIN_FILENO) && fdopen(STDIN_FILENO, "r"))
+		if (!isatty(STDIN_FILENO))
 			handleSTDINDiff();
 
 

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -21,8 +21,19 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		C0DE20000000000000000001 /* GitXFeatureTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE20000000000000000003 /* GitXFeatureTests.m */; };
+		C0DE20000000000000000002 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0DE20000000000000000005 /* XCTest.framework */; };
+		C0DE2000000000000000000F /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
         CC0000010000001 /* GitXScreenshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC0000020000002 /* GitXScreenshotTests.m */; };
 		AABBCC0300000003 /* GitXSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0200000002 /* GitXSwift.swift */; };
+		C0DE10000000000000000011 /* PBHighlighting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10000000000000000002 /* PBHighlighting.swift */; };
+		C0DE10000000000000000012 /* PBNativeContentView.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10000000000000000004 /* PBNativeContentView.m */; };
+		C0DE10000000000000000013 /* PBHistoryArrayController.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10000000000000000006 /* PBHistoryArrayController.m */; };
+		C0DE10000000000000000014 /* PBWorkingTree.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10000000000000000008 /* PBWorkingTree.m */; };
+		C0DE10000000000000000015 /* PBUncommittedChanges.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE1000000000000000000A /* PBUncommittedChanges.m */; };
+		C0DE10000000000000000019 /* PBAutoFetchManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE1000000000000000000C /* PBAutoFetchManager.m */; };
+		C0DE1000000000000000001A /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0DE1000000000000000001B /* UserNotifications.framework */; };
+		C0DE10000000000000000016 /* HighlightKit in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE10000000000000000018 /* HighlightKit */; };
 		0A6858C711F7EA8A00AC2BE4 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A6858C611F7EA8A00AC2BE4 /* CoreServices.framework */; };
 		2682AABB1929140E00271A4D /* GTOID+JavaScript.m in Sources */ = {isa = PBXBuildFile; fileRef = 2682AABA1929140E00271A4D /* GTOID+JavaScript.m */; };
 		2DE9B60629ABEB450097873A /* GitX.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 2DE9B60529ABEB450097873A /* GitX.xcconfig */; };
@@ -132,8 +143,6 @@
 		4A5D777414A9AEB000DF6C68 /* PBSourceViewBadge.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D776F14A9AEB000DF6C68 /* PBSourceViewBadge.m */; };
 		4A68AD7414A00541006DE321 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A68AD6714A0050F006DE321 /* Sparkle.framework */; };
 		4A774CC9142F482900E158CC /* ObjectiveGit.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4A4EF0AF142CBAD5001B8CDF /* ObjectiveGit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		4A8F6B4B14A9B6C20002F4D7 /* MGScopeBar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A8F6B4714A9B6110002F4D7 /* MGScopeBar.framework */; };
-		4A8F6B4C14A9B6C90002F4D7 /* MGScopeBar.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4A8F6B4714A9B6110002F4D7 /* MGScopeBar.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		4A90A73514A9D24300D0DA02 /* GitX.sdef in Resources */ = {isa = PBXBuildFile; fileRef = 4A90A73414A9D24300D0DA02 /* GitX.sdef */; };
 		4AAAFDDA14A010DD008FC9B5 /* Sparkle.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4A68AD6714A0050F006DE321 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		4AB057E31652652000DE751D /* PBRepositoryFinder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB057E21652652000DE751D /* PBRepositoryFinder.m */; };
@@ -188,11 +197,17 @@
 		D87127011229A21C00012334 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D87127001229A21C00012334 /* QuartzCore.framework */; };
 		D89E9B141218BA260097A90B /* ScriptingBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D89E9AB21218A9DA0097A90B /* ScriptingBridge.framework */; };
 		D8E3B2B810DC9FB2001096A3 /* ScriptingBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8E3B2B710DC9FB2001096A3 /* ScriptingBridge.framework */; };
-		F56526240E03D85900F03B52 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F56526230E03D85900F03B52 /* WebKit.framework */; };
 		F5E4DBFB0EAB58D90013FAFC /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F5E4DBFA0EAB58D90013FAFC /* SystemConfiguration.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		C0DE20000000000000000009 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8D1107260486CEB800E47090;
+			remoteInfo = GitX;
+		};
 		4A467EEF1546D1F300F8902B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 4A4EF09F142CBAD5001B8CDF /* ObjectiveGitFramework.xcodeproj */;
@@ -262,27 +277,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 913D5E480E55644600CECEA2;
 			remoteInfo = "cli tool";
-		};
-		4A8F6B4414A9B6110002F4D7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A8F6B3B14A9B6100002F4D7 /* MGScopeBar.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 8D1107320486CEB800E47090;
-			remoteInfo = MGScopeBar;
-		};
-		4A8F6B4614A9B6110002F4D7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A8F6B3B14A9B6100002F4D7 /* MGScopeBar.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = AAE785781419184700A6955E;
-			remoteInfo = MGScopeBar.framework;
-		};
-		4A8F6B4914A9B6B80002F4D7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4A8F6B3B14A9B6100002F4D7 /* MGScopeBar.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = AAE785771419184700A6955E;
-			remoteInfo = MGScopeBar.framework;
 		};
 		4ADAA9C11602ADB8007A0E6F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -433,7 +427,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				4A8F6B4C14A9B6C90002F4D7 /* MGScopeBar.framework in CopyFiles */,
 				4AAAFDDA14A010DD008FC9B5 /* Sparkle.framework in CopyFiles */,
 				4A774CC9142F482900E158CC /* ObjectiveGit.framework in CopyFiles */,
 			);
@@ -442,10 +435,26 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		C0DE20000000000000000003 /* GitXFeatureTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXFeatureTests.m; sourceTree = "<group>"; };
+		C0DE20000000000000000004 /* GitXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GitXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C0DE20000000000000000005 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		AABBCC0100000001 /* GitX-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GitX-Bridging-Header.h"; sourceTree = "<group>"; };
 		AABBCC0200000002 /* GitXSwift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitXSwift.swift; sourceTree = "<group>"; };
 		CC0000020000002 /* GitXScreenshotTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXScreenshotTests.m; sourceTree = "<group>"; };
 		CC0000030000003 /* GitXUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GitXUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C0DE10000000000000000001 /* PBHighlighting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBHighlighting.h; sourceTree = "<group>"; };
+		C0DE10000000000000000002 /* PBHighlighting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBHighlighting.swift; sourceTree = "<group>"; };
+		C0DE10000000000000000003 /* PBNativeContentView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBNativeContentView.h; sourceTree = "<group>"; };
+		C0DE10000000000000000004 /* PBNativeContentView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBNativeContentView.m; sourceTree = "<group>"; };
+		C0DE10000000000000000005 /* PBHistoryArrayController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBHistoryArrayController.h; sourceTree = "<group>"; };
+		C0DE10000000000000000006 /* PBHistoryArrayController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBHistoryArrayController.m; sourceTree = "<group>"; };
+		C0DE10000000000000000007 /* PBWorkingTree.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBWorkingTree.h; sourceTree = "<group>"; };
+		C0DE10000000000000000008 /* PBWorkingTree.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBWorkingTree.m; sourceTree = "<group>"; };
+		C0DE10000000000000000009 /* PBUncommittedChanges.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBUncommittedChanges.h; sourceTree = "<group>"; };
+		C0DE1000000000000000000A /* PBUncommittedChanges.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBUncommittedChanges.m; sourceTree = "<group>"; };
+		C0DE1000000000000000000B /* PBAutoFetchManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBAutoFetchManager.h; sourceTree = "<group>"; };
+		C0DE1000000000000000000C /* PBAutoFetchManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBAutoFetchManager.m; sourceTree = "<group>"; };
+		C0DE1000000000000000001B /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
 		0A6858C611F7EA8A00AC2BE4 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		2682AAB91929140E00271A4D /* GTOID+JavaScript.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GTOID+JavaScript.h"; sourceTree = "<group>"; };
@@ -623,7 +632,6 @@
 		4A5D776F14A9AEB000DF6C68 /* PBSourceViewBadge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBSourceViewBadge.m; sourceTree = "<group>"; };
 		4A5D777014A9AEB000DF6C68 /* PBSourceViewItems.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBSourceViewItems.h; sourceTree = "<group>"; };
 		4A68AD5814A0050E006DE321 /* Sparkle.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Sparkle.xcodeproj; path = Sparkle/Sparkle.xcodeproj; sourceTree = "<group>"; };
-		4A8F6B3B14A9B6100002F4D7 /* MGScopeBar.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = MGScopeBar.xcodeproj; path = MGScopeBar/MGScopeBar.xcodeproj; sourceTree = "<group>"; };
 		4A90A72914A9C12F00D0DA02 /* GitX_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GitX_Prefix.pch; sourceTree = "<group>"; };
 		4A90A72B14A9C12F00D0DA02 /* README.markdown */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.markdown; sourceTree = SOURCE_ROOT; };
 		4A90A73314A9D1E800D0DA02 /* GitX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GitX.h; path = ../Resources/GitX.h; sourceTree = "<group>"; };
@@ -716,12 +724,20 @@
 		D87127001229A21C00012334 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		D89E9AB21218A9DA0097A90B /* ScriptingBridge.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ScriptingBridge.framework; path = System/Library/Frameworks/ScriptingBridge.framework; sourceTree = SDKROOT; };
 		D8E3B2B710DC9FB2001096A3 /* ScriptingBridge.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ScriptingBridge.framework; path = /System/Library/Frameworks/ScriptingBridge.framework; sourceTree = "<absolute>"; };
-		F56526230E03D85900F03B52 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = /System/Library/Frameworks/WebKit.framework; sourceTree = "<absolute>"; };
 		F5D619ED0EAE62EA00341D73 /* html */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = folder; path = html; sourceTree = "<group>"; };
 		F5E4DBFA0EAB58D90013FAFC /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = /System/Library/Frameworks/SystemConfiguration.framework; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		C0DE20000000000000000008 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C0DE2000000000000000000F /* Cocoa.framework in Frameworks */,
+				C0DE20000000000000000002 /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		551BF10F112F371800265053 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -735,11 +751,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4A8F6B4B14A9B6C20002F4D7 /* MGScopeBar.framework in Frameworks */,
+				C0DE1000000000000000001A /* UserNotifications.framework in Frameworks */,
+				C0DE10000000000000000016 /* HighlightKit in Frameworks */,
 				4A68AD7414A00541006DE321 /* Sparkle.framework in Frameworks */,
 				4A4EF0BB142CBBC2001B8CDF /* ObjectiveGit.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
-				F56526240E03D85900F03B52 /* WebKit.framework in Frameworks */,
 				911112370E5A097800BF76B4 /* Security.framework in Frameworks */,
 				F5E4DBFB0EAB58D90013FAFC /* SystemConfiguration.framework in Frameworks */,
 				D8E3B2B810DC9FB2001096A3 /* ScriptingBridge.framework in Frameworks */,
@@ -777,6 +793,7 @@
 				913D5E490E55644600CECEA2 /* gitx */,
 				551BF111112F371800265053 /* gitx_askpasswd */,
 				CC0000030000003 /* GitXUITests.xctest */,
+				C0DE20000000000000000004 /* GitXTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -790,6 +807,15 @@
 			path = GitXUITests;
 			sourceTree = "<group>";
 		};
+		C0DE20000000000000000006 /* GitXTests */ = {
+			isa = PBXGroup;
+			children = (
+				C0DE20000000000000000003 /* GitXFeatureTests.m */,
+			);
+			name = GitXTests;
+			path = GitXTests;
+			sourceTree = "<group>";
+		};
 		29B97314FDCFA39411CA2CEA /* GitTest */ = {
 			isa = PBXGroup;
 			children = (
@@ -800,6 +826,7 @@
 				4A5D773E14A9AB3A00DF6C68 /* External Sources */,
 				4A5D757C14A9A90500DF6C68 /* Resources */,
 				CC0000040000004 /* GitXUITests */,
+				C0DE20000000000000000006 /* GitXTests */,
 				37A5656C1EAD077400CA0332 /* cli tool */,
 				37A5656D1EAD07C200CA0332 /* gitx_askpasswd */,
 				29B97323FDCFA39411CA2CEA /* Frameworks */,
@@ -812,6 +839,8 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				C0DE20000000000000000005 /* XCTest.framework */,
+				C0DE1000000000000000001B /* UserNotifications.framework */,
 				37A5657C1EAD096300CA0332 /* Quartz.framework */,
 				29B97324FDCFA39411CA2CEA /* AppKit.framework */,
 				4A40159814067B7A00DB9C07 /* AppKit.framework */,
@@ -825,7 +854,6 @@
 				D89E9AB21218A9DA0097A90B /* ScriptingBridge.framework */,
 				911112360E5A097800BF76B4 /* Security.framework */,
 				F5E4DBFA0EAB58D90013FAFC /* SystemConfiguration.framework */,
-				F56526230E03D85900F03B52 /* WebKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -996,6 +1024,8 @@
 		4A5D762514A9A9CC00DF6C68 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				C0DE1000000000000000000B /* PBAutoFetchManager.h */,
+				C0DE1000000000000000000C /* PBAutoFetchManager.m */,
 				4A5D762614A9A9CC00DF6C68 /* ApplicationController.h */,
 				4A5D762714A9A9CC00DF6C68 /* ApplicationController.m */,
 				4A5D762814A9A9CC00DF6C68 /* DBPrefsWindowController.h */,
@@ -1043,6 +1073,12 @@
 		4A5D764D14A9A9CC00DF6C68 /* git */ = {
 			isa = PBXGroup;
 			children = (
+				C0DE10000000000000000005 /* PBHistoryArrayController.h */,
+				C0DE10000000000000000006 /* PBHistoryArrayController.m */,
+				C0DE10000000000000000009 /* PBUncommittedChanges.h */,
+				C0DE1000000000000000000A /* PBUncommittedChanges.m */,
+				C0DE10000000000000000007 /* PBWorkingTree.h */,
+				C0DE10000000000000000008 /* PBWorkingTree.m */,
 				4A5D764E14A9A9CC00DF6C68 /* PBGitBinary.h */,
 				4A5D764F14A9A9CC00DF6C68 /* PBGitBinary.m */,
 				4A5D765014A9A9CC00DF6C68 /* PBGitCommit.h */,
@@ -1138,6 +1174,10 @@
 		4A5D76B314A9A9CC00DF6C68 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				C0DE10000000000000000001 /* PBHighlighting.h */,
+				C0DE10000000000000000002 /* PBHighlighting.swift */,
+				C0DE10000000000000000003 /* PBNativeContentView.h */,
+				C0DE10000000000000000004 /* PBNativeContentView.m */,
 				BF42F1431E025411004769FF /* GitXTextView.h */,
 				BF42F1321E025403004769FF /* GitXTextView.m */,
 				4A5D76B614A9A9CC00DF6C68 /* GLFileView.h */,
@@ -1189,7 +1229,6 @@
 				4DF173E421A1A679003CD3CE /* MAKVONotificationCenter.h */,
 				4DF173E521A1A67A003CD3CE /* MAKVONotificationCenter.m */,
 				4DE23D061CF31258004C3A6F /* libgit2 */,
-				4A8F6B3B14A9B6100002F4D7 /* MGScopeBar.xcodeproj */,
 				4A4EF09F142CBAD5001B8CDF /* ObjectiveGitFramework.xcodeproj */,
 				4A68AD5814A0050E006DE321 /* Sparkle.xcodeproj */,
 			);
@@ -1222,15 +1261,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		4A8F6B3C14A9B6100002F4D7 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				4A8F6B4514A9B6110002F4D7 /* MGScopeBar.app */,
-				4A8F6B4714A9B6110002F4D7 /* MGScopeBar.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		4DE23D061CF31258004C3A6F /* libgit2 */ = {
 			isa = PBXGroup;
 			children = (
@@ -1243,6 +1273,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		C0DE2000000000000000000B /* GitXTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C0DE2000000000000000000C /* Build configuration list for PBXNativeTarget "GitXTests" */;
+			buildPhases = (
+				C0DE20000000000000000007 /* Sources */,
+				C0DE20000000000000000008 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C0DE2000000000000000000A /* PBXTargetDependency */,
+			);
+			name = GitXTests;
+			productName = GitXTests;
+			productReference = C0DE20000000000000000004 /* GitXTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		551BF110112F371800265053 /* gitx_askpasswd */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 551BF119112F373E00265053 /* Build configuration list for PBXNativeTarget "gitx_askpasswd" */;
@@ -1267,20 +1314,21 @@
 				8D11072C0486CEB800E47090 /* Sources */,
 				8D11072E0486CEB800E47090 /* Frameworks */,
 				F580E6BD0E73329C009E2D3F /* CopyFiles */,
-				F5CF04A20EAE696C00D75C81 /* Copy HTML files */,
 				D14A145A27B23E52008374BA /* ShellScript */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				4D3F253118C37D9A000922D9 /* PBXTargetDependency */,
-				4A8F6B4A14A9B6B80002F4D7 /* PBXTargetDependency */,
 				4A68AD7114A00534006DE321 /* PBXTargetDependency */,
 				4A68AD7314A00534006DE321 /* PBXTargetDependency */,
 				4A774CBD142F464D00E158CC /* PBXTargetDependency */,
 				551BF175112F3F3500265053 /* PBXTargetDependency */,
 			);
 			name = GitX;
+			packageProductDependencies = (
+				C0DE10000000000000000018 /* HighlightKit */,
+			);
 			productInstallPath = "$(HOME)/Applications";
 			productName = GitTest;
 			productReference = 8D1107320486CEB800E47090 /* GitX.app */;
@@ -1341,12 +1389,11 @@
 				de,
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* GitTest */;
+			packageReferences = (
+				C0DE10000000000000000017 /* XCRemoteSwiftPackageReference "HighlightKit" */,
+			);
 			projectDirPath = "";
 			projectReferences = (
-				{
-					ProductGroup = 4A8F6B3C14A9B6100002F4D7 /* Products */;
-					ProjectRef = 4A8F6B3B14A9B6100002F4D7 /* MGScopeBar.xcodeproj */;
-				},
 				{
 					ProductGroup = 4A4EF0A0142CBAD5001B8CDF /* Products */;
 					ProjectRef = 4A4EF09F142CBAD5001B8CDF /* ObjectiveGitFramework.xcodeproj */;
@@ -1363,6 +1410,7 @@
 				551BF110112F371800265053 /* gitx_askpasswd */,
 				4D3F252B18C37D2E000922D9 /* Generate Scripting Header */,
 				CC000008A000008 /* GitXUITests */,
+				C0DE2000000000000000000B /* GitXTests */,
 			);
 		};
 /* End PBXProject section */
@@ -1408,20 +1456,6 @@
 			fileType = "compiled.mach-o.executable";
 			path = BinaryDelta;
 			remoteRef = 4A68AD6C14A0050F006DE321 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A8F6B4514A9B6110002F4D7 /* MGScopeBar.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = MGScopeBar.app;
-			remoteRef = 4A8F6B4414A9B6110002F4D7 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4A8F6B4714A9B6110002F4D7 /* MGScopeBar.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = MGScopeBar.framework;
-			remoteRef = 4A8F6B4614A9B6110002F4D7 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		4ADAA9C21602ADB8007A0E6F /* ObjectiveGit-MacTests.xctest */ = {
@@ -1651,6 +1685,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		C0DE20000000000000000007 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C0DE20000000000000000001 /* GitXFeatureTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		551BF10E112F371800265053 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1663,6 +1705,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C0DE10000000000000000019 /* PBAutoFetchManager.m in Sources */,
+				C0DE10000000000000000011 /* PBHighlighting.swift in Sources */,
+				C0DE10000000000000000012 /* PBNativeContentView.m in Sources */,
+				C0DE10000000000000000013 /* PBHistoryArrayController.m in Sources */,
+				C0DE10000000000000000014 /* PBWorkingTree.m in Sources */,
+				C0DE10000000000000000015 /* PBUncommittedChanges.m in Sources */,
 				4A5D76E114A9A9CC00DF6C68 /* ApplicationController.m in Sources */,
 				4DF173E621A1A67C003CD3CE /* MAKVONotificationCenter.m in Sources */,
 				4A5D76E214A9A9CC00DF6C68 /* DBPrefsWindowController.m in Sources */,
@@ -1782,6 +1830,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		C0DE2000000000000000000A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8D1107260486CEB800E47090 /* GitX */;
+			targetProxy = C0DE20000000000000000009 /* PBXContainerItemProxy */;
+		};
 		4A467EF01546D1F300F8902B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ObjectiveGit;
@@ -1801,11 +1854,6 @@
 			isa = PBXTargetDependency;
 			target = 913D5E480E55644600CECEA2 /* cli tool */;
 			targetProxy = 4A774CBC142F464D00E158CC /* PBXContainerItemProxy */;
-		};
-		4A8F6B4A14A9B6B80002F4D7 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = MGScopeBar.framework;
-			targetProxy = 4A8F6B4914A9B6B80002F4D7 /* PBXContainerItemProxy */;
 		};
 		4D3F253118C37D9A000922D9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1905,6 +1953,48 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		C0DE2000000000000000000D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "-";
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Classes",
+					"$(PROJECT_DIR)/Classes/git",
+					"$(PROJECT_DIR)/Classes/Controllers",
+					"$(PROJECT_DIR)/Classes/Views",
+					"$(PROJECT_DIR)/Classes/Util",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.phere.GitXTests;
+				PRODUCT_NAME = GitXTests;
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/GitX.app/Contents/MacOS/GitX";
+			};
+			name = Debug;
+		};
+		C0DE2000000000000000000E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "-";
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Classes",
+					"$(PROJECT_DIR)/Classes/git",
+					"$(PROJECT_DIR)/Classes/Controllers",
+					"$(PROJECT_DIR)/Classes/Views",
+					"$(PROJECT_DIR)/Classes/Util",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.phere.GitXTests;
+				PRODUCT_NAME = GitXTests;
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/GitX.app/Contents/MacOS/GitX";
+			};
+			name = Release;
+		};
 		26FC0A850875C7B200E6366F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1924,7 +2014,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_OTHER_PREPROCESSOR_FLAGS = "-traditional";
 				INSTALL_PATH = /Applications;
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.phere.GitX;
 				PRODUCT_NAME = GitX;
@@ -1954,7 +2044,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_OTHER_PREPROCESSOR_FLAGS = "-traditional";
 				INSTALL_PATH = /Applications;
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.phere.GitX;
 				PRODUCT_NAME = GitX;
@@ -2008,7 +2098,7 @@
 					"\"$(PROJECT_DIR)/External/objective-git/External/libgit2/include\"",
 				);
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-Werror=incompatible-pointer-types";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -2058,7 +2148,7 @@
 					"\"$(PROJECT_DIR)/External/objective-git/External/libgit2/include\"",
 				);
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-Werror=incompatible-pointer-types";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -2145,7 +2235,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				GENERATE_INFOPLIST_FILE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.phere.GitXUITests;
 				PRODUCT_NAME = GitXUITests;
 				SDKROOT = macosx;
@@ -2158,7 +2248,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				GENERATE_INFOPLIST_FILE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.phere.GitXUITests;
 				PRODUCT_NAME = GitXUITests;
 				SDKROOT = macosx;
@@ -2169,6 +2259,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		C0DE2000000000000000000C /* Build configuration list for PBXNativeTarget "GitXTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C0DE2000000000000000000D /* Debug */,
+				C0DE2000000000000000000E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		CC000009A000009 /* Build configuration list for PBXNativeTarget "GitXUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -2224,6 +2323,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		C0DE10000000000000000017 /* XCRemoteSwiftPackageReference "HighlightKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/PhraseHQ/HighlightKit.git";
+			requirement = {
+				kind = exactVersion;
+				version = 0.1.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		C0DE10000000000000000018 /* HighlightKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C0DE10000000000000000017 /* XCRemoteSwiftPackageReference "HighlightKit" */;
+			productName = HighlightKit;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 29B97313FDCFA39411CA2CEA /* Project object */;
 }

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -21,19 +21,6 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		C0DE20000000000000000001 /* GitXFeatureTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE20000000000000000003 /* GitXFeatureTests.m */; };
-		C0DE20000000000000000002 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0DE20000000000000000005 /* XCTest.framework */; };
-		C0DE2000000000000000000F /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
-        CC0000010000001 /* GitXScreenshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC0000020000002 /* GitXScreenshotTests.m */; };
-		AABBCC0300000003 /* GitXSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0200000002 /* GitXSwift.swift */; };
-		C0DE10000000000000000011 /* PBHighlighting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10000000000000000002 /* PBHighlighting.swift */; };
-		C0DE10000000000000000012 /* PBNativeContentView.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10000000000000000004 /* PBNativeContentView.m */; };
-		C0DE10000000000000000013 /* PBHistoryArrayController.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10000000000000000006 /* PBHistoryArrayController.m */; };
-		C0DE10000000000000000014 /* PBWorkingTree.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10000000000000000008 /* PBWorkingTree.m */; };
-		C0DE10000000000000000015 /* PBUncommittedChanges.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE1000000000000000000A /* PBUncommittedChanges.m */; };
-		C0DE10000000000000000019 /* PBAutoFetchManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE1000000000000000000C /* PBAutoFetchManager.m */; };
-		C0DE1000000000000000001A /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0DE1000000000000000001B /* UserNotifications.framework */; };
-		C0DE10000000000000000016 /* HighlightKit in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE10000000000000000018 /* HighlightKit */; };
 		0A6858C711F7EA8A00AC2BE4 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A6858C611F7EA8A00AC2BE4 /* CoreServices.framework */; };
 		2682AABB1929140E00271A4D /* GTOID+JavaScript.m in Sources */ = {isa = PBXBuildFile; fileRef = 2682AABA1929140E00271A4D /* GTOID+JavaScript.m */; };
 		2DE9B60629ABEB450097873A /* GitX.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 2DE9B60529ABEB450097873A /* GitX.xcconfig */; };
@@ -114,7 +101,6 @@
 		4A5D771314A9A9CC00DF6C68 /* PBChangedFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D768D14A9A9CC00DF6C68 /* PBChangedFile.m */; };
 		4A5D771414A9A9CC00DF6C68 /* PBCLIProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D768F14A9A9CC00DF6C68 /* PBCLIProxy.m */; };
 		4A5D771514A9A9CC00DF6C68 /* PBCommitList.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D769114A9A9CC00DF6C68 /* PBCommitList.m */; };
-		94280860227842508DE943E1 /* PBCommitList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1CE3C5CEB7C423189591B5A /* PBCommitList.swift */; };
 		4A5D771614A9A9CC00DF6C68 /* PBGraphCellInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D769314A9A9CC00DF6C68 /* PBGraphCellInfo.m */; };
 		4A5D771714A9A9CC00DF6C68 /* PBNSURLPathUserDefaultsTransfomer.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D769514A9A9CC00DF6C68 /* PBNSURLPathUserDefaultsTransfomer.m */; };
 		4A5D771B14A9A9CC00DF6C68 /* PBUnsortableTableHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D769F14A9A9CC00DF6C68 /* PBUnsortableTableHeader.m */; };
@@ -170,6 +156,7 @@
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		911112370E5A097800BF76B4 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 911112360E5A097800BF76B4 /* Security.framework */; };
 		913D5E500E55645900CECEA2 /* gitx in Resources */ = {isa = PBXBuildFile; fileRef = 913D5E490E55644600CECEA2 /* gitx */; };
+		94280860227842508DE943E1 /* PBCommitList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1CE3C5CEB7C423189591B5A /* PBCommitList.swift */; };
 		978357A6189C05B100ADC689 /* FolderClosedTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 978357A4189C05B100ADC689 /* FolderClosedTemplate.pdf */; };
 		978357A7189C05B100ADC689 /* FolderTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 978357A5189C05B100ADC689 /* FolderTemplate.pdf */; };
 		978357AD189C074500ADC689 /* BranchTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 978357A8189C074500ADC689 /* BranchTemplate.pdf */; };
@@ -193,7 +180,21 @@
 		97CF01FB18A6C5BB00E30F2B /* new_file.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 97CF01F818A6C5BB00E30F2B /* new_file.pdf */; };
 		A2F8D0DF17AAB32500580B84 /* PBGitStash.m in Sources */ = {isa = PBXBuildFile; fileRef = A2F8D0DE17AAB32500580B84 /* PBGitStash.m */; };
 		A2F8D0EB17AAB95E00580B84 /* PBSourceViewGitStashItem.m in Sources */ = {isa = PBXBuildFile; fileRef = A2F8D0EA17AAB95E00580B84 /* PBSourceViewGitStashItem.m */; };
+		AABBCC0300000003 /* GitXSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0200000002 /* GitXSwift.swift */; };
 		BF42F1331E025403004769FF /* GitXTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = BF42F1321E025403004769FF /* GitXTextView.m */; };
+		C0DE10000000000000000011 /* PBHighlighting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10000000000000000002 /* PBHighlighting.swift */; };
+		C0DE10000000000000000012 /* PBNativeContentView.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10000000000000000004 /* PBNativeContentView.m */; };
+		C0DE10000000000000000013 /* PBHistoryArrayController.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10000000000000000006 /* PBHistoryArrayController.m */; };
+		C0DE10000000000000000014 /* PBWorkingTree.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10000000000000000008 /* PBWorkingTree.m */; };
+		C0DE10000000000000000015 /* PBUncommittedChanges.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE1000000000000000000A /* PBUncommittedChanges.m */; };
+		C0DE10000000000000000016 /* HighlightKit in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE10000000000000000018 /* HighlightKit */; };
+		C0DE10000000000000000019 /* PBAutoFetchManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE1000000000000000000C /* PBAutoFetchManager.m */; };
+		C0DE1000000000000000001A /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0DE1000000000000000001B /* UserNotifications.framework */; };
+		C0DE20000000000000000001 /* GitXFeatureTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE20000000000000000003 /* GitXFeatureTests.m */; };
+		C0DE20000000000000000002 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0DE20000000000000000005 /* XCTest.framework */; };
+		C0DE2000000000000000000F /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+		C0DE30000000000000000001 /* GitXCoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DE30000000000000000002 /* GitXCoreTests.m */; };
+		CC0000010000001 /* GitXScreenshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC0000020000002 /* GitXScreenshotTests.m */; };
 		D87127011229A21C00012334 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D87127001229A21C00012334 /* QuartzCore.framework */; };
 		D89E9B141218BA260097A90B /* ScriptingBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D89E9AB21218A9DA0097A90B /* ScriptingBridge.framework */; };
 		D8E3B2B810DC9FB2001096A3 /* ScriptingBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8E3B2B710DC9FB2001096A3 /* ScriptingBridge.framework */; };
@@ -201,13 +202,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		C0DE20000000000000000009 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8D1107260486CEB800E47090;
-			remoteInfo = GitX;
-		};
 		4A467EEF1546D1F300F8902B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 4A4EF09F142CBAD5001B8CDF /* ObjectiveGitFramework.xcodeproj */;
@@ -355,6 +349,20 @@
 			remoteGlobalIDString = EA4311A0229D5FBC00A5503D;
 			remoteInfo = ed25519;
 		};
+		C0DE20000000000000000009 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8D1107260486CEB800E47090;
+			remoteInfo = GitX;
+		};
+		CC000007B000007 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8D1107260486CEB800E47090;
+			remoteInfo = GitX;
+		};
 		D19D706127B8DA2A00A5C740 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 4A68AD5814A0050E006DE321 /* Sparkle.xcodeproj */;
@@ -411,13 +419,6 @@
 			remoteGlobalIDString = 721C24451CB753E6005440CB;
 			remoteInfo = "Installer Progress";
 		};
-		CC000007B000007 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8D1107260486CEB800E47090;
-			remoteInfo = GitX;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -435,26 +436,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		C0DE20000000000000000003 /* GitXFeatureTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXFeatureTests.m; sourceTree = "<group>"; };
-		C0DE20000000000000000004 /* GitXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GitXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		C0DE20000000000000000005 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		AABBCC0100000001 /* GitX-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GitX-Bridging-Header.h"; sourceTree = "<group>"; };
-		AABBCC0200000002 /* GitXSwift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitXSwift.swift; sourceTree = "<group>"; };
-		CC0000020000002 /* GitXScreenshotTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXScreenshotTests.m; sourceTree = "<group>"; };
-		CC0000030000003 /* GitXUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GitXUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		C0DE10000000000000000001 /* PBHighlighting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBHighlighting.h; sourceTree = "<group>"; };
-		C0DE10000000000000000002 /* PBHighlighting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBHighlighting.swift; sourceTree = "<group>"; };
-		C0DE10000000000000000003 /* PBNativeContentView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBNativeContentView.h; sourceTree = "<group>"; };
-		C0DE10000000000000000004 /* PBNativeContentView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBNativeContentView.m; sourceTree = "<group>"; };
-		C0DE10000000000000000005 /* PBHistoryArrayController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBHistoryArrayController.h; sourceTree = "<group>"; };
-		C0DE10000000000000000006 /* PBHistoryArrayController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBHistoryArrayController.m; sourceTree = "<group>"; };
-		C0DE10000000000000000007 /* PBWorkingTree.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBWorkingTree.h; sourceTree = "<group>"; };
-		C0DE10000000000000000008 /* PBWorkingTree.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBWorkingTree.m; sourceTree = "<group>"; };
-		C0DE10000000000000000009 /* PBUncommittedChanges.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBUncommittedChanges.h; sourceTree = "<group>"; };
-		C0DE1000000000000000000A /* PBUncommittedChanges.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBUncommittedChanges.m; sourceTree = "<group>"; };
-		C0DE1000000000000000000B /* PBAutoFetchManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBAutoFetchManager.h; sourceTree = "<group>"; };
-		C0DE1000000000000000000C /* PBAutoFetchManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBAutoFetchManager.m; sourceTree = "<group>"; };
-		C0DE1000000000000000001B /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
 		0A6858C611F7EA8A00AC2BE4 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		2682AAB91929140E00271A4D /* GTOID+JavaScript.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GTOID+JavaScript.h"; sourceTree = "<group>"; };
@@ -580,7 +561,6 @@
 		4A5D768F14A9A9CC00DF6C68 /* PBCLIProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = PBCLIProxy.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		4A5D769014A9A9CC00DF6C68 /* PBCommitList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBCommitList.h; sourceTree = "<group>"; };
 		4A5D769114A9A9CC00DF6C68 /* PBCommitList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBCommitList.m; sourceTree = "<group>"; };
-		A1CE3C5CEB7C423189591B5A /* PBCommitList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PBCommitList.swift; sourceTree = "<group>"; };
 		4A5D769214A9A9CC00DF6C68 /* PBGraphCellInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBGraphCellInfo.h; sourceTree = "<group>"; };
 		4A5D769314A9A9CC00DF6C68 /* PBGraphCellInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBGraphCellInfo.m; sourceTree = "<group>"; };
 		4A5D769414A9A9CC00DF6C68 /* PBNSURLPathUserDefaultsTransfomer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBNSURLPathUserDefaultsTransfomer.h; sourceTree = "<group>"; };
@@ -715,12 +695,34 @@
 		97CF01F718A6C5BB00E30F2B /* empty_file.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = empty_file.pdf; sourceTree = "<group>"; };
 		97CF01F818A6C5BB00E30F2B /* new_file.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = new_file.pdf; sourceTree = "<group>"; };
 		A1021294218C5A2000D97D11 /* iTerm2GeneratedScriptingBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iTerm2GeneratedScriptingBridge.h; sourceTree = "<group>"; };
+		A1CE3C5CEB7C423189591B5A /* PBCommitList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PBCommitList.swift; sourceTree = "<group>"; };
 		A2F8D0DD17AAB32500580B84 /* PBGitStash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBGitStash.h; sourceTree = "<group>"; };
 		A2F8D0DE17AAB32500580B84 /* PBGitStash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBGitStash.m; sourceTree = "<group>"; };
 		A2F8D0E917AAB95E00580B84 /* PBSourceViewGitStashItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBSourceViewGitStashItem.h; sourceTree = "<group>"; };
 		A2F8D0EA17AAB95E00580B84 /* PBSourceViewGitStashItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBSourceViewGitStashItem.m; sourceTree = "<group>"; };
+		AABBCC0100000001 /* GitX-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GitX-Bridging-Header.h"; sourceTree = "<group>"; };
+		AABBCC0200000002 /* GitXSwift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitXSwift.swift; sourceTree = "<group>"; };
 		BF42F1321E025403004769FF /* GitXTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXTextView.m; sourceTree = "<group>"; };
 		BF42F1431E025411004769FF /* GitXTextView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GitXTextView.h; sourceTree = "<group>"; };
+		C0DE10000000000000000001 /* PBHighlighting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBHighlighting.h; sourceTree = "<group>"; };
+		C0DE10000000000000000002 /* PBHighlighting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBHighlighting.swift; sourceTree = "<group>"; };
+		C0DE10000000000000000003 /* PBNativeContentView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBNativeContentView.h; sourceTree = "<group>"; };
+		C0DE10000000000000000004 /* PBNativeContentView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBNativeContentView.m; sourceTree = "<group>"; };
+		C0DE10000000000000000005 /* PBHistoryArrayController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBHistoryArrayController.h; sourceTree = "<group>"; };
+		C0DE10000000000000000006 /* PBHistoryArrayController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBHistoryArrayController.m; sourceTree = "<group>"; };
+		C0DE10000000000000000007 /* PBWorkingTree.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBWorkingTree.h; sourceTree = "<group>"; };
+		C0DE10000000000000000008 /* PBWorkingTree.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBWorkingTree.m; sourceTree = "<group>"; };
+		C0DE10000000000000000009 /* PBUncommittedChanges.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBUncommittedChanges.h; sourceTree = "<group>"; };
+		C0DE1000000000000000000A /* PBUncommittedChanges.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBUncommittedChanges.m; sourceTree = "<group>"; };
+		C0DE1000000000000000000B /* PBAutoFetchManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBAutoFetchManager.h; sourceTree = "<group>"; };
+		C0DE1000000000000000000C /* PBAutoFetchManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBAutoFetchManager.m; sourceTree = "<group>"; };
+		C0DE1000000000000000001B /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
+		C0DE20000000000000000003 /* GitXFeatureTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXFeatureTests.m; sourceTree = "<group>"; };
+		C0DE20000000000000000004 /* GitXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GitXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C0DE20000000000000000005 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		C0DE30000000000000000002 /* GitXCoreTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXCoreTests.m; sourceTree = "<group>"; };
+		CC0000020000002 /* GitXScreenshotTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXScreenshotTests.m; sourceTree = "<group>"; };
+		CC0000030000003 /* GitXUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GitXUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D87127001229A21C00012334 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		D89E9AB21218A9DA0097A90B /* ScriptingBridge.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ScriptingBridge.framework; path = System/Library/Frameworks/ScriptingBridge.framework; sourceTree = SDKROOT; };
 		D8E3B2B710DC9FB2001096A3 /* ScriptingBridge.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ScriptingBridge.framework; path = /System/Library/Frameworks/ScriptingBridge.framework; sourceTree = "<absolute>"; };
@@ -729,15 +731,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		C0DE20000000000000000008 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				C0DE2000000000000000000F /* Cocoa.framework in Frameworks */,
-				C0DE20000000000000000002 /* XCTest.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		551BF10F112F371800265053 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -776,6 +769,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C0DE20000000000000000008 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C0DE2000000000000000000F /* Cocoa.framework in Frameworks */,
+				C0DE20000000000000000002 /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CC0000060000006 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -796,24 +798,6 @@
 				C0DE20000000000000000004 /* GitXTests.xctest */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		CC0000040000004 /* GitXUITests */ = {
-			isa = PBXGroup;
-			children = (
-				CC0000020000002 /* GitXScreenshotTests.m */,
-			);
-			name = GitXUITests;
-			path = GitXUITests;
-			sourceTree = "<group>";
-		};
-		C0DE20000000000000000006 /* GitXTests */ = {
-			isa = PBXGroup;
-			children = (
-				C0DE20000000000000000003 /* GitXFeatureTests.m */,
-			);
-			name = GitXTests;
-			path = GitXTests;
 			sourceTree = "<group>";
 		};
 		29B97314FDCFA39411CA2CEA /* GitTest */ = {
@@ -1270,26 +1254,26 @@
 			name = libgit2;
 			sourceTree = "<group>";
 		};
+		C0DE20000000000000000006 /* GitXTests */ = {
+			isa = PBXGroup;
+			children = (
+				C0DE30000000000000000002 /* GitXCoreTests.m */,
+				C0DE20000000000000000003 /* GitXFeatureTests.m */,
+			);
+			path = GitXTests;
+			sourceTree = "<group>";
+		};
+		CC0000040000004 /* GitXUITests */ = {
+			isa = PBXGroup;
+			children = (
+				CC0000020000002 /* GitXScreenshotTests.m */,
+			);
+			path = GitXUITests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		C0DE2000000000000000000B /* GitXTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = C0DE2000000000000000000C /* Build configuration list for PBXNativeTarget "GitXTests" */;
-			buildPhases = (
-				C0DE20000000000000000007 /* Sources */,
-				C0DE20000000000000000008 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				C0DE2000000000000000000A /* PBXTargetDependency */,
-			);
-			name = GitXTests;
-			productName = GitXTests;
-			productReference = C0DE20000000000000000004 /* GitXTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		551BF110112F371800265053 /* gitx_askpasswd */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 551BF119112F373E00265053 /* Build configuration list for PBXNativeTarget "gitx_askpasswd" */;
@@ -1351,6 +1335,23 @@
 			productName = "cli tool";
 			productReference = 913D5E490E55644600CECEA2 /* gitx */;
 			productType = "com.apple.product-type.tool";
+		};
+		C0DE2000000000000000000B /* GitXTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C0DE2000000000000000000C /* Build configuration list for PBXNativeTarget "GitXTests" */;
+			buildPhases = (
+				C0DE20000000000000000007 /* Sources */,
+				C0DE20000000000000000008 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C0DE2000000000000000000A /* PBXTargetDependency */,
+			);
+			name = GitXTests;
+			productName = GitXTests;
+			productReference = C0DE20000000000000000004 /* GitXTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		CC000008A000008 /* GitXUITests */ = {
 			isa = PBXNativeTarget;
@@ -1666,33 +1667,9 @@
 			shellPath = /bin/sh;
 			shellScript = "#!/bin/bash\n\n# This script automatically sets the version and short version string of\n# an Xcode project from the Git repository containing the project.\n#\n# To use this script in Xcode, add the script's path to a \"Run Script\" build\n# phase for your application target.\n\nset -o errexit\nset -o nounset\n\n# Alternatively, we could use Xcode's copy of the Git binary,\n# but old Xcodes don't have this.\nGIT=$(xcrun -find git)\n\n# Run Script build phases that operate on product files of the target that defines them should use the value of this build setting [TARGET_BUILD_DIR]. But Run Script build phases that operate on product files of other targets should use “BUILT_PRODUCTS_DIR” instead.\nINFO_PLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n\n# Build version (closest-tag-or-branch \"-\" commits-since-tag \"-\" short-hash dirty-flag)\nBUILD_VERSION=$(git describe --tags --always --dirty=-dirty)-$(git rev-parse --abbrev-ref HEAD)\n\n# Use the latest tag for short version (expected tag format \"vn[.n[.n]]\")\n# or if there are no tags, we make up version 0.0.<commit count>\nLATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null)\nLATEST_TAG=${LATEST_TAG##v} # Remove the \"v\" from the front of the tag\nARCHITECTURE=$(uname -p)\nSHORT_VERSION=\"$LATEST_TAG\"\n\nMASTER_COMMIT_COUNT=$(git rev-list --count HEAD)\nBRANCH_COMMIT_COUNT=0\nBUNDLE_VERSION=\"$SHORT_VERSION\".\"$MASTER_COMMIT_COUNT [$ARCHITECTURE]\"\n\n# For debugging:\necho \"BUILD VERSION: $BUILD_VERSION\"\necho \"SHORT VERSION: $SHORT_VERSION\"\necho \"BUNDLE_VERSION: $BUNDLE_VERSION\"\n\n/usr/libexec/PlistBuddy -c \"Add :CFBundleBuildVersion string $BUILD_VERSION\" \"$INFO_PLIST\" 2>/dev/null || /usr/libexec/PlistBuddy -c \"Set :CFBundleBuildVersion $BUILD_VERSION\" \"$INFO_PLIST\"\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString $BUILD_VERSION\" \"$INFO_PLIST\"\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $BUNDLE_VERSION\" \"$INFO_PLIST\"\n";
 		};
-		F5CF04A20EAE696C00D75C81 /* Copy HTML files */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			comments = "This is added as a script rather than a 'copy files' phase because those aren't updated correctly when you edit just a single file in a directory.\n\nThis might be improved further by using rsync, but I didn't dive into that yet.";
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy HTML files";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "resource_path=\"$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH\"\nrm -rf \"$resource_path/html\"\ncp -r Resources/html \"$resource_path\"\n";
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		C0DE20000000000000000007 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				C0DE20000000000000000001 /* GitXFeatureTests.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		551BF10E112F371800265053 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1819,6 +1796,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C0DE20000000000000000007 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C0DE30000000000000000001 /* GitXCoreTests.m in Sources */,
+				C0DE20000000000000000001 /* GitXFeatureTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CC0000050000005 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1830,11 +1816,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		C0DE2000000000000000000A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 8D1107260486CEB800E47090 /* GitX */;
-			targetProxy = C0DE20000000000000000009 /* PBXContainerItemProxy */;
-		};
 		4A467EF01546D1F300F8902B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ObjectiveGit;
@@ -1869,6 +1850,11 @@
 			isa = PBXTargetDependency;
 			target = 551BF110112F371800265053 /* gitx_askpasswd */;
 			targetProxy = 551BF174112F3F3500265053 /* PBXContainerItemProxy */;
+		};
+		C0DE2000000000000000000A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8D1107260486CEB800E47090 /* GitX */;
+			targetProxy = C0DE20000000000000000009 /* PBXContainerItemProxy */;
 		};
 		CC000007A000007 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1953,63 +1939,22 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		C0DE2000000000000000000D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_IDENTITY = "-";
-				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/Classes",
-					"$(PROJECT_DIR)/Classes/git",
-					"$(PROJECT_DIR)/Classes/Controllers",
-					"$(PROJECT_DIR)/Classes/Views",
-					"$(PROJECT_DIR)/Classes/Util",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				PRODUCT_BUNDLE_IDENTIFIER = net.phere.GitXTests;
-				PRODUCT_NAME = GitXTests;
-				SDKROOT = macosx;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/GitX.app/Contents/MacOS/GitX";
-			};
-			name = Debug;
-		};
-		C0DE2000000000000000000E /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_IDENTITY = "-";
-				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/Classes",
-					"$(PROJECT_DIR)/Classes/git",
-					"$(PROJECT_DIR)/Classes/Controllers",
-					"$(PROJECT_DIR)/Classes/Views",
-					"$(PROJECT_DIR)/Classes/Util",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				PRODUCT_BUNDLE_IDENTIFIER = net.phere.GitXTests;
-				PRODUCT_NAME = GitXTests;
-				SDKROOT = macosx;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/GitX.app/Contents/MacOS/GitX";
-			};
-			name = Release;
-		};
 		26FC0A850875C7B200E6366F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = GitX.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = MGPHJKUJSY;
 				FRAMEWORK_SEARCH_PATHS = "\"$(PROJECT_DIR)\"";
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = Resources/GitX_Prefix.pch;
 				INFOPLIST_FILE = Resources/Info.plist;
-				SWIFT_OBJC_BRIDGING_HEADER = Classes/GitX-Bridging-Header.h;
-				SWIFT_VERSION = 5.0;
 				INFOPLIST_KEY_CFBundleDisplayName = GitX;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_OTHER_PREPROCESSOR_FLAGS = "-traditional";
@@ -2018,6 +1963,9 @@
 				MARKETING_VERSION = 0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.phere.GitX;
 				PRODUCT_NAME = GitX;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = "Classes/GitX-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = "x86_64 arm64";
 				VERSIONING_SYSTEM = "apple-generic";
 				WRAPPER_EXTENSION = app;
@@ -2030,16 +1978,17 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = GitX.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = MGPHJKUJSY;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = "\"$(PROJECT_DIR)\"";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = Resources/GitX_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = "";
 				INFOPLIST_FILE = Resources/Info.plist;
-				SWIFT_OBJC_BRIDGING_HEADER = Classes/GitX-Bridging-Header.h;
-				SWIFT_VERSION = 5.0;
 				INFOPLIST_KEY_CFBundleDisplayName = GitX;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_OTHER_PREPROCESSOR_FLAGS = "-traditional";
@@ -2048,7 +1997,10 @@
 				MARKETING_VERSION = 0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.phere.GitX;
 				PRODUCT_NAME = GitX;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRIP_INSTALLED_PRODUCT = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "Classes/GitX-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = "x86_64 arm64";
 				VERSIONING_SYSTEM = "apple-generic";
 				WRAPPER_EXTENSION = app;
@@ -2084,6 +2036,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				EXCLUDED_ARCHS = x86_64;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
@@ -2101,7 +2054,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-Werror=incompatible-pointer-types";
-				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = macosx;
 				STRIP_INSTALLED_PRODUCT = NO;
 				VALID_ARCHS = "x86_64 arm64";
@@ -2135,6 +2087,7 @@
 				CURRENT_PROJECT_VERSION = 0.12;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXCLUDED_ARCHS = x86_64;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = GITX_NO_DEPRECATE;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -2151,7 +2104,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-Werror=incompatible-pointer-types";
-				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = macosx;
 				VALID_ARCHS = "x86_64 arm64";
 			};
@@ -2230,6 +2182,48 @@
 			};
 			name = Release;
 		};
+		C0DE2000000000000000000D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "-";
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Classes",
+					"$(PROJECT_DIR)/Classes/git",
+					"$(PROJECT_DIR)/Classes/Controllers",
+					"$(PROJECT_DIR)/Classes/Views",
+					"$(PROJECT_DIR)/Classes/Util",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.phere.GitXTests;
+				PRODUCT_NAME = GitXTests;
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/GitX.app/Contents/MacOS/GitX";
+			};
+			name = Debug;
+		};
+		C0DE2000000000000000000E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "-";
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Classes",
+					"$(PROJECT_DIR)/Classes/git",
+					"$(PROJECT_DIR)/Classes/Controllers",
+					"$(PROJECT_DIR)/Classes/Views",
+					"$(PROJECT_DIR)/Classes/Util",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.phere.GitXTests;
+				PRODUCT_NAME = GitXTests;
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/GitX.app/Contents/MacOS/GitX";
+			};
+			name = Release;
+		};
 		CC00000AA00000A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2259,24 +2253,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		C0DE2000000000000000000C /* Build configuration list for PBXNativeTarget "GitXTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				C0DE2000000000000000000D /* Debug */,
-				C0DE2000000000000000000E /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		CC000009A000009 /* Build configuration list for PBXNativeTarget "GitXUITests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				CC00000AA00000A /* Debug */,
-				CC00000BA00000B /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		26FC0A840875C7B200E6366F /* Build configuration list for PBXNativeTarget "GitX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -2318,6 +2294,24 @@
 			buildConfigurations = (
 				913D5E4B0E55644600CECEA2 /* Debug */,
 				913D5E4C0E55644600CECEA2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C0DE2000000000000000000C /* Build configuration list for PBXNativeTarget "GitXTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C0DE2000000000000000000D /* Debug */,
+				C0DE2000000000000000000E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CC000009A000009 /* Build configuration list for PBXNativeTarget "GitXUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CC00000AA00000A /* Debug */,
+				CC00000BA00000B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/GitX.xcodeproj/xcshareddata/xcschemes/GitX.xcscheme
+++ b/GitX.xcodeproj/xcshareddata/xcschemes/GitX.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BBCCDDA000000A00"
+               BlueprintIdentifier = "C0DE2000000000000000000B"
                BuildableName = "GitXTests.xctest"
                BlueprintName = "GitXTests"
                ReferencedContainer = "container:GitX.xcodeproj">
@@ -76,7 +76,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BBCCDDA000000A00"
+               BlueprintIdentifier = "C0DE2000000000000000000B"
                BuildableName = "GitXTests.xctest"
                BlueprintName = "GitXTests"
                ReferencedContainer = "container:GitX.xcodeproj">

--- a/GitX.xcodeproj/xcshareddata/xcschemes/GitX.xcscheme
+++ b/GitX.xcodeproj/xcshareddata/xcschemes/GitX.xcscheme
@@ -64,13 +64,18 @@
             ReferencedContainer = "container:GitX.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "GITX_UITEST_REPO"
-            value = "$(GITX_SCREENSHOT_REPO)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:GitXTests/GitX.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:GitXTests/GitXAddressUndefined.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:GitXTests/GitXThreadSanitizer.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/GitX.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GitX.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "fdb8ee2984dd82212388d07e31e3536a31a63b3883913e13a00018dd340075b6",
+  "pins" : [
+    {
+      "identity" : "highlightkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PhraseHQ/HighlightKit.git",
+      "state" : {
+        "revision" : "b323d4a052dba9155120587686e54ef535852235",
+        "version" : "0.1.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+        "version" : "0.5.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/GitXTests/GitX.xctestplan
+++ b/GitXTests/GitX.xctestplan
@@ -1,0 +1,37 @@
+{
+  "configurations" : [
+    {
+      "id" : "C6D29B2D-6A21-45CB-AFF6-96234E2B2ABF",
+      "name" : "Default",
+      "options" : {
+        "mainThreadCheckerEnabled" : true
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : true,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:GitX.xcodeproj",
+      "identifier" : "8D1107260486CEB800E47090",
+      "name" : "GitX"
+    },
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:GitX.xcodeproj",
+        "identifier" : "C0DE2000000000000000000B",
+        "name" : "GitXTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:GitX.xcodeproj",
+        "identifier" : "CC000008A000008",
+        "name" : "GitXUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/GitXTests/GitXAddressUndefined.xctestplan
+++ b/GitXTests/GitXAddressUndefined.xctestplan
@@ -1,0 +1,34 @@
+{
+  "configurations" : [
+    {
+      "id" : "042BB3B6-E916-4F9F-A735-E5B65A786F31",
+      "name" : "Address and Undefined Behavior",
+      "options" : {
+        "addressSanitizer" : {
+          "enabled" : true
+        },
+        "mainThreadCheckerEnabled" : true,
+        "undefinedBehaviorSanitizerEnabled" : true
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:GitX.xcodeproj",
+      "identifier" : "8D1107260486CEB800E47090",
+      "name" : "GitX"
+    },
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:GitX.xcodeproj",
+        "identifier" : "C0DE2000000000000000000B",
+        "name" : "GitXTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/GitXTests/GitXCoreTests.m
+++ b/GitXTests/GitXCoreTests.m
@@ -1,0 +1,572 @@
+#import <XCTest/XCTest.h>
+#import <ObjectiveGit/GTCommit.h>
+#import <ObjectiveGit/GTOID.h>
+#import <ObjectiveGit/GTRepository.h>
+
+#import "PBChangedFile.h"
+#import "PBGraphCellInfo.h"
+#import "PBGitBinary.h"
+#import "PBGitCommit.h"
+#import "PBGitGrapher.h"
+#import "PBGitIndex.h"
+#import "PBGitRef.h"
+#import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
+#import "PBGitRevSpecifier.h"
+#import "PBNativeContentView.h"
+#import "PBUncommittedChanges.h"
+#import "PBWorkingTree.h"
+#import "PBTask.h"
+
+@interface PBNativeContentView (GitXCoreTests)
+- (nullable NSString *)patchWithFileHeader:(NSArray<NSString *> *)fileHeader
+								 hunkLines:(NSArray<NSString *> *)hunkLines
+						   selectedIndexes:(NSIndexSet *)selectedIndexes
+								   reverse:(BOOL)reverse;
+@end
+
+@interface GitXTestRepository : NSObject
+
+@property (nonatomic, copy, readonly) NSString *path;
+
+- (nullable instancetype)initWithError:(NSError **)error;
+- (nullable NSString *)git:(NSArray<NSString *> *)arguments error:(NSError **)error;
+- (BOOL)writeText:(NSString *)text toPath:(NSString *)relativePath error:(NSError **)error;
+- (BOOL)commitAllWithMessage:(NSString *)message error:(NSError **)error;
+
+@end
+
+@implementation GitXTestRepository
+
+- (nullable instancetype)initWithError:(NSError **)error
+{
+	self = [super init];
+	if (!self) return nil;
+
+	_path = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"GitXTests-%@", NSUUID.UUID.UUIDString]];
+	if (![[NSFileManager defaultManager] createDirectoryAtPath:_path withIntermediateDirectories:YES attributes:nil error:error])
+		return nil;
+
+	if (![self git:@[ @"init", @"--quiet", @"--initial-branch=main" ] error:error] ||
+		![self git:@[ @"config", @"user.name", @"GitX Test" ] error:error] ||
+		![self git:@[ @"config", @"user.email", @"gitx-tests@example.invalid" ] error:error])
+		return nil;
+
+	return self;
+}
+
+- (void)dealloc
+{
+	[[NSFileManager defaultManager] removeItemAtPath:self.path error:nil];
+}
+
+- (nullable NSString *)git:(NSArray<NSString *> *)arguments error:(NSError **)error
+{
+	return [PBTask outputForCommand:PBGitBinary.path arguments:arguments inDirectory:self.path error:error];
+}
+
+- (BOOL)writeText:(NSString *)text toPath:(NSString *)relativePath error:(NSError **)error
+{
+	NSString *absolutePath = [self.path stringByAppendingPathComponent:relativePath];
+	NSString *parent = absolutePath.stringByDeletingLastPathComponent;
+	if (![[NSFileManager defaultManager] createDirectoryAtPath:parent withIntermediateDirectories:YES attributes:nil error:error])
+		return NO;
+	return [text writeToFile:absolutePath atomically:YES encoding:NSUTF8StringEncoding error:error];
+}
+
+- (BOOL)commitAllWithMessage:(NSString *)message error:(NSError **)error
+{
+	return [self git:@[ @"add", @"--all" ] error:error] != nil &&
+		[self git:@[ @"commit", @"--quiet", @"-m", message ]
+			error:error] != nil;
+}
+
+@end
+
+@interface GitXRepositoryTestCase : XCTestCase
+
+@property (nonatomic, strong) GitXTestRepository *fixture;
+@property (nonatomic, strong) PBGitRepository *repository;
+
+- (void)refreshIndexAfterPerforming:(dispatch_block_t)operation;
+- (nullable PBChangedFile *)changedFileAtPath:(NSString *)path;
+- (nullable PBGitTree *)treeAtPath:(NSString *)path inRoot:(PBGitTree *)root;
+
+@end
+
+
+@implementation GitXRepositoryTestCase
+
+- (void)setUp
+{
+	[super setUp];
+	NSError *error = nil;
+	self.fixture = [[GitXTestRepository alloc] initWithError:&error];
+	XCTAssertNotNil(self.fixture, @"%@", error);
+	XCTAssertTrue([self.fixture writeText:@"first line\n" toPath:@"tracked.txt" error:&error], @"%@", error);
+	XCTAssertTrue([self.fixture commitAllWithMessage:@"initial commit" error:&error], @"%@", error);
+	self.repository = [[PBGitRepository alloc] initWithURL:[NSURL fileURLWithPath:self.fixture.path] error:&error];
+	XCTAssertNotNil(self.repository, @"%@", error);
+}
+
+- (void)tearDown
+{
+	self.repository = nil;
+	self.fixture = nil;
+	[super tearDown];
+}
+
+- (void)refreshIndexAfterPerforming:(dispatch_block_t)operation
+{
+	XCTestExpectation *expectation = [self expectationWithDescription:@"index refresh finished"];
+	id token = [[NSNotificationCenter defaultCenter]
+		addObserverForName:PBGitIndexFinishedIndexRefresh
+					object:self.repository.index
+					 queue:NSOperationQueue.mainQueue
+				usingBlock:^(__unused NSNotification *notification) {
+					[expectation fulfill];
+				}];
+	operation();
+	[self waitForExpectations:@[ expectation ] timeout:10.0];
+	[[NSNotificationCenter defaultCenter] removeObserver:token];
+}
+
+- (nullable PBChangedFile *)changedFileAtPath:(NSString *)path
+{
+	for (PBChangedFile *file in self.repository.index.indexChanges) {
+		if ([file.path isEqualToString:path])
+			return file;
+	}
+	return nil;
+}
+
+- (nullable PBGitTree *)treeAtPath:(NSString *)path inRoot:(PBGitTree *)root
+{
+	NSMutableArray<PBGitTree *> *pending = [root.children mutableCopy];
+	while (pending.count) {
+		PBGitTree *candidate = pending.firstObject;
+		[pending removeObjectAtIndex:0];
+		if ([candidate.fullPath isEqualToString:path]) return candidate;
+		[pending addObjectsFromArray:candidate.children];
+	}
+	return nil;
+}
+
+@end
+
+
+@interface GitXRefAndRevisionTests : XCTestCase
+@end
+
+@implementation GitXRefAndRevisionTests
+
+- (void)testRefClassificationAndNames
+{
+	PBGitRef *branch = [PBGitRef refFromString:@"refs/heads/feature/nested"];
+	XCTAssertTrue(branch.isBranch);
+	XCTAssertEqualObjects(branch.branchName, @"feature/nested");
+	XCTAssertEqualObjects(branch.shortName, @"feature/nested");
+	XCTAssertEqualObjects(branch.refishType, kGitXBranchType);
+
+	PBGitRef *tag = [PBGitRef refFromString:@"refs/tags/v1.2.3"];
+	XCTAssertTrue(tag.isTag);
+	XCTAssertEqualObjects(tag.tagName, @"v1.2.3");
+	XCTAssertEqualObjects(tag.refishType, kGitXTagType);
+
+	PBGitRef *remoteBranch = [PBGitRef refFromString:@"refs/remotes/origin/team/topic"];
+	XCTAssertTrue(remoteBranch.isRemote);
+	XCTAssertTrue(remoteBranch.isRemoteBranch);
+	XCTAssertEqualObjects(remoteBranch.remoteName, @"origin");
+	XCTAssertEqualObjects(remoteBranch.remoteBranchName, @"team/topic");
+	XCTAssertEqualObjects(remoteBranch.remoteRef.ref, @"refs/remotes/origin");
+	XCTAssertEqualObjects(remoteBranch.refishType, kGitXRemoteBranchType);
+
+	PBGitRef *stash = [PBGitRef refFromString:@"refs/stash@{2}"];
+	XCTAssertTrue(stash.isStash);
+	XCTAssertEqualObjects(stash.shortName, @"stash@{2}");
+	XCTAssertEqualObjects(stash.refishType, kGitXStashType);
+}
+
+- (void)testRefEqualityUsesFullReference
+{
+	PBGitRef *first = [PBGitRef refFromString:@"refs/heads/main"];
+	PBGitRef *same = [PBGitRef refFromString:@"refs/heads/main"];
+	PBGitRef *tag = [PBGitRef refFromString:@"refs/tags/main"];
+	XCTAssertTrue([first isEqualToRef:same]);
+	XCTAssertFalse([first isEqualToRef:tag]);
+}
+
+- (void)testRevisionSpecifierDistinguishesSimpleAndComplexRevisions
+{
+	PBGitRevSpecifier *simple = [[PBGitRevSpecifier alloc] initWithParameters:@[ @"refs/heads/main" ]];
+	XCTAssertTrue(simple.isSimpleRef);
+	XCTAssertEqualObjects(simple.simpleRef, @"refs/heads/main");
+	XCTAssertEqualObjects(simple.ref.ref, @"refs/heads/main");
+	XCTAssertFalse(simple.hasPathLimiter);
+
+	NSArray<NSString *> *complexValues = @[ @"HEAD~2", @"main..topic", @"branch@{upstream}", @"-invalid", @"name with space" ];
+	for (NSString *value in complexValues) {
+		PBGitRevSpecifier *complex = [[PBGitRevSpecifier alloc] initWithParameters:@[ value ]];
+		XCTAssertFalse(complex.isSimpleRef, @"%@ should be complex", value);
+		XCTAssertNil(complex.simpleRef);
+	}
+
+	PBGitRevSpecifier *pathLimited = [[PBGitRevSpecifier alloc] initWithParameters:@[ @"HEAD", @"--", @"Sources" ]];
+	XCTAssertTrue(pathLimited.hasPathLimiter);
+	XCTAssertEqualObjects(pathLimited.title, @"“Sources”");
+}
+
+- (void)testRevisionSpecifierCopyAndWellKnownFilters
+{
+	PBGitRevSpecifier *source = [[PBGitRevSpecifier alloc] initWithParameters:@[ @"main", @"--", @"file.txt" ] description:@"selection"];
+	source.workingDirectory = [NSURL fileURLWithPath:@"/tmp"];
+	PBGitRevSpecifier *copy = [source copy];
+	XCTAssertNotEqual(source, copy);
+	XCTAssertEqualObjects(source.parameters, copy.parameters);
+	XCTAssertEqualObjects(source.description, copy.description);
+	XCTAssertEqualObjects(source.workingDirectory, copy.workingDirectory);
+	XCTAssertTrue(PBGitRevSpecifier.allBranchesRevSpec.isAllBranchesRev);
+	XCTAssertTrue(PBGitRevSpecifier.localBranchesRevSpec.isLocalBranchesRev);
+}
+
+@end
+
+
+@interface GitXRepositoryIntegrationTests : GitXRepositoryTestCase
+@end
+
+
+@implementation GitXRepositoryIntegrationTests
+
+- (void)testRepositoryDiscoversHeadAndReferences
+{
+	XCTAssertFalse(self.repository.isBareRepository);
+	XCTAssertFalse(self.repository.isShallowRepository);
+	XCTAssertEqualObjects(self.repository.workingDirectory.stringByResolvingSymlinksInPath,
+						  self.fixture.path.stringByResolvingSymlinksInPath);
+	XCTAssertEqualObjects(self.repository.projectName, self.fixture.path.lastPathComponent);
+	XCTAssertNotNil(self.repository.headOID);
+	XCTAssertEqualObjects(self.repository.headRef.ref.ref, @"refs/heads/main");
+	XCTAssertTrue([self.repository revisionExists:@"HEAD"]);
+	XCTAssertFalse([self.repository revisionExists:@"refs/heads/missing"]);
+
+	PBGitRef *main = [self.repository refForName:@"main"];
+	XCTAssertEqualObjects(main.ref, @"refs/heads/main");
+	XCTAssertTrue([self.repository refExists:main]);
+	XCTAssertTrue([self.repository checkRefFormat:@"refs/heads/valid-name"]);
+	XCTAssertFalse([self.repository checkRefFormat:@"invalid ref"]);
+}
+
+- (void)testCreateReloadAndDeleteBranchAndTag
+{
+	NSError *error = nil;
+	XCTAssertTrue([self.repository createBranch:@"feature/integration" atRefish:self.repository.headRef.ref error:&error], @"%@", error);
+	XCTAssertTrue([self.repository createTag:@"v-test" message:@"integration tag" atRefish:self.repository.headRef.ref error:&error], @"%@", error);
+	[self.repository reloadRefs];
+
+	PBGitRef *branch = [self.repository refForName:@"feature/integration"];
+	PBGitRef *tag = [self.repository refForName:@"v-test"];
+	XCTAssertNotNil(branch);
+	XCTAssertNotNil(tag);
+	XCTAssertTrue([self.repository refExists:branch]);
+	XCTAssertTrue([self.repository refExists:tag]);
+	XCTAssertTrue([self.repository deleteRef:branch error:&error], @"%@", error);
+	XCTAssertTrue([self.repository deleteRef:tag error:&error], @"%@", error);
+	XCTAssertFalse([self.repository refExists:branch]);
+	XCTAssertFalse([self.repository refExists:tag]);
+}
+
+- (void)testRemoteDiscoveryUsesLocalFixture
+{
+	NSError *error = nil;
+	XCTAssertTrue([self.repository addRemote:@"origin" withURL:self.fixture.path error:&error], @"%@", error);
+	XCTAssertEqualObjects(self.repository.remotes, (@[ @"origin" ]));
+	XCTAssertTrue(self.repository.hasRemotes);
+	NSString *fetchOutput = [self.fixture git:@[ @"fetch", @"--quiet", @"origin" ] error:&error];
+	XCTAssertNotNil(fetchOutput, @"%@", error);
+	[self.repository reloadRefs];
+	XCTAssertNotNil([self.repository refForName:@"origin/main"]);
+}
+
+- (void)testDetachedHeadIsRepresentedByHeadSpecifier
+{
+	NSError *error = nil;
+	NSString *checkoutOutput = [self.fixture git:@[ @"checkout", @"--quiet", @"--detach", @"HEAD" ] error:&error];
+	XCTAssertNotNil(checkoutOutput, @"%@", error);
+	self.repository = nil;
+	self.repository = [[PBGitRepository alloc] initWithURL:[NSURL fileURLWithPath:self.fixture.path] error:&error];
+	XCTAssertNotNil(self.repository, @"%@", error);
+	XCTAssertEqualObjects(self.repository.headRef.simpleRef, @"HEAD");
+	XCTAssertEqualObjects(self.repository.headRef.title, @"“detached HEAD”");
+	XCTAssertNotNil(self.repository.headOID);
+}
+
+- (void)testBareAndShallowRepositoryDiscovery
+{
+	NSError *error = nil;
+	NSString *barePath = [self.fixture.path stringByAppendingString:@"-bare.git"];
+	NSString *shallowPath = [self.fixture.path stringByAppendingString:@"-shallow"];
+	@try {
+		NSString *bareOutput = [self.fixture git:@[ @"clone", @"--bare", @"--quiet", self.fixture.path, barePath ] error:&error];
+		XCTAssertNotNil(bareOutput, @"%@", error);
+		PBGitRepository *bare = [[PBGitRepository alloc] initWithURL:[NSURL fileURLWithPath:barePath] error:&error];
+		XCTAssertNotNil(bare, @"%@", error);
+		XCTAssertTrue(bare.isBareRepository);
+		XCTAssertFalse(bare.isShallowRepository);
+		XCTAssertNotNil(bare.headOID);
+
+		XCTAssertTrue([self.fixture writeText:@"second commit\n" toPath:@"second.txt" error:&error], @"%@", error);
+		XCTAssertTrue([self.fixture commitAllWithMessage:@"second commit" error:&error], @"%@", error);
+		NSString *sourceURL = [NSURL fileURLWithPath:self.fixture.path].absoluteString;
+		NSString *shallowOutput = [self.fixture git:@[ @"clone", @"--quiet", @"--depth", @"1", sourceURL, shallowPath ] error:&error];
+		XCTAssertNotNil(shallowOutput, @"%@", error);
+		PBGitRepository *shallow = [[PBGitRepository alloc] initWithURL:[NSURL fileURLWithPath:shallowPath] error:&error];
+		XCTAssertNotNil(shallow, @"%@", error);
+		XCTAssertTrue(shallow.isShallowRepository);
+		NSString *commitCount = [PBTask outputForCommand:PBGitBinary.path arguments:@[ @"rev-list", @"--count", @"HEAD" ] inDirectory:shallowPath error:&error];
+		XCTAssertEqualObjects([commitCount stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet], @"1");
+	} @finally {
+		[[NSFileManager defaultManager] removeItemAtPath:barePath error:nil];
+		[[NSFileManager defaultManager] removeItemAtPath:shallowPath error:nil];
+	}
+}
+
+- (void)testLinkedWorktreeDiscovery
+{
+	NSError *error = nil;
+	NSString *worktreePath = [self.fixture.path stringByAppendingString:@"-worktree"];
+	PBGitRepository *worktree = nil;
+	@try {
+		NSString *output = [self.fixture git:@[ @"worktree", @"add", @"--quiet", @"-b", @"linked", worktreePath ] error:&error];
+		XCTAssertNotNil(output, @"%@", error);
+		worktree = [[PBGitRepository alloc] initWithURL:[NSURL fileURLWithPath:worktreePath] error:&error];
+		XCTAssertNotNil(worktree, @"%@", error);
+		XCTAssertEqualObjects(worktree.workingDirectory.stringByResolvingSymlinksInPath,
+							  worktreePath.stringByResolvingSymlinksInPath);
+		XCTAssertEqualObjects(worktree.headRef.ref.branchName, @"linked");
+	} @finally {
+		worktree = nil;
+		[self.fixture git:@[ @"worktree", @"remove", @"--force", worktreePath ] error:nil];
+		[[NSFileManager defaultManager] removeItemAtPath:worktreePath error:nil];
+	}
+}
+
+- (void)testSubmoduleDiscovery
+{
+	NSError *error = nil;
+	GitXTestRepository *submoduleSource = [[GitXTestRepository alloc] initWithError:&error];
+	XCTAssertNotNil(submoduleSource, @"%@", error);
+	XCTAssertTrue([submoduleSource writeText:@"child\n" toPath:@"child.txt" error:&error], @"%@", error);
+	XCTAssertTrue([submoduleSource commitAllWithMessage:@"child commit" error:&error], @"%@", error);
+	NSString *output = [self.fixture git:@[ @"-c", @"protocol.file.allow=always", @"submodule", @"add", @"--quiet", submoduleSource.path, @"Modules/Child" ] error:&error];
+	XCTAssertNotNil(output, @"%@", error);
+	XCTAssertTrue([self.fixture commitAllWithMessage:@"add submodule" error:&error], @"%@", error);
+	[self.repository reloadRefs];
+	XCTAssertEqual(self.repository.submodules.count, 1);
+	XCTAssertNotNil([self.repository submoduleAtPath:@"Modules/Child" error:&error], @"%@", error);
+}
+
+- (void)testCommitGraphDecoratesMergeHistory
+{
+	NSError *error = nil;
+	XCTAssertNotNil(([self.fixture git:@[ @"checkout", @"--quiet", @"-b", @"topic" ] error:&error]));
+	XCTAssertTrue([self.fixture writeText:@"topic\n" toPath:@"topic.txt" error:&error], @"%@", error);
+	XCTAssertTrue([self.fixture commitAllWithMessage:@"topic commit" error:&error], @"%@", error);
+	XCTAssertNotNil(([self.fixture git:@[ @"checkout", @"--quiet", @"main" ] error:&error]));
+	XCTAssertTrue([self.fixture writeText:@"main\n" toPath:@"main.txt" error:&error], @"%@", error);
+	XCTAssertTrue([self.fixture commitAllWithMessage:@"main commit" error:&error], @"%@", error);
+	XCTAssertNotNil(([self.fixture git:@[ @"merge", @"--quiet", @"--no-ff", @"topic", @"-m", @"merge topic" ] error:&error]));
+
+	NSString *revisionOutput = [self.fixture git:@[ @"rev-list", @"--topo-order", @"--all" ] error:&error];
+	NSArray<NSString *> *revisions = [revisionOutput componentsSeparatedByCharactersInSet:NSCharacterSet.newlineCharacterSet];
+	PBGitGrapher *grapher = [[PBGitGrapher alloc] init];
+	__block long maximumColumns = 0;
+	for (NSString *SHA in revisions) {
+		if (!SHA.length) continue;
+		GTCommit *gtCommit = [self.repository.gtRepo lookUpObjectBySHA:SHA objectType:GTObjectTypeCommit error:&error];
+		XCTAssertNotNil(gtCommit, @"%@", error);
+		PBGitCommit *commit = [[PBGitCommit alloc] initWithRepository:self.repository andCommit:gtCommit];
+		[grapher decorateCommit:commit];
+		XCTAssertNotNil(commit.lineInfo);
+		maximumColumns = MAX(maximumColumns, commit.lineInfo.numColumns);
+	}
+	XCTAssertGreaterThanOrEqual(maximumColumns, 2, @"A merge should use at least two graph lanes");
+}
+
+@end
+
+
+@interface GitXIndexIntegrationTests : GitXRepositoryTestCase
+@end
+
+
+@implementation GitXIndexIntegrationTests
+
+- (void)testRefreshStageAndUnstageTrackedAndUnicodePaths
+{
+	NSError *error = nil;
+	XCTAssertTrue([self.fixture writeText:@"first line\nsecond line\n" toPath:@"tracked.txt" error:&error], @"%@", error);
+	XCTAssertTrue([self.fixture writeText:@"new contents\n" toPath:@"folder/spaced ünicode.txt" error:&error], @"%@", error);
+	[self refreshIndexAfterPerforming:^{
+		[self.repository.index refresh];
+	}];
+
+	PBChangedFile *tracked = [self changedFileAtPath:@"tracked.txt"];
+	PBChangedFile *untracked = [self changedFileAtPath:@"folder/spaced ünicode.txt"];
+	XCTAssertNotNil(tracked);
+	XCTAssertNotNil(untracked);
+	XCTAssertEqual(tracked.status, MODIFIED);
+	XCTAssertEqual(untracked.status, NEW);
+	XCTAssertTrue(tracked.hasUnstagedChanges);
+	XCTAssertTrue(untracked.hasUnstagedChanges);
+
+	XCTAssertTrue(([self.repository.index stageFiles:@[ tracked, untracked ]]));
+	NSString *cached = [self.fixture git:@[ @"diff", @"--cached", @"--name-only" ] error:&error];
+	XCTAssertTrue([cached containsString:@"tracked.txt"]);
+	XCTAssertTrue([cached containsString:@"folder/spaced"]);
+	XCTAssertTrue(([self.repository.index unstageFiles:@[ tracked, untracked ]]));
+	NSString *cachedAfterUnstage = [self.fixture git:@[ @"diff", @"--cached", @"--name-only" ] error:&error];
+	XCTAssertEqualObjects(cachedAfterUnstage, @"");
+}
+
+- (void)testDiffAndPatchRoundTrip
+{
+	NSError *error = nil;
+	XCTAssertTrue([self.fixture writeText:@"first line\nchanged line\n" toPath:@"tracked.txt" error:&error], @"%@", error);
+	[self refreshIndexAfterPerforming:^{
+		[self.repository.index refresh];
+	}];
+	PBChangedFile *tracked = [self changedFileAtPath:@"tracked.txt"];
+	XCTAssertNotNil(tracked);
+	NSString *diff = [self.repository.index diffForFile:tracked staged:NO contextLines:3];
+	XCTAssertTrue([diff containsString:@"+changed line"]);
+
+	[self refreshIndexAfterPerforming:^{
+		XCTAssertTrue([self.repository.index applyPatch:diff stage:YES reverse:NO]);
+	}];
+	NSString *stagedDiff = [self.fixture git:@[ @"diff", @"--cached" ] error:&error];
+	XCTAssertTrue([stagedDiff containsString:@"+changed line"]);
+
+	[self refreshIndexAfterPerforming:^{
+		XCTAssertTrue([self.repository.index applyPatch:diff stage:YES reverse:YES]);
+	}];
+	NSString *unstagedDiff = [self.fixture git:@[ @"diff", @"--cached" ] error:&error];
+	XCTAssertEqualObjects(unstagedDiff, @"");
+	XCTAssertFalse([self.repository.index applyPatch:@"not a patch\n" stage:YES reverse:NO]);
+}
+
+- (void)testDiscardRestoresTrackedFilesButLeavesUntrackedFiles
+{
+	NSError *error = nil;
+	XCTAssertTrue([self.fixture writeText:@"modified\n" toPath:@"tracked.txt" error:&error], @"%@", error);
+	XCTAssertTrue([self.fixture writeText:@"untracked\n" toPath:@"untracked.txt" error:&error], @"%@", error);
+	[self refreshIndexAfterPerforming:^{
+		[self.repository.index refresh];
+	}];
+	PBChangedFile *tracked = [self changedFileAtPath:@"tracked.txt"];
+	PBChangedFile *untracked = [self changedFileAtPath:@"untracked.txt"];
+	[self.repository.index discardChangesForFiles:@[ tracked, untracked ]];
+	NSString *trackedText = [NSString stringWithContentsOfFile:[self.fixture.path stringByAppendingPathComponent:@"tracked.txt"] encoding:NSUTF8StringEncoding error:&error];
+	XCTAssertEqualObjects(trackedText, @"first line\n");
+	XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:[self.fixture.path stringByAppendingPathComponent:@"untracked.txt"]]);
+}
+
+- (void)testPartialPatchDoesNotCarryNoNewlineMarkerFromOmittedLine
+{
+	NSError *error = nil;
+	XCTAssertTrue([self.fixture writeText:@"a\nold\ntail\n" toPath:@"tracked.txt" error:&error], @"%@", error);
+	XCTAssertTrue([self.fixture commitAllWithMessage:@"patch base" error:&error], @"%@", error);
+	self.repository = [[PBGitRepository alloc] initWithURL:[NSURL fileURLWithPath:self.fixture.path] error:&error];
+	XCTAssertNotNil(self.repository, @"%@", error);
+
+	PBNativeContentView *view = [[PBNativeContentView alloc] initWithFrame:NSMakeRect(0, 0, 500, 300)];
+	NSArray *header = @[ @"diff --git a/tracked.txt b/tracked.txt", @"--- a/tracked.txt", @"+++ b/tracked.txt" ];
+	NSArray *hunk = @[ @"@@ -1,3 +1,5 @@", @" a", @" old", @"+new", @" tail", @"+extra", @"\\ No newline at end of file" ];
+	NSString *patch = [view patchWithFileHeader:header hunkLines:hunk selectedIndexes:[NSIndexSet indexSetWithIndex:3] reverse:NO];
+	XCTAssertNotNil(patch);
+	XCTAssertFalse([patch containsString:@"No newline at end of file"]);
+	XCTAssertTrue([self.repository.index applyPatch:patch stage:YES reverse:NO]);
+	NSString *stagedContents = [self.fixture git:@[ @"show", @":tracked.txt" ] error:&error];
+	XCTAssertEqualObjects(stagedContents, @"a\nold\nnew\ntail\n");
+}
+
+- (void)testWorkingTreeTreatsNulBytesAsBinaryAndUncommittedTreeIsCached
+{
+	unsigned char bytes[] = {0x89, 0x00, 0x50, 0x4e, 0x47};
+	NSData *data = [NSData dataWithBytes:bytes length:sizeof(bytes)];
+	NSString *path = [self.fixture.path stringByAppendingPathComponent:@"binary.dat"];
+	XCTAssertTrue([data writeToFile:path options:NSDataWritingAtomic error:nil]);
+
+	PBWorkingTree *root = [PBWorkingTree rootForRepository:self.repository];
+	PBGitTree *binary = [self treeAtPath:@"binary.dat" inRoot:root];
+	XCTAssertNotNil(binary);
+	XCTAssertEqualObjects(binary.textContents, @"This file cannot be displayed as text.");
+
+	PBUncommittedChanges *changes = [[PBUncommittedChanges alloc] initWithRepository:self.repository];
+	XCTAssertEqual(changes.tree, changes.tree);
+}
+
+@end
+
+
+@interface PBTaskCoreTests : XCTestCase
+@end
+
+
+@implementation PBTaskCoreTests
+
+- (void)testStandardInputRoundTrip
+{
+	PBTask *task = [PBTask taskWithLaunchPath:@"/bin/cat" arguments:@[] inDirectory:nil];
+	task.standardInputData = [@"héllo from stdin\n" dataUsingEncoding:NSUTF8StringEncoding];
+	NSError *error = nil;
+	XCTAssertTrue([task launchTask:&error], @"%@", error);
+	XCTAssertEqualObjects(task.standardOutputString, @"héllo from stdin\n");
+}
+
+- (void)testNonZeroExitIncludesStatusAndCombinedOutput
+{
+	NSError *error = nil;
+	NSString *output = [PBTask outputForCommand:@"/bin/sh"
+									  arguments:@[ @"-c", @"printf stdout; printf stderr >&2; exit 7" ]
+									inDirectory:nil
+										  error:&error];
+	XCTAssertNil(output);
+	XCTAssertEqualObjects(error.domain, PBTaskErrorDomain);
+	XCTAssertEqual(error.code, PBTaskNonZeroExitCodeError);
+	XCTAssertEqualObjects(error.userInfo[PBTaskTerminationStatusKey], @7);
+	NSString *failureOutput = error.userInfo[PBTaskTerminationOutputKey];
+	XCTAssertTrue([failureOutput containsString:@"stdout"]);
+	XCTAssertTrue([failureOutput containsString:@"stderr"]);
+}
+
+- (void)testMissingExecutableReturnsLaunchError
+{
+	PBTask *task = [PBTask taskWithLaunchPath:@"/path/that/does/not/exist" arguments:@[] inDirectory:nil];
+	NSError *error = nil;
+	XCTAssertFalse([task launchTask:&error]);
+	XCTAssertEqualObjects(error.domain, PBTaskErrorDomain);
+	XCTAssertEqual(error.code, PBTaskLaunchError);
+	XCTAssertNotNil(error.userInfo[PBTaskUnderlyingExceptionKey]);
+}
+
+- (void)testAsyncCompletionUsesRequestedQueueAndCapturesLargeOutput
+{
+	static void *queueKey = &queueKey;
+	dispatch_queue_t queue = dispatch_queue_create("org.gitx.tests.task-completion", DISPATCH_QUEUE_SERIAL);
+	dispatch_queue_set_specific(queue, queueKey, queueKey, NULL);
+	XCTestExpectation *expectation = [self expectationWithDescription:@"task completion"];
+	PBTask *task = [PBTask taskWithLaunchPath:@"/usr/bin/seq" arguments:@[ @"1", @"10000" ] inDirectory:nil];
+	[task performTaskOnQueue:queue
+		   completionHandler:^(NSData *data, NSError *error) {
+			   XCTAssertTrue(dispatch_get_specific(queueKey) != NULL);
+			   XCTAssertNil(error);
+			   NSString *output = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+			   XCTAssertTrue([output hasPrefix:@"1\n2\n"]);
+			   XCTAssertTrue([output hasSuffix:@"10000\n"]);
+			   [expectation fulfill];
+		   }];
+	[self waitForExpectations:@[ expectation ] timeout:10.0];
+}
+
+@end

--- a/GitXTests/GitXFeatureTests.m
+++ b/GitXTests/GitXFeatureTests.m
@@ -1,19 +1,33 @@
 #import <XCTest/XCTest.h>
+#import <dlfcn.h>
+#import <objc/runtime.h>
 
 #import "PBGitDefaults.h"
+#import "PBAutoFetchManager.h"
 #import "PBHistoryArrayController.h"
 #import "PBHighlighting.h"
 #import "PBNativeContentView.h"
 #import "PBTask.h"
+#import "NSAppearance+PBDarkMode.h"
 
 @interface GitXFeatureTests : XCTestCase
+
+@property (nonatomic) BOOL originalHistorySortingEnabled;
+@property (nonatomic) PBAutoFetchScope originalAutoFetchScope;
+@property (nonatomic) NSInteger originalAutoFetchInterval;
+
 @end
 
 @interface PBNativeContentView (GitXFeatureTests)
 - (nullable NSString *)patchWithFileHeader:(NSArray<NSString *> *)fileHeader
-							 hunkLines:(NSArray<NSString *> *)hunkLines
-						selectedIndexes:(NSIndexSet *)selectedIndexes
-							  reverse:(BOOL)reverse;
+								 hunkLines:(NSArray<NSString *> *)hunkLines
+						   selectedIndexes:(NSIndexSet *)selectedIndexes
+								   reverse:(BOOL)reverse;
+- (NSString *)pathForDiffHeaderAtIndex:(NSUInteger)headerIndex lines:(NSArray<NSString *> *)lines;
+@end
+
+@interface PBAutoFetchManager (GitXFeatureTests)
++ (NSTimeInterval)retryDelayForFailureCount:(NSUInteger)failureCount;
 @end
 
 @implementation GitXFeatureTests
@@ -21,9 +35,20 @@
 - (void)setUp
 {
 	[super setUp];
+	self.originalHistorySortingEnabled = [PBGitDefaults historyColumnSortingEnabled];
+	self.originalAutoFetchScope = [PBGitDefaults autoFetchScope];
+	self.originalAutoFetchInterval = [PBGitDefaults autoFetchIntervalMinutes];
 	[PBGitDefaults setHistoryColumnSortingEnabled:YES];
 	[PBGitDefaults setAutoFetchScope:PBAutoFetchScopeNone];
 	[PBGitDefaults setAutoFetchIntervalMinutes:15];
+}
+
+- (void)tearDown
+{
+	[PBGitDefaults setHistoryColumnSortingEnabled:self.originalHistorySortingEnabled];
+	[PBGitDefaults setAutoFetchScope:self.originalAutoFetchScope];
+	[PBGitDefaults setAutoFetchIntervalMinutes:self.originalAutoFetchInterval];
+	[super tearDown];
 }
 
 - (void)testAutoFetchDefaultsClampInterval
@@ -36,10 +61,47 @@
 	XCTAssertEqual([PBGitDefaults autoFetchScope], PBAutoFetchScopeOpenRepositories);
 }
 
+- (void)testAppearancePreferenceValidatesAndAppliesGlobally
+{
+	PBAppearancePreference originalPreference = [PBGitDefaults appearancePreference];
+	NSAppearance *originalAppearance = NSApp.appearance;
+	__block NSInteger notificationCount = 0;
+	id notificationToken = [[NSNotificationCenter defaultCenter]
+		addObserverForName:PBAppearancePreferenceDidChangeNotification
+					object:nil
+					 queue:nil
+				usingBlock:^(NSNotification *notification) {
+					notificationCount++;
+				}];
+
+	@try {
+		[PBGitDefaults setAppearancePreference:PBAppearancePreferenceLight];
+		XCTAssertEqual([PBGitDefaults appearancePreference], PBAppearancePreferenceLight);
+		XCTAssertEqualObjects(NSApp.appearance.name, NSAppearanceNameAqua);
+
+		[PBGitDefaults setAppearancePreference:PBAppearancePreferenceDark];
+		XCTAssertEqual([PBGitDefaults appearancePreference], PBAppearancePreferenceDark);
+		XCTAssertEqualObjects(NSApp.appearance.name, NSAppearanceNameDarkAqua);
+
+		[PBGitDefaults setAppearancePreference:PBAppearancePreferenceAutomatic];
+		XCTAssertEqual([PBGitDefaults appearancePreference], PBAppearancePreferenceAutomatic);
+		XCTAssertNil(NSApp.appearance);
+
+		[PBGitDefaults setAppearancePreference:(PBAppearancePreference)NSIntegerMax];
+		XCTAssertEqual([PBGitDefaults appearancePreference], PBAppearancePreferenceAutomatic);
+		XCTAssertNil(NSApp.appearance);
+		XCTAssertEqual(notificationCount, 4);
+	} @finally {
+		[[NSNotificationCenter defaultCenter] removeObserver:notificationToken];
+		[PBGitDefaults setAppearancePreference:originalPreference];
+		NSApp.appearance = originalAppearance;
+	}
+}
+
 - (void)testHistoryControllerPinsWorkingStateAboveSortedCommits
 {
 	PBHistoryArrayController *controller = [[PBHistoryArrayController alloc] initWithContent:@[
-		@{ @"subject" : @"B" }, @{ @"subject" : @"A" }
+		@{@"subject" : @"B"}, @{@"subject" : @"A"}
 	]];
 	NSObject *workingState = [[NSObject alloc] init];
 	controller.pinnedObject = workingState;
@@ -78,6 +140,41 @@
 	XCTAssertTrue([task.standardOutputString containsString:@"GITX_TEST_ENVIRONMENT=present"]);
 }
 
+- (void)testAppearanceObservationDoesNotOverrideNSApplicationKVOHandling
+{
+	Method method = class_getInstanceMethod(NSApplication.class,
+											@selector(observeValueForKeyPath:ofObject:change:context:));
+	Dl_info methodInfo = {0};
+	int lookupResult = dladdr(method_getImplementation(method), &methodInfo);
+	XCTAssertEqual(lookupResult, 1);
+	if (lookupResult == 0 || methodInfo.dli_fname == NULL)
+		return;
+	XCTAssertFalse([[NSString stringWithUTF8String:methodInfo.dli_fname] containsString:@"/GitX.app/Contents/MacOS/GitX"]);
+}
+
+- (void)testAppearanceObservationPostsEffectiveAppearanceNotification
+{
+	NSApplication *application = NSApplication.sharedApplication;
+	NSObject *notificationObject = [[NSObject alloc] init];
+	__block BOOL receivedNotification = NO;
+	id notificationToken = [[NSNotificationCenter defaultCenter]
+		addObserverForName:PBEffectiveAppearanceChanged
+					object:notificationObject
+					 queue:nil
+				usingBlock:^(NSNotification *notification) {
+					receivedNotification = YES;
+				}];
+
+	NSAppearance *originalAppearance = application.appearance;
+	[application registerObserverForAppearanceChanges:notificationObject];
+	application.appearance = [NSAppearance appearanceNamed:application.isDarkMode ? NSAppearanceNameAqua : NSAppearanceNameDarkAqua];
+
+	XCTAssertTrue(receivedNotification);
+	application.appearance = originalAppearance;
+	[application registerObserverForAppearanceChanges:application.delegate];
+	[[NSNotificationCenter defaultCenter] removeObserver:notificationToken];
+}
+
 - (void)testNativeDiffBuildsLinePatchesForStageAndUnstage
 {
 	PBNativeContentView *view = [[PBNativeContentView alloc] initWithFrame:NSMakeRect(0, 0, 500, 300)];
@@ -93,6 +190,47 @@
 	XCTAssertTrue([unstagePatch containsString:@"@@ -1,4 +1,3 @@"]);
 	XCTAssertTrue([unstagePatch containsString:@"-old\n new"]);
 	XCTAssertFalse([unstagePatch containsString:@"+new"]);
+}
+
+- (void)testNativeDiffOmitsNoNewlineMarkerWhenAssociatedChangeIsOmitted
+{
+	PBNativeContentView *view = [[PBNativeContentView alloc] initWithFrame:NSMakeRect(0, 0, 500, 300)];
+	NSArray *header = @[ @"diff --git a/file.txt b/file.txt", @"--- a/file.txt", @"+++ b/file.txt" ];
+	NSArray *hunk = @[ @"@@ -1,3 +1,5 @@", @" a", @" old", @"+new", @" tail", @"+extra", @"\\ No newline at end of file" ];
+	NSString *patch = [view patchWithFileHeader:header hunkLines:hunk selectedIndexes:[NSIndexSet indexSetWithIndex:3] reverse:NO];
+	XCTAssertNotNil(patch);
+	XCTAssertTrue([patch containsString:@"+new"]);
+	XCTAssertFalse([patch containsString:@"+extra"]);
+	XCTAssertFalse([patch containsString:@"No newline at end of file"]);
+}
+
+- (void)testNativeDiffExtractsPathsContainingSpacesAndRenameDestinations
+{
+	PBNativeContentView *view = [[PBNativeContentView alloc] initWithFrame:NSMakeRect(0, 0, 500, 300)];
+	NSArray *spaced = @[ @"diff --git a/Folder/file name.txt b/Folder/file name.txt", @"--- a/Folder/file name.txt", @"+++ b/Folder/file name.txt" ];
+	XCTAssertEqualObjects([view pathForDiffHeaderAtIndex:0 lines:spaced], @"Folder/file name.txt");
+	NSArray *renamed = @[ @"diff --git a/old.txt b/new name.txt", @"similarity index 100%", @"rename from old.txt", @"rename to new name.txt" ];
+	XCTAssertEqualObjects([view pathForDiffHeaderAtIndex:0 lines:renamed], @"new name.txt");
+}
+
+- (void)testTaskSupportsShortConfigurableTimeouts
+{
+	PBTask *task = [PBTask taskWithLaunchPath:@"/bin/sleep" arguments:@[ @"1" ] inDirectory:nil];
+	task.timeout = 0.02;
+	NSError *error = nil;
+	XCTAssertFalse([task launchTask:&error]);
+	XCTAssertEqualObjects(error.domain, PBTaskErrorDomain);
+	XCTAssertEqual(error.code, PBTaskTimeoutError);
+}
+
+- (void)testAutoFetchRetryDelayIsExponentialAndBounded
+{
+	XCTAssertEqual([PBAutoFetchManager retryDelayForFailureCount:0], 0);
+	XCTAssertEqual([PBAutoFetchManager retryDelayForFailureCount:1], 60);
+	XCTAssertEqual([PBAutoFetchManager retryDelayForFailureCount:2], 120);
+	XCTAssertEqual([PBAutoFetchManager retryDelayForFailureCount:4], 480);
+	XCTAssertEqual([PBAutoFetchManager retryDelayForFailureCount:5], 900);
+	XCTAssertEqual([PBAutoFetchManager retryDelayForFailureCount:20], 900);
 }
 
 @end

--- a/GitXTests/GitXFeatureTests.m
+++ b/GitXTests/GitXFeatureTests.m
@@ -1,0 +1,98 @@
+#import <XCTest/XCTest.h>
+
+#import "PBGitDefaults.h"
+#import "PBHistoryArrayController.h"
+#import "PBHighlighting.h"
+#import "PBNativeContentView.h"
+#import "PBTask.h"
+
+@interface GitXFeatureTests : XCTestCase
+@end
+
+@interface PBNativeContentView (GitXFeatureTests)
+- (nullable NSString *)patchWithFileHeader:(NSArray<NSString *> *)fileHeader
+							 hunkLines:(NSArray<NSString *> *)hunkLines
+						selectedIndexes:(NSIndexSet *)selectedIndexes
+							  reverse:(BOOL)reverse;
+@end
+
+@implementation GitXFeatureTests
+
+- (void)setUp
+{
+	[super setUp];
+	[PBGitDefaults setHistoryColumnSortingEnabled:YES];
+	[PBGitDefaults setAutoFetchScope:PBAutoFetchScopeNone];
+	[PBGitDefaults setAutoFetchIntervalMinutes:15];
+}
+
+- (void)testAutoFetchDefaultsClampInterval
+{
+	[PBGitDefaults setAutoFetchIntervalMinutes:0];
+	XCTAssertEqual([PBGitDefaults autoFetchIntervalMinutes], 1);
+	[PBGitDefaults setAutoFetchIntervalMinutes:2000];
+	XCTAssertEqual([PBGitDefaults autoFetchIntervalMinutes], 1440);
+	[PBGitDefaults setAutoFetchScope:PBAutoFetchScopeOpenRepositories];
+	XCTAssertEqual([PBGitDefaults autoFetchScope], PBAutoFetchScopeOpenRepositories);
+}
+
+- (void)testHistoryControllerPinsWorkingStateAboveSortedCommits
+{
+	PBHistoryArrayController *controller = [[PBHistoryArrayController alloc] initWithContent:@[
+		@{ @"subject" : @"B" }, @{ @"subject" : @"A" }
+	]];
+	NSObject *workingState = [[NSObject alloc] init];
+	controller.pinnedObject = workingState;
+	controller.sortDescriptors = @[ [NSSortDescriptor sortDescriptorWithKey:@"subject" ascending:YES] ];
+	NSArray *arranged = controller.arrangedObjects;
+	XCTAssertEqual(arranged.firstObject, workingState);
+	XCTAssertEqualObjects(arranged[1][@"subject"], @"A");
+}
+
+- (void)testDisablingHistorySortingClearsNewDescriptors
+{
+	PBHistoryArrayController *controller = [[PBHistoryArrayController alloc] initWithContent:@[]];
+	[PBGitDefaults setHistoryColumnSortingEnabled:NO];
+	controller.sortDescriptors = @[ [NSSortDescriptor sortDescriptorWithKey:@"subject" ascending:YES] ];
+	XCTAssertEqual(controller.sortDescriptors.count, 0);
+}
+
+- (void)testHighlightingProducesAttributedSourceAndNativeViewsStayReadOnly
+{
+	NSAttributedString *source = [PBHighlighting highlightedStringForText:@"let value = 42\n" path:@"Example.swift"];
+	XCTAssertEqualObjects(source.string, @"let value = 42\n");
+	XCTAssertNotNil([source attribute:NSForegroundColorAttributeName atIndex:0 effectiveRange:nil]);
+
+	PBNativeContentView *view = [[PBNativeContentView alloc] initWithFrame:NSMakeRect(0, 0, 500, 300)];
+	[view showSourceSections:@[@{ PBNativeSectionPathKey : @"Example.swift", PBNativeSectionTextKey : @"let value = 42\n" }]];
+	XCTAssertFalse(view.textView.isEditable);
+	XCTAssertTrue(view.textView.isSelectable);
+}
+
+- (void)testTaskAppliesEnvironmentConfiguredAfterCreation
+{
+	PBTask *task = [PBTask taskWithLaunchPath:@"/usr/bin/env" arguments:@[] inDirectory:nil];
+	task.additionalEnvironment = @{ @"GITX_TEST_ENVIRONMENT" : @"present" };
+	NSError *error = nil;
+	XCTAssertTrue([task launchTask:&error], @"%@", error);
+	XCTAssertTrue([task.standardOutputString containsString:@"GITX_TEST_ENVIRONMENT=present"]);
+}
+
+- (void)testNativeDiffBuildsLinePatchesForStageAndUnstage
+{
+	PBNativeContentView *view = [[PBNativeContentView alloc] initWithFrame:NSMakeRect(0, 0, 500, 300)];
+	NSArray *header = @[ @"diff --git a/file.txt b/file.txt", @"--- a/file.txt", @"+++ b/file.txt" ];
+	NSArray *hunk = @[ @"@@ -1,3 +1,3 @@", @" same", @"-old", @"+new", @" tail" ];
+
+	NSString *stagePatch = [view patchWithFileHeader:header hunkLines:hunk selectedIndexes:[NSIndexSet indexSetWithIndex:3] reverse:NO];
+	XCTAssertTrue([stagePatch containsString:@"@@ -1,3 +1,4 @@"]);
+	XCTAssertTrue([stagePatch containsString:@" old\n+new"]);
+	XCTAssertFalse([stagePatch containsString:@"-old"]);
+
+	NSString *unstagePatch = [view patchWithFileHeader:header hunkLines:hunk selectedIndexes:[NSIndexSet indexSetWithIndex:2] reverse:YES];
+	XCTAssertTrue([unstagePatch containsString:@"@@ -1,4 +1,3 @@"]);
+	XCTAssertTrue([unstagePatch containsString:@"-old\n new"]);
+	XCTAssertFalse([unstagePatch containsString:@"+new"]);
+}
+
+@end

--- a/GitXTests/GitXThreadSanitizer.xctestplan
+++ b/GitXTests/GitXThreadSanitizer.xctestplan
@@ -1,0 +1,31 @@
+{
+  "configurations" : [
+    {
+      "id" : "024B3F2D-ECE7-40B7-9F37-6427498B657A",
+      "name" : "Thread Sanitizer",
+      "options" : {
+        "mainThreadCheckerEnabled" : true,
+        "threadSanitizerEnabled" : true
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:GitX.xcodeproj",
+      "identifier" : "8D1107260486CEB800E47090",
+      "name" : "GitX"
+    },
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:GitX.xcodeproj",
+        "identifier" : "C0DE2000000000000000000B",
+        "name" : "GitXTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/GitXUITests/GitXScreenshotTests.m
+++ b/GitXUITests/GitXScreenshotTests.m
@@ -11,179 +11,218 @@
 
 @interface GitXScreenshotTests : XCTestCase
 @property (nonatomic, strong) XCUIApplication *app;
+@property (nonatomic, strong) NSMutableArray<NSString *> *temporaryRepositoryPaths;
+- (NSString *)makeDirtyRepositoryFixture;
 @end
 
 @implementation GitXScreenshotTests
 
-- (void)setUp {
-    [super setUp];
-    self.continueAfterFailure = NO;
-    self.app = [[XCUIApplication alloc] init];
+- (void)setUp
+{
+	[super setUp];
+	self.continueAfterFailure = NO;
+	self.app = [[XCUIApplication alloc] init];
+	self.app.launchArguments = @[ @"-ApplePersistenceIgnoreState", @"YES" ];
+	self.temporaryRepositoryPaths = [NSMutableArray array];
 
-    // GITX_UITEST_REPO is set by the scheme to $(GITX_SCREENSHOT_REPO).
-    // Locally this expands to $(SRCROOT). On CI, xcodebuild overrides
-    // GITX_SCREENSHOT_REPO=/tmp/gitx-screenshot-repo (the fixed commit checkout).
-    NSDictionary *env = [[NSProcessInfo processInfo] environment];
-    NSString *repoPath = env[@"GITX_UITEST_REPO"];
+	// An explicit environment override is useful for local one-off runs. CI
+	// checks out its fixed screenshot repository at the path below.
+	NSDictionary *env = [[NSProcessInfo processInfo] environment];
+	NSString *repoPath = env[@"GITX_SCREENSHOT_REPO"];
+	NSString *ciRepositoryPath = @"/tmp/gitx-screenshot-repo";
+	if (!repoPath.length && [[NSFileManager defaultManager] fileExistsAtPath:ciRepositoryPath]) {
+		repoPath = ciRepositoryPath;
+	}
 
-    if (!repoPath) {
-        // Fallback: a fixture repo bundled with the test target
-        NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-        NSURL *bundledRepo = [bundle URLForResource:@"testrepo" withExtension:nil];
-        if (bundledRepo && [[NSFileManager defaultManager] fileExistsAtPath:bundledRepo.path]) {
-            repoPath = bundledRepo.path;
-        }
-    }
+	if (!repoPath.length) {
+		// Fallback: a fixture repo bundled with the test target
+		NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+		NSURL *bundledRepo = [bundle URLForResource:@"testrepo" withExtension:nil];
+		if (bundledRepo && [[NSFileManager defaultManager] fileExistsAtPath:bundledRepo.path]) {
+			repoPath = bundledRepo.path;
+		}
+	}
+	if (!repoPath.length) {
+		repoPath = [self makeDirtyRepositoryFixture];
+	}
 
-    NSLog(@"[GitXScreenshotTests] repoPath = %@", repoPath ?: @"(none)");
+	NSLog(@"[GitXScreenshotTests] repoPath = %@", repoPath ?: @"(none)");
 
-    if (repoPath) {
-        // Passed to the app via applicationDidFinishLaunching: which opens
-        // the repo directly, giving the test a reliable document window.
-        self.app.launchEnvironment = @{@"GITX_UITEST_REPO": repoPath};
-    }
+	if (repoPath) {
+		// Passed to the app via applicationDidFinishLaunching: which opens
+		// the repo directly, giving the test a reliable document window.
+		self.app.launchEnvironment = @{@"GITX_UITEST_REPO" : repoPath};
+	}
 
-    [self.app launch];
+	[self.app launch];
 }
 
-- (void)tearDown {
-    [self.app terminate];
-    [super tearDown];
+- (void)tearDown
+{
+	[self.app terminate];
+	for (NSString *path in self.temporaryRepositoryPaths) {
+		[[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+	}
+	[super tearDown];
 }
 
 // MARK: - Helpers
 
-- (BOOL)waitForWindow {
-    XCUIElement *window = self.app.windows.firstMatch;
-    if ([window waitForExistenceWithTimeout:20]) {
-        return YES;
-    }
-    // Activate the app and give it one more chance — it may have launched
-    // but not yet brought its window to the front.
-    [self.app activate];
-    return [self.app.windows.firstMatch waitForExistenceWithTimeout:10];
-}
-
-- (void)saveScreenshotNamed:(NSString *)name {
-    XCUIScreenshot *screenshot = [[XCUIScreen mainScreen] screenshot];
-    XCTAttachment *attachment = [XCTAttachment attachmentWithScreenshot:screenshot];
-    attachment.name = name;
-    attachment.lifetime = XCTAttachmentLifetimeKeepAlways;
-    [self addAttachment:attachment];
-}
-
-- (void)saveWindowScreenshotNamed:(NSString *)name {
-    XCUIElement *window = self.app.windows.firstMatch;
-    if (!window.exists) {
-        [self saveScreenshotNamed:name]; // fall back to full screen
-        return;
-    }
-    XCUIScreenshot *screenshot = [window screenshot];
-    XCTAttachment *attachment = [XCTAttachment attachmentWithScreenshot:screenshot];
-    attachment.name = name;
-    attachment.lifetime = XCTAttachmentLifetimeKeepAlways;
-    [self addAttachment:attachment];
-}
-
-- (BOOL)runGit:(NSArray<NSString *> *)arguments inDirectory:(NSString *)directory {
-    NSTask *task = [[NSTask alloc] init];
-    // /usr/bin/git delegates through xcrun, which refuses to run from the UI
-    // test runner's sandbox. Invoke Xcode's real Git binary directly.
-    task.executableURL = [NSURL fileURLWithPath:@"/Applications/Xcode.app/Contents/Developer/usr/bin/git"];
-    task.arguments = arguments;
-    task.currentDirectoryURL = [NSURL fileURLWithPath:directory isDirectory:YES];
-    NSError *error = nil;
-    [task launchAndReturnError:&error];
-    [task waitUntilExit];
-    return error == nil && task.terminationStatus == 0;
-}
-
-- (NSString *)makeDirtyRepositoryFixture {
-    NSString *repositoryPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"gitx-dirty-%@", NSUUID.UUID.UUIDString]];
-    [[NSFileManager defaultManager] createDirectoryAtPath:repositoryPath withIntermediateDirectories:YES attributes:nil error:nil];
-    XCTAssertTrue(([self runGit:@[@"init", @"-q"] inDirectory:repositoryPath]));
-    XCTAssertTrue(([self runGit:@[@"config", @"user.name", @"GitX Tests"] inDirectory:repositoryPath]));
-    XCTAssertTrue(([self runGit:@[@"config", @"user.email", @"tests@gitx.invalid"] inDirectory:repositoryPath]));
-    [@"tracked\n" writeToFile:[repositoryPath stringByAppendingPathComponent:@"tracked.swift"] atomically:YES encoding:NSUTF8StringEncoding error:nil];
-    XCTAssertTrue(([self runGit:@[@"add", @"tracked.swift"] inDirectory:repositoryPath]));
-    XCTAssertTrue(([self runGit:@[@"commit", @"-q", @"-m", @"Initial"] inDirectory:repositoryPath]));
-    [@"tracked\nchanged\n" writeToFile:[repositoryPath stringByAppendingPathComponent:@"tracked.swift"] atomically:YES encoding:NSUTF8StringEncoding error:nil];
-    [@"new\n" writeToFile:[repositoryPath stringByAppendingPathComponent:@"new.txt"] atomically:YES encoding:NSUTF8StringEncoding error:nil];
-    return repositoryPath;
-}
-
-- (XCUIElement *)selectHistoryForCurrentBranch {
+- (BOOL)waitForWindow
+{
+	XCUIElement *window = self.app.windows.firstMatch;
+	if ([window waitForExistenceWithTimeout:20]) {
+		return YES;
+	}
+	// Activate the app and give it one more chance — it may have launched
+	// but not yet brought its window to the front.
 	[self.app activate];
-    NSPredicate *branchName = [NSPredicate predicateWithFormat:@"value == 'main' OR value == 'master'"];
-    XCUIElement *branch = [self.app.staticTexts matchingPredicate:branchName].firstMatch;
-    XCTAssertTrue([branch waitForExistenceWithTimeout:10], @"The repository's current branch should be visible in the sidebar");
-    [branch click];
-    XCUIElement *table = self.app.tables[@"CommitList"];
-    XCTAssertTrue([table waitForExistenceWithTimeout:15], @"Selecting the current branch should open history");
-    return table;
+	return [self.app.windows.firstMatch waitForExistenceWithTimeout:10];
+}
+
+- (void)saveScreenshotNamed:(NSString *)name
+{
+	XCUIScreenshot *screenshot = [[XCUIScreen mainScreen] screenshot];
+	XCTAttachment *attachment = [XCTAttachment attachmentWithScreenshot:screenshot];
+	attachment.name = name;
+	attachment.lifetime = XCTAttachmentLifetimeKeepAlways;
+	[self addAttachment:attachment];
+}
+
+- (void)saveWindowScreenshotNamed:(NSString *)name
+{
+	XCUIElement *window = self.app.windows.firstMatch;
+	if (!window.exists) {
+		[self saveScreenshotNamed:name]; // fall back to full screen
+		return;
+	}
+	XCUIScreenshot *screenshot = [window screenshot];
+	XCTAttachment *attachment = [XCTAttachment attachmentWithScreenshot:screenshot];
+	attachment.name = name;
+	attachment.lifetime = XCTAttachmentLifetimeKeepAlways;
+	[self addAttachment:attachment];
+}
+
+- (BOOL)runGit:(NSArray<NSString *> *)arguments inDirectory:(NSString *)directory
+{
+	NSTask *task = [[NSTask alloc] init];
+	// /usr/bin/git delegates through xcrun, which refuses to run from the UI
+	// test runner's sandbox. Invoke the selected Xcode's Git binary directly.
+	NSString *developerDirectory = NSProcessInfo.processInfo.environment[@"DEVELOPER_DIR"];
+	if (!developerDirectory.length) {
+		developerDirectory = @"/Applications/Xcode.app/Contents/Developer";
+	}
+	NSString *gitPath = [developerDirectory stringByAppendingPathComponent:@"usr/bin/git"];
+	if (![[NSFileManager defaultManager] isExecutableFileAtPath:gitPath]) {
+		gitPath = @"/usr/bin/git";
+	}
+	task.executableURL = [NSURL fileURLWithPath:gitPath];
+	task.arguments = arguments;
+	task.currentDirectoryURL = [NSURL fileURLWithPath:directory isDirectory:YES];
+	NSError *error = nil;
+	[task launchAndReturnError:&error];
+	[task waitUntilExit];
+	return error == nil && task.terminationStatus == 0;
+}
+
+- (NSString *)makeDirtyRepositoryFixture
+{
+	NSString *repositoryPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"gitx-dirty-%@", NSUUID.UUID.UUIDString]];
+	[[NSFileManager defaultManager] createDirectoryAtPath:repositoryPath withIntermediateDirectories:YES attributes:nil error:nil];
+	[self.temporaryRepositoryPaths addObject:repositoryPath];
+	XCTAssertTrue(([self runGit:@[ @"init", @"-q", @"-b", @"main" ] inDirectory:repositoryPath]));
+	XCTAssertTrue(([self runGit:@[ @"config", @"user.name", @"GitX Tests" ] inDirectory:repositoryPath]));
+	XCTAssertTrue(([self runGit:@[ @"config", @"user.email", @"tests@gitx.invalid" ] inDirectory:repositoryPath]));
+	[@"tracked\n" writeToFile:[repositoryPath stringByAppendingPathComponent:@"tracked.swift"] atomically:YES encoding:NSUTF8StringEncoding error:nil];
+	XCTAssertTrue(([self runGit:@[ @"add", @"tracked.swift" ] inDirectory:repositoryPath]));
+	XCTAssertTrue(([self runGit:@[ @"commit", @"-q", @"-m", @"Initial" ] inDirectory:repositoryPath]));
+	[@"tracked\nsecond\n" writeToFile:[repositoryPath stringByAppendingPathComponent:@"tracked.swift"] atomically:YES encoding:NSUTF8StringEncoding error:nil];
+	XCTAssertTrue(([self runGit:@[ @"add", @"tracked.swift" ] inDirectory:repositoryPath]));
+	XCTAssertTrue(([self runGit:@[ @"commit", @"-q", @"-m", @"Second" ] inDirectory:repositoryPath]));
+	[@"tracked\nsecond\nthird\n" writeToFile:[repositoryPath stringByAppendingPathComponent:@"tracked.swift"] atomically:YES encoding:NSUTF8StringEncoding error:nil];
+	XCTAssertTrue(([self runGit:@[ @"add", @"tracked.swift" ] inDirectory:repositoryPath]));
+	XCTAssertTrue(([self runGit:@[ @"commit", @"-q", @"-m", @"Third" ] inDirectory:repositoryPath]));
+	[@"tracked\nsecond\nthird\nchanged\n" writeToFile:[repositoryPath stringByAppendingPathComponent:@"tracked.swift"] atomically:YES encoding:NSUTF8StringEncoding error:nil];
+	[@"new\n" writeToFile:[repositoryPath stringByAppendingPathComponent:@"new.txt"] atomically:YES encoding:NSUTF8StringEncoding error:nil];
+	return repositoryPath;
+}
+
+- (XCUIElement *)selectHistoryForCurrentBranch
+{
+	[self.app activate];
+	NSPredicate *branchName = [NSPredicate predicateWithFormat:@"value == 'main' OR value == 'master'"];
+	XCUIElement *branch = [self.app.staticTexts matchingPredicate:branchName].firstMatch;
+	XCTAssertTrue([branch waitForExistenceWithTimeout:10], @"The repository's current branch should be visible in the sidebar");
+	[branch click];
+	XCUIElement *table = self.app.tables[@"CommitList"];
+	XCTAssertTrue([table waitForExistenceWithTimeout:15], @"Selecting the current branch should open history");
+	return table;
 }
 
 // MARK: - Tests
 
-- (void)testMainWindowExists {
-    XCTAssertTrue([self waitForWindow],
-                  @"Main window should appear within 30 seconds");
-    [self saveWindowScreenshotNamed:@"main-window"];
+- (void)testMainWindowExists
+{
+	XCTAssertTrue([self waitForWindow],
+				  @"Main window should appear within 30 seconds");
+	[self saveWindowScreenshotNamed:@"main-window"];
 }
 
-- (void)testHistoryTabScreenshot {
-    if (![self waitForWindow]) { return; }
-    [self saveWindowScreenshotNamed:@"history-view"];
+- (void)testHistoryTabScreenshot
+{
+	XCTAssertTrue([self waitForWindow], @"History requires a repository window");
+	[self selectHistoryForCurrentBranch];
+	[self saveWindowScreenshotNamed:@"history-view"];
 }
 
-- (void)testStagingTabScreenshot {
-    if (![self waitForWindow]) { return; }
+- (void)testStagingTabScreenshot
+{
+	XCTAssertTrue([self waitForWindow], @"Staging requires a repository window");
+	XCUIElement *sidebar = self.app.outlines[@"RepositorySidebar"];
+	XCTAssertTrue([sidebar waitForExistenceWithTimeout:10], @"The repository sidebar should be accessible");
+	XCUIElement *stageItem = sidebar.staticTexts[@"Stage"];
+	XCTAssertTrue([stageItem waitForExistenceWithTimeout:10], @"The Stage item should be visible in the sidebar");
+	[stageItem click];
 
-    // Click the Stage tab / toolbar button if present
-    XCUIElement *stageButton = self.app.toolbars.buttons[@"Stage"];
-    if (!stageButton.exists) {
-        // Try as a tab or segmented control
-        stageButton = [self.app.windows.firstMatch.buttons elementMatchingType:XCUIElementTypeButton
-                                                                    identifier:@"Stage"];
-    }
-    if (stageButton.exists) {
-        [stageButton click];
-        [NSThread sleepForTimeInterval:0.5];
-    }
-
-    [self saveWindowScreenshotNamed:@"staging-view"];
+	[self saveWindowScreenshotNamed:@"staging-view"];
 }
 
-- (void)testUncommittedChangesRowAppearsForDirtyRepository {
-    [self.app terminate];
-    NSString *fixture = [self makeDirtyRepositoryFixture];
-    self.app.launchEnvironment = @{ @"GITX_UITEST_REPO" : fixture };
-    [self.app launch];
-    XCTAssertTrue([self waitForWindow]);
+- (void)testUncommittedChangesRowAppearsForDirtyRepository
+{
+	[self.app terminate];
+	NSString *fixture = [self makeDirtyRepositoryFixture];
+	self.app.launchEnvironment = @{@"GITX_UITEST_REPO" : fixture};
+	[self.app launch];
+	XCTAssertTrue([self waitForWindow]);
 	[self selectHistoryForCurrentBranch];
 
-    XCUIElement *workingState = [self.app.staticTexts matchingPredicate:[NSPredicate predicateWithFormat:@"value BEGINSWITH 'Uncommitted Changes'"]].firstMatch;
-    XCTAssertTrue([workingState waitForExistenceWithTimeout:15], @"Dirty repositories should pin an Uncommitted Changes row above history");
-    [self saveWindowScreenshotNamed:@"uncommitted-changes-row"];
+	XCUIElement *workingState = [self.app.staticTexts matchingPredicate:[NSPredicate predicateWithFormat:@"value BEGINSWITH 'Uncommitted Changes'"]].firstMatch;
+	XCTAssertTrue([workingState waitForExistenceWithTimeout:15], @"Dirty repositories should pin an Uncommitted Changes row above history");
+	[self saveWindowScreenshotNamed:@"uncommitted-changes-row"];
 }
 
-- (void)testMultipleCommitSelectionShowsDiffPresentationControl {
-    if (![self waitForWindow]) { return; }
+- (void)testMultipleCommitSelectionShowsDiffPresentationControl
+{
+	XCTAssertTrue([self waitForWindow], @"Commit selection requires a repository window");
 	XCUIElement *table = [self selectHistoryForCurrentBranch];
-    [NSThread sleepForTimeInterval:1.0];
-    XCTAssertGreaterThan(table.tableRows.count, 2);
-    [[table.tableRows elementBoundByIndex:1] click];
-    [XCUIElement performWithKeyModifiers:XCUIKeyModifierCommand block:^{
-        [[table.tableRows elementBoundByIndex:2] click];
-    }];
+	XCUIElement *firstCommit = [table.tableRows elementBoundByIndex:1];
+	XCUIElement *secondCommit = [table.tableRows elementBoundByIndex:2];
+	XCTAssertTrue([firstCommit waitForExistenceWithTimeout:15]);
+	XCTAssertTrue([secondCommit waitForExistenceWithTimeout:15], @"The screenshot repository must contain at least two commits plus working state");
+	[firstCommit click];
+	[XCUIElement performWithKeyModifiers:XCUIKeyModifierCommand
+								   block:^{
+									   [secondCommit click];
+								   }];
 
-    XCUIElement *presentation = [[self.app descendantsMatchingType:XCUIElementTypeAny] elementMatchingPredicate:[NSPredicate predicateWithFormat:@"identifier == 'MultiCommitDiffPresentation'"]];
-    XCTAssertTrue([presentation waitForExistenceWithTimeout:10]);
-    [self saveWindowScreenshotNamed:@"multiple-commit-diff"];
+	XCUIElement *presentation = [[self.app descendantsMatchingType:XCUIElementTypeAny] elementMatchingPredicate:[NSPredicate predicateWithFormat:@"identifier == 'MultiCommitDiffPresentation'"]];
+	XCTAssertTrue([presentation waitForExistenceWithTimeout:10]);
+	[self saveWindowScreenshotNamed:@"multiple-commit-diff"];
 }
 
-- (void)testHistoryAndFetchPreferencesAreAvailable {
-    if (![self waitForWindow]) { return; }
+- (void)testHistoryAndFetchPreferencesAreAvailable
+{
+	XCTAssertTrue([self waitForWindow], @"Preferences require the application to finish launching");
 	[self.app activate];
 	[self.app.menuBars.menuBarItems[@"GitX"] click];
 	[self.app.menuItems[@"Settings…"] click];
@@ -200,9 +239,44 @@
 		XCTAssertTrue([menuItem waitForExistenceWithTimeout:5]);
 		[menuItem click];
 	}
-    XCTAssertTrue([preferences.checkBoxes[@"Allow commit columns to sort history"] waitForExistenceWithTimeout:5]);
-    XCTAssertTrue(preferences.popUpButtons.firstMatch.exists);
-    [self saveWindowScreenshotNamed:@"history-fetch-preferences"];
+	XCTAssertTrue([preferences.checkBoxes[@"Allow commit columns to sort history"] waitForExistenceWithTimeout:5]);
+	XCTAssertTrue(preferences.popUpButtons.firstMatch.exists);
+	[self saveWindowScreenshotNamed:@"history-fetch-preferences"];
+}
+
+- (void)testAppearancePreferenceOffersAutomaticLightAndDark
+{
+	XCTAssertTrue([self waitForWindow], @"Preferences require the application to finish launching");
+	[self.app activate];
+	[self.app.menuBars.menuBarItems[@"GitX"] click];
+	[self.app.menuItems[@"Settings…"] click];
+	XCUIElement *preferences = self.app.dialogs.firstMatch;
+	XCTAssertTrue([preferences waitForExistenceWithTimeout:5]);
+
+	XCUIElement *generalPane = preferences.toolbars.buttons[@"General"];
+	XCTAssertTrue([generalPane waitForExistenceWithTimeout:5]);
+	[generalPane click];
+
+	XCUIElement *appearance = preferences.popUpButtons[@"AppearancePreference"];
+	XCTAssertTrue([appearance waitForExistenceWithTimeout:5]);
+	NSString *originalValue = appearance.value;
+
+	@try {
+		for (NSString *title in @[ @"Dark", @"Light", @"Automatic (System)" ]) {
+			[appearance click];
+			XCUIElement *choice = self.app.menuItems[title];
+			XCTAssertTrue([choice waitForExistenceWithTimeout:5]);
+			[choice click];
+			XCTAssertEqualObjects(appearance.value, title);
+			[NSThread sleepForTimeInterval:0.2];
+			[self saveWindowScreenshotNamed:[NSString stringWithFormat:@"appearance-%@", title.lowercaseString]];
+		}
+	} @finally {
+		if (originalValue.length && ![appearance.value isEqual:originalValue]) {
+			[appearance click];
+			[self.app.menuItems[originalValue] click];
+		}
+	}
 }
 
 // - (void)testFullScreenScreenshot {
@@ -211,41 +285,26 @@
 //     [self saveScreenshotNamed:@"full-screen"];
 // }
 
-- (void)testCommitContextMenuScreenshot {
-    if (![self waitForWindow]) { return; }
+- (void)testCommitContextMenuScreenshot
+{
+	XCTAssertTrue([self waitForWindow], @"The context menu requires a repository window");
+	XCUIElement *table = [self selectHistoryForCurrentBranch];
+	XCUIElement *window = self.app.windows.firstMatch;
+	XCUIElement *firstRow = [table.tableRows elementBoundByIndex:0];
+	XCTAssertTrue([firstRow waitForExistenceWithTimeout:15], @"The commit list should contain a row");
 
-    // The commit list is a table — find the first (most recent) commit row
-    XCUIElement *window = self.app.windows.firstMatch;
-    XCUIElement *table = window.tables.firstMatch;
-    if (![table waitForExistenceWithTimeout:10]) {
-        NSLog(@"[GitXScreenshotTests] Commit table not found, skipping context menu screenshot");
-        return;
-    }
+	// Right-click to open the context menu
+	[firstRow rightClick];
 
-    // Let the history list fully load
-    [NSThread sleepForTimeInterval:1.0];
+	// Wait for the menu to appear
+	XCUIElement *menu = self.app.menus.firstMatch;
+	XCTAssertTrue([menu waitForExistenceWithTimeout:5], @"Right-clicking a commit should open its context menu");
 
-    XCUIElement *firstRow = [table.tableRows elementBoundByIndex:0];
-    if (!firstRow.exists) {
-        NSLog(@"[GitXScreenshotTests] No commit rows found, skipping context menu screenshot");
-        return;
-    }
+	[NSThread sleepForTimeInterval:0.3]; // let the menu fully render
+	[self saveWindowScreenshotNamed:@"commit-context-menu"];
 
-    // Right-click to open the context menu
-    [firstRow rightClick];
-
-    // Wait for the menu to appear
-    XCUIElement *menu = self.app.menus.firstMatch;
-    if (![menu waitForExistenceWithTimeout:5]) {
-        NSLog(@"[GitXScreenshotTests] Context menu did not appear");
-        return;
-    }
-
-    [NSThread sleepForTimeInterval:0.3]; // let the menu fully render
-    [self saveWindowScreenshotNamed:@"commit-context-menu"];
-
-    // Dismiss the menu
-    [window typeKey:XCUIKeyboardKeyEscape modifierFlags:0];
+	// Dismiss the menu
+	[window typeKey:XCUIKeyboardKeyEscape modifierFlags:0];
 }
 
 @end

--- a/GitXUITests/GitXScreenshotTests.m
+++ b/GitXUITests/GitXScreenshotTests.m
@@ -85,6 +85,44 @@
     [self addAttachment:attachment];
 }
 
+- (BOOL)runGit:(NSArray<NSString *> *)arguments inDirectory:(NSString *)directory {
+    NSTask *task = [[NSTask alloc] init];
+    // /usr/bin/git delegates through xcrun, which refuses to run from the UI
+    // test runner's sandbox. Invoke Xcode's real Git binary directly.
+    task.executableURL = [NSURL fileURLWithPath:@"/Applications/Xcode.app/Contents/Developer/usr/bin/git"];
+    task.arguments = arguments;
+    task.currentDirectoryURL = [NSURL fileURLWithPath:directory isDirectory:YES];
+    NSError *error = nil;
+    [task launchAndReturnError:&error];
+    [task waitUntilExit];
+    return error == nil && task.terminationStatus == 0;
+}
+
+- (NSString *)makeDirtyRepositoryFixture {
+    NSString *repositoryPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"gitx-dirty-%@", NSUUID.UUID.UUIDString]];
+    [[NSFileManager defaultManager] createDirectoryAtPath:repositoryPath withIntermediateDirectories:YES attributes:nil error:nil];
+    XCTAssertTrue(([self runGit:@[@"init", @"-q"] inDirectory:repositoryPath]));
+    XCTAssertTrue(([self runGit:@[@"config", @"user.name", @"GitX Tests"] inDirectory:repositoryPath]));
+    XCTAssertTrue(([self runGit:@[@"config", @"user.email", @"tests@gitx.invalid"] inDirectory:repositoryPath]));
+    [@"tracked\n" writeToFile:[repositoryPath stringByAppendingPathComponent:@"tracked.swift"] atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    XCTAssertTrue(([self runGit:@[@"add", @"tracked.swift"] inDirectory:repositoryPath]));
+    XCTAssertTrue(([self runGit:@[@"commit", @"-q", @"-m", @"Initial"] inDirectory:repositoryPath]));
+    [@"tracked\nchanged\n" writeToFile:[repositoryPath stringByAppendingPathComponent:@"tracked.swift"] atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    [@"new\n" writeToFile:[repositoryPath stringByAppendingPathComponent:@"new.txt"] atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    return repositoryPath;
+}
+
+- (XCUIElement *)selectHistoryForCurrentBranch {
+	[self.app activate];
+    NSPredicate *branchName = [NSPredicate predicateWithFormat:@"value == 'main' OR value == 'master'"];
+    XCUIElement *branch = [self.app.staticTexts matchingPredicate:branchName].firstMatch;
+    XCTAssertTrue([branch waitForExistenceWithTimeout:10], @"The repository's current branch should be visible in the sidebar");
+    [branch click];
+    XCUIElement *table = self.app.tables[@"CommitList"];
+    XCTAssertTrue([table waitForExistenceWithTimeout:15], @"Selecting the current branch should open history");
+    return table;
+}
+
 // MARK: - Tests
 
 - (void)testMainWindowExists {
@@ -114,6 +152,57 @@
     }
 
     [self saveWindowScreenshotNamed:@"staging-view"];
+}
+
+- (void)testUncommittedChangesRowAppearsForDirtyRepository {
+    [self.app terminate];
+    NSString *fixture = [self makeDirtyRepositoryFixture];
+    self.app.launchEnvironment = @{ @"GITX_UITEST_REPO" : fixture };
+    [self.app launch];
+    XCTAssertTrue([self waitForWindow]);
+	[self selectHistoryForCurrentBranch];
+
+    XCUIElement *workingState = [self.app.staticTexts matchingPredicate:[NSPredicate predicateWithFormat:@"value BEGINSWITH 'Uncommitted Changes'"]].firstMatch;
+    XCTAssertTrue([workingState waitForExistenceWithTimeout:15], @"Dirty repositories should pin an Uncommitted Changes row above history");
+    [self saveWindowScreenshotNamed:@"uncommitted-changes-row"];
+}
+
+- (void)testMultipleCommitSelectionShowsDiffPresentationControl {
+    if (![self waitForWindow]) { return; }
+	XCUIElement *table = [self selectHistoryForCurrentBranch];
+    [NSThread sleepForTimeInterval:1.0];
+    XCTAssertGreaterThan(table.tableRows.count, 2);
+    [[table.tableRows elementBoundByIndex:1] click];
+    [XCUIElement performWithKeyModifiers:XCUIKeyModifierCommand block:^{
+        [[table.tableRows elementBoundByIndex:2] click];
+    }];
+
+    XCUIElement *presentation = [[self.app descendantsMatchingType:XCUIElementTypeAny] elementMatchingPredicate:[NSPredicate predicateWithFormat:@"identifier == 'MultiCommitDiffPresentation'"]];
+    XCTAssertTrue([presentation waitForExistenceWithTimeout:10]);
+    [self saveWindowScreenshotNamed:@"multiple-commit-diff"];
+}
+
+- (void)testHistoryAndFetchPreferencesAreAvailable {
+    if (![self waitForWindow]) { return; }
+	[self.app activate];
+	[self.app.menuBars.menuBarItems[@"GitX"] click];
+	[self.app.menuItems[@"Settings…"] click];
+	XCUIElement *preferences = self.app.dialogs.firstMatch;
+	XCTAssertTrue([preferences waitForExistenceWithTimeout:5]);
+	XCUIElement *pane = preferences.toolbars.buttons[@"History & Fetch"];
+	if (pane.exists) {
+		[pane click];
+	} else {
+		XCUIElement *more = preferences.popUpButtons[@"more toolbar items"];
+		XCTAssertTrue([more waitForExistenceWithTimeout:5]);
+		[more click];
+		XCUIElement *menuItem = self.app.menuItems[@"History & Fetch"];
+		XCTAssertTrue([menuItem waitForExistenceWithTimeout:5]);
+		[menuItem click];
+	}
+    XCTAssertTrue([preferences.checkBoxes[@"Allow commit columns to sort history"] waitForExistenceWithTimeout:5]);
+    XCTAssertTrue(preferences.popUpButtons.firstMatch.exists);
+    [self saveWindowScreenshotNamed:@"history-fetch-preferences"];
 }
 
 // - (void)testFullScreenScreenshot {
@@ -160,4 +249,3 @@
 }
 
 @end
-

--- a/Resources/XIBs/PBDiffWindow.xib
+++ b/Resources/XIBs/PBDiffWindow.xib
@@ -3,7 +3,6 @@
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9060"/>
-        <plugIn identifier="com.apple.WebKitIBPlugin" version="9060"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PBDiffWindowController">
@@ -28,16 +27,11 @@
                 <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <webView id="7">
+                    <customView id="7">
                         <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <animations/>
-                        <webPreferences key="preferences" defaultFontSize="12" defaultFixedFontSize="12"/>
-                        <connections>
-                            <outlet property="UIDelegate" destination="8" id="11"/>
-                            <outlet property="frameLoadDelegate" destination="8" id="10"/>
-                        </connections>
-                    </webView>
+                    </customView>
                 </subviews>
                 <animations/>
             </view>

--- a/Resources/XIBs/PBGitCommitView.xib
+++ b/Resources/XIBs/PBGitCommitView.xib
@@ -3,7 +3,6 @@
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14109"/>
-        <plugIn identifier="com.apple.WebKitIBPlugin" version="14109"/>
         <capability name="Aspect ratio constraints" minToolsVersion="7.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
         <capability name="stacking Non-gravity area distributions on NSStackView" minToolsVersion="7.0" minSystemVersion="10.11"/>
@@ -32,19 +31,13 @@
                 <splitView autosaveName="Commit" translatesAutoresizingMaskIntoConstraints="NO" id="186">
                     <rect key="frame" x="0.0" y="0.0" width="852" height="432"/>
                     <subviews>
-                        <webView id="125">
+                        <customView id="125">
                             <rect key="frame" x="0.0" y="0.0" width="852" height="181"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="150" id="HKc-oj-R06"/>
                             </constraints>
-                            <webPreferences key="preferences" defaultFontSize="12" defaultFixedFontSize="12">
-                                <nil key="identifier"/>
-                            </webPreferences>
-                            <connections>
-                                <outlet property="frameLoadDelegate" destination="96" id="137"/>
-                            </connections>
-                        </webView>
+                        </customView>
                         <splitView autosaveName="Staging" vertical="YES" id="209">
                             <rect key="frame" x="0.0" y="190" width="852" height="242"/>
                             <autoresizingMask key="autoresizingMask"/>

--- a/Resources/XIBs/PBGitHistoryView.xib
+++ b/Resources/XIBs/PBGitHistoryView.xib
@@ -3,7 +3,6 @@
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
-        <plugIn identifier="com.apple.WebKitIBPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -40,7 +39,7 @@
                 <binding destination="-2" name="contentArray" keyPath="gitTree.children" id="90"/>
             </connections>
         </treeController>
-        <arrayController objectClassName="PBGitCommit" editable="NO" selectsInsertedObjects="NO" avoidsEmptySelection="NO" id="39" userLabel="CommitsController">
+        <arrayController objectClassName="PBGitCommit" editable="NO" selectsInsertedObjects="NO" avoidsEmptySelection="NO" id="39" userLabel="CommitsController" customClass="PBHistoryArrayController">
             <declaredKeys>
                 <string>self</string>
                 <string>OID</string>
@@ -586,18 +585,10 @@
                                                             <rect key="frame" x="0.0" y="0.0" width="955" height="207"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
-                                                                <webView focusRingType="none" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="21">
+                                                                <customView focusRingType="none" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="21">
                                                                     <rect key="frame" x="-1" y="-1" width="957" height="209"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                    <webPreferences key="preferences" defaultFontSize="12" defaultFixedFontSize="12">
-                                                                        <nil key="identifier"/>
-                                                                    </webPreferences>
-                                                                    <connections>
-                                                                        <outlet property="UIDelegate" destination="40" id="85"/>
-                                                                        <outlet property="frameLoadDelegate" destination="40" id="84"/>
-                                                                        <outlet property="policyDelegate" destination="40" id="109"/>
-                                                                    </connections>
-                                                                </webView>
+                                                                </customView>
                                                             </subviews>
                                                         </view>
                                                         <color key="fillColor" name="windowBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -620,7 +611,7 @@
                                                                     <rect key="frame" x="0.0" y="0.0" width="233" height="214"/>
                                                                     <autoresizingMask key="autoresizingMask"/>
                                                                     <subviews>
-                                                                        <outlineView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" autosaveColumns="NO" indentationPerLevel="16" autoresizesOutlineColumn="YES" outlineTableColumn="18" id="15" customClass="PBQLOutlineView">
+                                                                        <outlineView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" allowsMultipleSelection="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" autosaveColumns="NO" indentationPerLevel="16" autoresizesOutlineColumn="YES" outlineTableColumn="18" id="15" customClass="PBQLOutlineView">
                                                                             <rect key="frame" x="0.0" y="0.0" width="233" height="214"/>
                                                                             <autoresizingMask key="autoresizingMask" heightSizable="YES"/>
                                                                             <size key="intercellSpacing" width="3" height="2"/>
@@ -640,7 +631,7 @@
                                                                                     </textFieldCell>
                                                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                                                     <connections>
-                                                                                        <binding destination="38" name="value" keyPath="arrangedObjects.path" id="92">
+                                                                                        <binding destination="38" name="value" keyPath="arrangedObjects.displayPath" id="92">
                                                                                             <dictionary key="options">
                                                                                                 <integer key="NSConditionallySetsEditable" value="1"/>
                                                                                             </dictionary>
@@ -667,14 +658,11 @@
                                                                 <rect key="frame" x="234" y="0.0" width="721" height="214"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                 <subviews>
-                                                                    <webView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="450" userLabel="FileViewer">
+                                                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="450" userLabel="FileViewer">
                                                                         <rect key="frame" x="0.0" y="0.0" width="721" height="189"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                        <webPreferences key="preferences" defaultFontSize="12" defaultFixedFontSize="12">
-                                                                            <nil key="identifier"/>
-                                                                        </webPreferences>
-                                                                    </webView>
-                                                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="475" userLabel="TypeBar" customClass="MGScopeBar">
+                                                                    </customView>
+                                                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="475" userLabel="TypeBar" customClass="PBGitGradientBarView">
                                                                         <rect key="frame" x="0.0" y="190" width="721" height="24"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                         <subviews>
@@ -700,9 +688,6 @@ IA
                                                                                 </subviews>
                                                                             </customView>
                                                                         </subviews>
-                                                                        <connections>
-                                                                            <outlet property="delegate" destination="452" id="485"/>
-                                                                        </connections>
                                                                     </customView>
                                                                 </subviews>
                                                             </customView>

--- a/Resources/en.lproj/MainMenu.xib
+++ b/Resources/en.lproj/MainMenu.xib
@@ -116,6 +116,12 @@
                                     <action selector="performClose:" target="-1" id="193"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Repository Settings…" id="codex-repo-settings">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="showRepositorySettings:" target="-1" id="codex-repo-settings-action"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Clone To…" id="954">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>

--- a/docs/adr/0001-native-content-rendering-on-macos-15.md
+++ b/docs/adr/0001-native-content-rendering-on-macos-15.md
@@ -1,0 +1,3 @@
+# Use native content rendering and HighlightKit on macOS 15
+
+GitX will target macOS 15 and replace its legacy WebKit and SyntaxHighlighter content surfaces with shared native AppKit renderers using PhraseHQ HighlightKit. This deliberately trades support for older macOS releases for adaptive native appearance, one reusable diff interaction model across History and Commit workflows, and maintained Swift syntax grammars; the existing WebKit/SyntaxHighlighter implementation and the narrower swift-highlight package were rejected because they would either retain duplicate browser UI or cover substantially fewer languages.

--- a/scripts/check_analyzer_diagnostics.py
+++ b/scripts/check_analyzer_diagnostics.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Enforce analyzer findings and a shrinking budget for compiler warnings."""
+
+from __future__ import annotations
+
+import collections
+import json
+import pathlib
+import re
+import sys
+
+
+DIAGNOSTIC = re.compile(
+    r"^(?P<path>.+?/Classes/.+?):(?P<line>\d+):(?P<column>\d+): "
+    r"(?P<severity>warning|error): (?P<message>.+)$"
+)
+COMPILER_WARNING = re.compile(r"\[(?P<category>-W[^]]+)\]$")
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <xcodebuild.log>", file=sys.stderr)
+        return 2
+
+    log_path = pathlib.Path(sys.argv[1])
+    diagnostics: dict[tuple[str, str, str, str], str] = {}
+    for line in log_path.read_text(errors="replace").splitlines():
+        match = DIAGNOSTIC.match(line)
+        if not match:
+            continue
+        key = (
+            str(pathlib.Path(match.group("path"))),
+            match.group("line"),
+            match.group("severity"),
+            match.group("message"),
+        )
+        diagnostics[key] = line
+
+    if not diagnostics:
+        print("No first-party Xcode diagnostics found.")
+        return 0
+
+    analyzer_findings: list[str] = []
+    compiler_warnings: collections.Counter[str] = collections.Counter()
+    for key, line in diagnostics.items():
+        severity = key[2]
+        message = key[3]
+        compiler_match = COMPILER_WARNING.search(message)
+        if severity == "error" or not compiler_match:
+            analyzer_findings.append(line)
+        else:
+            compiler_warnings[compiler_match.group("category")] += 1
+
+    budget_path = pathlib.Path(__file__).with_name("xcode-warning-budget.json")
+    budgets = json.loads(budget_path.read_text())
+    exceeded: list[str] = []
+    for category, count in sorted(compiler_warnings.items()):
+        budget = budgets.get(category, 0)
+        print(f"{category}: {count}/{budget}")
+        if count > budget:
+            exceeded.append(f"{category}: found {count}, budget is {budget}")
+
+    if analyzer_findings:
+        print(f"Found {len(analyzer_findings)} first-party analyzer finding(s) or error(s):", file=sys.stderr)
+        for line in sorted(analyzer_findings):
+            print(line, file=sys.stderr)
+    if exceeded:
+        print("Compiler warning budget exceeded:", file=sys.stderr)
+        for line in exceeded:
+            print(line, file=sys.stderr)
+
+    if analyzer_findings or exceeded:
+        return 1
+
+    print(f"Analyzer passed; {sum(compiler_warnings.values())} budgeted compiler warning(s) remain.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_changed_format.py
+++ b/scripts/check_changed_format.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Check clang-format only on Objective-C lines changed from a Git base."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+
+HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(?P<start>\d+)(?:,(?P<count>\d+))? @@")
+CONTEXT_LINES = 5
+
+
+def run(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, check=check, capture_output=True, text=True)
+
+
+def changed_ranges(base: str, path: pathlib.Path) -> list[tuple[int, int]]:
+    tracked = run("git", "ls-files", "--error-unmatch", str(path), check=False).returncode == 0
+    if not tracked:
+        line_count = sum(1 for _ in path.open(errors="replace"))
+        return [(1, max(line_count, 1))]
+
+    diff = run("git", "diff", "--unified=0", base, "--", str(path)).stdout
+    ranges: list[tuple[int, int]] = []
+    for line in diff.splitlines():
+        match = HUNK.match(line)
+        if not match:
+            continue
+        start = int(match.group("start"))
+        count = int(match.group("count") or "1")
+        if count:
+            ranges.append((max(1, start - CONTEXT_LINES), start + count - 1 + CONTEXT_LINES))
+
+    merged: list[tuple[int, int]] = []
+    for start, end in ranges:
+        if merged and start <= merged[-1][1] + 1:
+            merged[-1] = (merged[-1][0], max(end, merged[-1][1]))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def main() -> int:
+    arguments = sys.argv[1:]
+    fix = "--fix" in arguments
+    arguments = [argument for argument in arguments if argument != "--fix"]
+    if len(arguments) < 2:
+        print(f"Usage: {sys.argv[0]} <git-base> [--fix] <file>...", file=sys.stderr)
+        return 2
+
+    base, *names = arguments
+    failures: list[str] = []
+    for name in names:
+        path = pathlib.Path(name)
+        if not path.is_file():
+            continue
+        ranges = changed_ranges(base, path)
+        if not ranges:
+            continue
+
+        command = ["xcrun", "clang-format", "--style=file"]
+        if fix:
+            command.append("-i")
+        else:
+            command.extend(("--dry-run", "--Werror"))
+        command.extend(f"--lines={start}:{end}" for start, end in ranges)
+        result = run(*command, str(path), check=False)
+        if not fix and result.returncode:
+            failures.append(name)
+            print(result.stderr, file=sys.stderr, end="")
+
+    if failures:
+        print("Changed Objective-C lines need clang-format:", file=sys.stderr)
+        for name in failures:
+            print(f"- {name}", file=sys.stderr)
+        return 1
+
+    action = "Formatted" if fix else "Checked"
+    print(f"{action} changed Objective-C lines.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Enforce ratcheting line-coverage floors from an Xcode result bundle."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+
+
+TARGET_MINIMUM = 0.165
+FILE_MINIMUMS = {
+    "Classes/Util/PBTask.m": 0.88,
+    "Classes/Views/PBNativeContentView.m": 0.25,
+    "Classes/git/PBGitBinary.m": 0.60,
+    "Classes/git/PBGitGrapher.mm": 0.87,
+    "Classes/git/PBGitIndex.m": 0.61,
+    "Classes/git/PBGitRef.m": 0.82,
+    "Classes/git/PBGitRepository.m": 0.29,
+    "Classes/git/PBGitRevSpecifier.m": 0.83,
+    "Classes/git/PBWorkingTree.m": 0.56,
+}
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <result.xcresult>", file=sys.stderr)
+        return 2
+
+    result = subprocess.run(
+        ["xcrun", "xccov", "view", "--report", "--json", sys.argv[1]],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    report = json.loads(result.stdout)
+    target = next((item for item in report["targets"] if item["name"] == "GitX.app"), None)
+    if target is None:
+        print("GitX.app coverage was not found.", file=sys.stderr)
+        return 1
+
+    failures: list[str] = []
+    target_coverage = float(target["lineCoverage"])
+    print(f"GitX.app: {target_coverage:.2%} (minimum {TARGET_MINIMUM:.2%})")
+    if target_coverage < TARGET_MINIMUM:
+        failures.append(f"GitX.app coverage regressed to {target_coverage:.2%}")
+
+    files = {str(pathlib.Path(item["path"])): float(item["lineCoverage"]) for item in target["files"]}
+    root = pathlib.Path.cwd()
+    for relative_path, minimum in FILE_MINIMUMS.items():
+        actual = files.get(str(root / relative_path))
+        if actual is None:
+            failures.append(f"Missing coverage for {relative_path}")
+            continue
+        print(f"{relative_path}: {actual:.2%} (minimum {minimum:.2%})")
+        if actual < minimum:
+            failures.append(f"{relative_path} regressed to {actual:.2%}")
+
+    if failures:
+        print("Coverage gate failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_analyzer.sh
+++ b/scripts/run_analyzer.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+if [[ -n "${RUNNER_TEMP:-}" ]]; then
+    default_temp=$RUNNER_TEMP
+else
+    default_temp=/tmp
+fi
+derived_data=${DERIVED_DATA_PATH:-"$default_temp/GitXAnalyze"}
+log_path=${ANALYZER_LOG_PATH:-"$default_temp/GitXAnalyze.log"}
+
+cd "$root"
+xcodebuild analyze \
+    -workspace GitX.xcworkspace \
+    -scheme GitX \
+    -configuration Debug \
+    -destination "platform=macOS,arch=arm64" \
+    -derivedDataPath "$derived_data" \
+    ARCHS=arm64 \
+    CODE_SIGN_IDENTITY="-" \
+    2>&1 | tee "$log_path"
+
+python3 scripts/check_analyzer_diagnostics.py "$log_path"

--- a/scripts/verify_static.sh
+++ b/scripts/verify_static.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+cd "$root"
+
+base_ref=${1:-}
+if [[ -n "$base_ref" ]] && ! git rev-parse --verify "$base_ref^{commit}" >/dev/null 2>&1; then
+	base_ref=
+fi
+if [[ -z "$base_ref" ]] && git rev-parse --verify origin/master >/dev/null 2>&1; then
+    base_ref=origin/master
+fi
+if [[ -z "$base_ref" ]]; then
+    base_ref=HEAD~1
+fi
+
+merge_base=$(git merge-base "$base_ref" HEAD)
+changed_files=$(
+	{
+		git diff --diff-filter=ACMR --name-only "$merge_base"
+		git ls-files --others --exclude-standard
+	} | sort -u
+)
+added_files=$(
+	{
+		git diff --diff-filter=A --name-only "$merge_base"
+		git ls-files --others --exclude-standard
+	} | sort -u
+)
+
+echo "Checking formatting against $merge_base"
+xcrun clang-format -dump-config -style=file Classes/main.m >/dev/null
+
+objc_files=()
+swift_files=()
+while IFS= read -r file; do
+    [[ -f "$file" ]] || continue
+    case "$file" in
+		Classes/*.h)
+			if [[ "$file" != "Classes/iTerm2GeneratedScriptingBridge.h" ]]; then
+				objc_files+=("$file")
+            fi
+            ;;
+		Classes/*.m|Classes/*.mm|GitXTests/*.m|GitXUITests/*.m)
+            objc_files+=("$file")
+            ;;
+		Classes/*.swift)
+            swift_files+=("$file")
+            ;;
+    esac
+done <<< "$changed_files"
+
+if (( ${#objc_files[@]} )); then
+	python3 scripts/check_changed_format.py "$merge_base" "${objc_files[@]}"
+fi
+if (( ${#swift_files[@]} )); then
+    swiftformat --lint "${swift_files[@]}"
+fi
+
+while IFS= read -r file; do
+	case "$file" in
+		Classes/*.h)
+			if [[ "$file" != "Classes/iTerm2GeneratedScriptingBridge.h" ]] && ! grep -q "NS_ASSUME_NONNULL_BEGIN" "$file"; then
+				echo "$file must declare an NS_ASSUME_NONNULL region" >&2
+				exit 1
+			fi
+			;;
+	esac
+done <<< "$added_files"
+
+nonnull_headers=$(rg -l 'NS_ASSUME_NONNULL_BEGIN' Classes --glob '*.h' | wc -l | tr -d ' ')
+if (( nonnull_headers < 27 )); then
+	echo "Nullability coverage regressed: $nonnull_headers headers, expected at least 27" >&2
+	exit 1
+fi
+echo "Nullability regions: $nonnull_headers/103 headers (minimum 27)"
+
+find Resources -name '*.plist' -print0 | xargs -0 -n1 plutil -lint
+find Resources -name '*.xib' -print0 | while IFS= read -r -d '' xib; do
+    xcrun ibtool --warnings --errors --output-format human-readable-text "$xib" >/dev/null
+done
+find GitXTests -maxdepth 1 -name '*.xctestplan' -print0 | xargs -0 -n1 jq empty
+find .github -name '*.yml' -print0 | xargs -0 ruby -e 'require "yaml"; ARGV.each { |path| YAML.safe_load_file(path, aliases: true) }'
+
+PYTHONPYCACHEPREFIX="${TMPDIR:-/tmp}/gitx-pycache" python3 -m py_compile scripts/*.py
+for script in scripts/*.sh; do
+    bash -n "$script"
+done
+if command -v shellcheck >/dev/null 2>&1; then
+    shellcheck scripts/*.sh
+fi
+if command -v actionlint >/dev/null 2>&1; then
+	actionlint
+fi
+
+git diff --check "$merge_base"
+echo "Static verification passed."

--- a/scripts/xcode-warning-budget.json
+++ b/scripts/xcode-warning-budget.json
@@ -1,0 +1,3 @@
+{
+  "-Wdeprecated-declarations": 16
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "skills": {
+    "domain-modeling": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/domain-modeling/SKILL.md",
+      "computedHash": "363cb0f53b0b431e7c00086ad1f823500b7e1b70b5616ee969c979f0934e9e6e"
+    },
+    "grill-with-docs": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
+      "computedHash": "9c460cbd94fd3c63cdef967dbdb6e66ca687103cdc380cd37834e4d10b738f78"
+    },
+    "grilling": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grilling/SKILL.md",
+      "computedHash": "368d3dd7251247c69f3656d93dc83c8f1577792eacac2111f1e7981db2ece49b"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add native history, commit diff, file preview, and working-tree views with dark-mode-aware rendering
- make repository loading, selection, diff generation, task execution, and auto-fetch behavior asynchronous, cancellable, and race-safe
- harden patch generation and staging for renames, binary files, empty repositories, submodules, and partial selections
- expand preferences, coverage, unit/integration/UI tests, sanitizer plans, formatting checks, static analysis, and CI verification
- include the complete current worktree, ignore local `reviews_triage/` output, and pin the ObjectiveGit reliability update

## Why

Several native workflows could block the main thread, render stale selections after rapid navigation, mishandle edge-case paths or partial patches, and leave auto-fetch permanently paused after transient failures. The existing CI suite also did not exercise enough of these paths or enforce formatting, coverage, and analyzer regressions.

This change moves expensive Git/rendering work off the UI thread, adds cancellation and generation guards, bounds subprocesses and fetch retry behavior, strengthens Git edge-case handling, and adds regression coverage around the affected flows.

## Dependency

Depends on [gitx/objective-git#97](https://github.com/gitx/objective-git/pull/97), which makes the libgit2 update script deterministic and validates the built architecture before the parent submodule pointer advances.

## Validation

- `scripts/verify_static.sh origin/master`
- 34 unit/integration tests passed; 0 failed and 0 skipped
- all per-target coverage floors passed (GitX app coverage: 16.84%, floor: 16.50%)
- Clang static analysis succeeded; the warning-budget check passed at the measured 16-warning legacy baseline
- `sh -n External/objective-git/script/update_libgit2`
