### PR TITLE
fix(git): support relative worktree repositories

### DIFF
--- a/Classes/git/GitRepoFinder.m
+++ b/Classes/git/GitRepoFinder.m
@@ -43,8 +43,8 @@
 
 	NSData *repoPathBuffer = nil;
 	if (path_buffer.ptr) {
-		repoPathBuffer = [NSData dataWithBytes:path_buffer.ptr length:path_buffer.asize];
-		git_buf_free(&path_buffer);
+		repoPathBuffer = [NSData dataWithBytes:path_buffer.ptr length:path_buffer.size];
+		git_buf_dispose(&path_buffer);
 	}
 
 	if (gitResult == GIT_OK && repoPathBuffer.length) {

--- a/Classes/git/PBRepositoryFinder.m
+++ b/Classes/git/PBRepositoryFinder.m
@@ -46,8 +46,8 @@
 
 	NSData *repoPathBuffer = nil;
 	if (path_buffer.ptr) {
-		repoPathBuffer = [NSData dataWithBytes:path_buffer.ptr length:path_buffer.asize];
-		git_buf_free(&path_buffer);
+		repoPathBuffer = [NSData dataWithBytes:path_buffer.ptr length:path_buffer.size];
+		git_buf_dispose(&path_buffer);
 	}
 
 	if (gitResult == GIT_OK && repoPathBuffer.length) {

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+XCODEBUILD ?= xcodebuild
+ARCH ?= $(shell uname -m)
+CONFIGURATION ?= Debug
+DERIVED_DATA ?= build/DerivedData
+
+.DEFAULT_GOAL := build
+
+.PHONY: build clean rebuild
+
+build:
+	$(XCODEBUILD) \
+		-workspace GitX.xcworkspace \
+		-scheme GitX \
+		-configuration $(CONFIGURATION) \
+		-destination 'platform=macOS,arch=$(ARCH)' \
+		-derivedDataPath $(DERIVED_DATA) \
+		build
+
+clean:
+	$(XCODEBUILD) \
+		-workspace GitX.xcworkspace \
+		-scheme GitX \
+		-configuration $(CONFIGURATION) \
+		-destination 'platform=macOS,arch=$(ARCH)' \
+		-derivedDataPath $(DERIVED_DATA) \
+		clean
+
+rebuild: clean build


### PR DESCRIPTION
## Summary
Update GitX to use ObjectiveGit with libgit2 1.9.4 so repositories using the `relativeWorktrees` extension can be opened. This depends on [gitx/objective-git#98](https://github.com/gitx/objective-git/pull/98).

## Changes
- Update GitX buffer API usage and advance the ObjectiveGit submodule
- Add default `make`, `clean`, and `rebuild` targets for local builds
