### PR TITLE
Fix duplicate commits from overlapping history refreshes (#563)

### DIFF
--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -198,8 +198,11 @@
 {
 	PBGitRepositoryWatcherEventType eventType = [(NSNumber *)[[notification userInfo] objectForKey:kPBGitRepositoryEventTypeUserInfoKey] unsignedIntValue];
 	if (eventType & PBGitRepositoryWatcherEventTypeGitDirectory) {
-		// refresh if the .git repository is modified
-		[self refresh:self];
+		// refresh if the .git repository is modified, coalescing bursts of
+		// git-directory events (e.g. a single `git switch -c` touching both a
+		// ref file and HEAD) into a single refresh
+		[NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(refresh:) object:self];
+		[self performSelector:@selector(refresh:) withObject:self afterDelay:0.2];
 	}
 }
 
@@ -599,6 +602,7 @@
 - (void)closeView
 {
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
+	[NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(refresh:) object:self];
 
 	[webHistoryController closeView];
 	[fileView closeView];

--- a/Classes/git/PBGitRevList.m
+++ b/Classes/git/PBGitRevList.m
@@ -31,6 +31,8 @@
 
 @property (nonatomic, strong) NSOperationQueue *operationQueue;
 
+@property (nonatomic, assign) NSUInteger loadGeneration;
+
 @end
 
 
@@ -62,6 +64,8 @@
 
 	self.resetCommits = YES;
 
+	NSUInteger generation = ++self.loadGeneration;
+
 	NSBlockOperation *parseOperation = [[NSBlockOperation alloc] init];
 
 	__weak typeof(self) weakSelf = self;
@@ -75,7 +79,7 @@
 		GTEnumerator *enu = [[GTEnumerator alloc] initWithRepository:repo error:&error];
 
 		[weakSelf setupEnumerator:enu forRevspec:weakSelf.currentRev];
-		[weakSelf addCommitsFromEnumerator:enu operation:weakParseOperation];
+		[weakSelf addCommitsFromEnumerator:enu operation:weakParseOperation generation:generation];
 	}];
 	[parseOperation setCompletionBlock:completionBlock];
 
@@ -94,9 +98,9 @@
 }
 
 
-- (void)updateCommits:(NSArray<PBGitCommit *> *)revisions operation:(NSOperation *)operation
+- (void)updateCommits:(NSArray<PBGitCommit *> *)revisions operation:(NSOperation *)operation generation:(NSUInteger)generation
 {
-	if (!revisions || [revisions count] == 0 || operation.cancelled)
+	if (!revisions || [revisions count] == 0 || operation.cancelled || generation != self.loadGeneration)
 		return;
 
 	if (self.resetCommits) {
@@ -193,7 +197,7 @@ static BOOL hasParameter(NSMutableArray *parameters, NSString *paramName)
 	}
 }
 
-- (void)addCommitsFromEnumerator:(GTEnumerator *)enumerator operation:(NSOperation *)operation
+- (void)addCommitsFromEnumerator:(GTEnumerator *)enumerator operation:(NSOperation *)operation generation:(NSUInteger)generation
 {
 	PBGitGrapher *g = [[PBGitGrapher alloc] init];
 	__block NSDate *lastUpdate = [NSDate date];
@@ -248,7 +252,7 @@ static BOOL hasParameter(NSMutableArray *parameters, NSString *paramName)
 				NSArray<PBGitCommit *> *updatedRevisions = [revisions copy];
 
 				dispatch_async(dispatch_get_main_queue(), ^{
-					[self updateCommits:updatedRevisions operation:operation];
+					[self updateCommits:updatedRevisions operation:operation generation:generation];
 				});
 
 				[revisions removeAllObjects];
@@ -266,7 +270,7 @@ static BOOL hasParameter(NSMutableArray *parameters, NSString *paramName)
 	NSArray<PBGitCommit *> *updatedRevisions = [revisions copy];
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		[self updateCommits:updatedRevisions operation:operation];
+		[self updateCommits:updatedRevisions operation:operation generation:generation];
 	});
 }
 


### PR DESCRIPTION
## Summary
- Fixes #563: rapid successive git-directory changes (e.g. `git switch -c <branch>`) could trigger overlapping `PBGitRevList` parses, and a stale parse's trailing commit flush could land after a newer parse had already started, duplicating commits in the history list.
- Guard `PBGitRevList` with a per-instance load generation: `updateCommits:operation:generation:` now rejects any flush whose generation no longer matches the current one, closing the race regardless of operation-queue/FSEvents timing.
- Debounce `PBGitHistoryController._repositoryUpdatedNotification:` so a burst of git-directory FSEvents (e.g. the ref-file write and HEAD rewrite from a single `git switch -c`) collapses into one `refresh:` call.

## Test plan
- `xcodebuild -project GitX.xcodeproj -scheme GitX -configuration Debug -destination 'platform=macOS' build` succeeds.
- lldb breakpoints on `-[PBGitHistoryList updateProjectHistoryForRev:]`, `-[PBGitRevList loadRevisionsWithCompletionBlock:]`, and `-[PBGitRevList updateCommits:operation:generation:]` resolve at the expected source lines in the built binary, confirming the generation-guard code is live.
- Manual repro: launch the built app against a throwaway repo and run a burst of rapid `git switch -c` calls while watching the commit list ("All" scope) for duplicate rows.