### PR TITLE
Fix gitx CLI crash when GitX is not running (Sparkle Updater.app steals the bundle identifier)

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -142,7 +142,12 @@ jobs:
       # end test
           
       - name: Build project
-        run: xcodebuild -workspace GitX.xcworkspace -scheme GitX -archivePath ./GitX archive ARCHS="${{ matrix.abi }}" PRODUCT_BUNDLE_IDENTIFIER=net.phere.GitX
+        # Do NOT pass PRODUCT_BUNDLE_IDENTIFIER on the command line: it would
+        # override every target in the workspace, including Sparkle's
+        # Updater.app, which then shares the app's bundle ID and breaks the
+        # gitx CLI (Scripting Bridge resolves the wrong bundle). The GitX
+        # target already sets its identifier in the project file.
+        run: xcodebuild -workspace GitX.xcworkspace -scheme GitX -archivePath ./GitX archive ARCHS="${{ matrix.abi }}"
       - name: Prepare artifact
         if: ${{ env.variableSet != '' }}
         env:

--- a/Classes/gitx.m
+++ b/Classes/gitx.m
@@ -11,6 +11,46 @@
 #import "GitX.h"
 #import "PBHistorySearchController.h"
 
+#import <mach-o/dyld.h>
+#include <sys/param.h>
+
+
+#pragma mark GitX application lookup
+
+NSString *executablePath(void)
+{
+	char path[MAXPATHLEN];
+	uint32_t size = sizeof(path);
+	if (_NSGetExecutablePath(path, &size) != 0)
+		return nil;
+
+	// The tool is usually invoked through a symlink (e.g. /usr/local/bin/gitx)
+	char resolved[MAXPATHLEN];
+	if (!realpath(path, resolved))
+		return nil;
+
+	return [NSString stringWithUTF8String:resolved];
+}
+
+GitXApplication *gitXApplication(void)
+{
+	// This tool ships inside the app bundle at GitX.app/Contents/Resources/gitx,
+	// so locate the app relative to the tool itself. Looking it up by bundle
+	// identifier is unreliable: if another bundle on disk claims the same
+	// identifier (e.g. Sparkle's embedded Updater.app in some releases),
+	// LaunchServices can resolve to a bundle without our scripting definition
+	// and every GitX command crashes with an unrecognized selector.
+	NSString *appPath = [[[[executablePath() stringByDeletingLastPathComponent] // Resources
+		stringByDeletingLastPathComponent] // Contents
+		stringByDeletingLastPathComponent] // GitX.app
+		stringByStandardizingPath];
+	if ([[appPath pathExtension] isEqualToString:@"app"])
+		return [SBApplication applicationWithURL:[NSURL fileURLWithPath:appPath]];
+
+	// Not inside an app bundle (e.g. running from the build directory)
+	return [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
+}
+
 
 #pragma mark Commands handled locally
 
@@ -99,7 +139,7 @@ void handleSTDINDiff(void)
 	NSString *diff = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 
 	if (diff && [diff length] > 0) {
-		GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
+		GitXApplication *gitXApp = gitXApplication();
 		[gitXApp setSendMode:kAENoReply];
 		[gitXApp activate];
 		[gitXApp showDiff:diff];
@@ -109,7 +149,7 @@ void handleSTDINDiff(void)
 
 void handleDiffWithArguments(NSURL *repositoryURL, NSArray *arguments)
 {
-	GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
+	GitXApplication *gitXApp = gitXApplication();
 	[gitXApp setSendMode:kAENoReply];
 	[gitXApp activate];
 	[gitXApp performDiffIn:repositoryURL withOptions:arguments];
@@ -118,7 +158,7 @@ void handleDiffWithArguments(NSURL *repositoryURL, NSArray *arguments)
 
 void handleOpenRepository(NSURL *repositoryURL, NSArray *arguments)
 {
-	GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
+	GitXApplication *gitXApp = gitXApplication();
 	[gitXApp setSendMode:kAENoReply];
 	[gitXApp open:repositoryURL withOptions:arguments];
 	[gitXApp activate];
@@ -127,7 +167,7 @@ void handleOpenRepository(NSURL *repositoryURL, NSArray *arguments)
 
 void handleInit(NSURL *repositoryURL)
 {
-	GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
+	GitXApplication *gitXApp = gitXApplication();
 	[gitXApp createRepository:repositoryURL];
 
 	exit(0);
@@ -144,7 +184,7 @@ void handleClone(NSURL *repositoryURL, NSMutableArray *arguments)
 				repositoryURL = url;
 		}
 
-		GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
+		GitXApplication *gitXApp = gitXApplication();
 		[gitXApp cloneRepository:repository to:repositoryURL isBare:NO];
 	} else {
 		printf("Error: --clone needs the URL of the repository to clone.\n");
@@ -212,7 +252,7 @@ void handleGitXSearch(NSURL *repositoryURL, PBHistorySearchMode mode, NSMutableA
 	if ([searchString isEqualToString:@""])
 		exit(0);
 
-	GitXApplication *gitXApp = [SBApplication applicationWithBundleIdentifier:kGitXBundleIdentifier];
+	GitXApplication *gitXApp = gitXApplication();
 	[gitXApp open:[NSArray arrayWithObject:repositoryURL]];
 
 	// need to find the document after opening it


### PR DESCRIPTION
## Symptom

Since recent releases, running `gitx` from the command line crashes whenever GitX.app is **not** already running:

```
warning: failed to get scripting definition from /Applications/GitX.app/Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app; it may not be scriptable.
*** Terminating app due to uncaught exception 'NSInvalidArgumentException',
reason: '-[SBApplication open:withOptions:]: unrecognized selector sent to instance ...'
```

Launching the app first and re-running `gitx` works, which is the tell-tale for the root cause below.

## Root cause

The archive step in `BuildPR.yml` passes `PRODUCT_BUNDLE_IDENTIFIER=net.phere.GitX` on the `xcodebuild` command line (added in da70aa5c). A command-line build setting overrides **every target in the workspace**, including Sparkle's `Updater.app` built from the submodule. Since the Sparkle 2.9.3 bump (#556 / 68f83247), Updater.app's Info.plist takes its identifier from `$(PRODUCT_BUNDLE_IDENTIFIER)`, so shipped bundles contain **two** bundles claiming `net.phere.GitX`:

- `/Applications/GitX.app` (the real app), and
- `/Applications/GitX.app/Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app`

The CLI resolves the app with `[SBApplication applicationWithBundleIdentifier:@"net.phere.GitX"]`. When the app is not running, LaunchServices resolves that identifier ambiguously and can return the Updater.app — which has no scripting definition (hence the warning), so the Scripting Bridge proxy only knows the standard suite and `open:withOptions:` throws `unrecognized selector`. When the app is already running, SBApplication binds to the running process and everything works.

## Fix (two commits)

1. **Drop the command-line override.** It is redundant: every target already sets its own `PRODUCT_BUNDLE_IDENTIFIER` in `project.pbxproj` (`net.phere.GitX` for the app, `net.phere.gitx-cli` for the CLI). A comment in the workflow explains why it must not come back.
2. **Harden the CLI.** Since `gitx` ships at `GitX.app/Contents/Resources/gitx`, derive the app URL from the tool's own symlink-resolved path and use `applicationWithURL:` (falling back to the bundle-identifier lookup when running outside a bundle, e.g. from the build directory). This also makes new CLIs immune to the broken bundles installed by existing releases, which will remain on users' disks until they update.

Verified locally: with the identifier override, `Updater.app/Contents/Info.plist` in the shipped 1.5-HEAD app contains `net.phere.GitX` (upstream Sparkle uses `org.sparkle-project.Sparkle.Updater`), and the crash reproduces 100% from a cold start.