### PR TITLE
Fix sidebar-refresh to respond to manual refreshes and external branch changes

### DIFF
--- a/Classes/Controllers/PBGitSidebarController.m
+++ b/Classes/Controllers/PBGitSidebarController.m
@@ -113,6 +113,16 @@
 						  [observer.sourceView reloadItem:observer->stashes reloadChildren:YES];
 					  }];
 
+	[repository addObserver:self
+					keyPath:@"refs"
+					options:0
+					  block:^(MAKVONotification *notification) {
+						  PBGitSidebarController *observer = notification.observer;
+						  NSInteger row = observer.sourceView.selectedRow;
+						  [observer.sourceView reloadData];
+						  [observer.sourceView selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
+					  }];
+
 	[sourceView setTarget:self];
 	[sourceView setDoubleAction:@selector(doubleClicked:)];
 


### PR DESCRIPTION
## Summary
- The sidebar's checked-out branch checkmark went stale after a branch change made outside GitX (e.g. `git switch` in a terminal) or even after clicking GitX's own manual Refresh button, even though the commit-list header updated correctly.
- `reloadRefs` already invalidates the repository's cached HEAD ref and fires KVO on `refs` on every refresh cycle, automatic or manual — `PBGitSidebarController` just wasn't listening to it.
- `PBGitSidebarController` now observes the repository's existing `refs` property, reloading the outline view (preserving the current selection) so the checkmark badge is recomputed against the current HEAD whenever refs change, regardless of what triggered the refresh.

Also fixes #404.

## Test plan
- [ ] Open a repo in GitX with a branch checked out.
- [ ] In a terminal, `git switch` to a different local branch. Confirm the sidebar checkmark moves within ~1-2s without disturbing the current sidebar selection.
- [ ] Click the manual Refresh button right after an external branch change, before the automatic watcher would fire on its own. Confirm the checkmark updates immediately.