### PR TITLE
Dispatch preferencesChanged WebKit calls to the main thread

### DIFF
--- a/Classes/Controllers/PBWebHistoryController.m
+++ b/Classes/Controllers/PBWebHistoryController.m
@@ -346,7 +346,9 @@ static NSDictionary *loadCommitSummary(GTRepository *repo, GTCommit *commit, BOO
 
 - (void)preferencesChanged
 {
-	[[self script] callWebScriptMethod:@"enableFeatures" withArguments:nil];
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[[self script] callWebScriptMethod:@"enableFeatures" withArguments:nil];
+	});
 }
 
 @end


### PR DESCRIPTION
## Summary
PBWebHistoryController's preferencesChanged touched WebView's windowScriptObject synchronously from whatever thread posted NSUserDefaultsDidChangeNotification. WebKit requires windowScriptObject to be accessed only on the main thread and raises WebKitThreadingException otherwise, crashing the process.

## Changes
- Wrap the script call in dispatch_async(dispatch_get_main_queue())
- Found via a new GitXTests unit-test target (not part of this PR): XCTest's bootstrap registers NSUserDefaults from a background thread during process startup, crashing GitX consistently
- Unrelated to issue #563 (duplicate commits race)

## Test plan
- [ ] Verify GitX still updates its web views normally after a preference change (main-thread path unaffected)
- [ ] Confirm a background-thread NSUserDefaultsDidChangeNotification no longer crashes with WebKitThreadingException