### PR TITLE
Add Git Preferences window for editing git config

### DIFF
--- a/Classes/Controllers/PBGitPrefsWindowController.h
+++ b/Classes/Controllers/PBGitPrefsWindowController.h
@@ -1,0 +1,55 @@
+//
+//  PBGitPrefsWindowController.h
+//  GitX
+//
+
+#import <Cocoa/Cocoa.h>
+#import "DBPrefsWindowController.h"
+
+@class PBGitRepository;
+
+@interface PBGitPrefsWindowController : DBPrefsWindowController
+
++ (void)showPrefsForRepository:(PBGitRepository *)repository;
+
+@property (nonatomic, strong) PBGitRepository *repository;
+
+@property (readwrite, weak) IBOutlet NSView *repositoryPrefsView;
+@property (readwrite, weak) IBOutlet NSView *globalPrefsView;
+
+@property (readwrite, weak) IBOutlet NSTextField *repositoryErrorMessage;
+@property (readwrite, weak) IBOutlet NSTextField *globalErrorMessage;
+
+@property (readwrite, weak) IBOutlet NSTextField *localUserNameField;
+@property (readwrite, weak) IBOutlet NSTextField *globalUserNameField;
+@property (readwrite, weak) IBOutlet NSTextField *localUserEmailField;
+@property (readwrite, weak) IBOutlet NSTextField *globalUserEmailField;
+@property (readwrite, weak) IBOutlet NSTextField *localCoreEditorField;
+@property (readwrite, weak) IBOutlet NSTextField *globalCoreEditorField;
+@property (readwrite, weak) IBOutlet NSPopUpButton *localAutocrlfPopUp;
+@property (readwrite, weak) IBOutlet NSPopUpButton *globalAutocrlfPopUp;
+@property (readwrite, weak) IBOutlet NSButton *localMergeSummaryCheckbox;
+@property (readwrite, weak) IBOutlet NSButton *globalMergeSummaryCheckbox;
+@property (readwrite, weak) IBOutlet NSTextField *localMergeVerbosityField;
+@property (readwrite, weak) IBOutlet NSTextField *globalMergeVerbosityField;
+@property (readwrite, weak) IBOutlet NSButton *localMergeDiffstatCheckbox;
+@property (readwrite, weak) IBOutlet NSButton *globalMergeDiffstatCheckbox;
+@property (readwrite, weak) IBOutlet NSTextField *localMergeToolField;
+@property (readwrite, weak) IBOutlet NSTextField *globalMergeToolField;
+@property (readwrite, weak) IBOutlet NSTextField *localDiffToolField;
+@property (readwrite, weak) IBOutlet NSTextField *globalDiffToolField;
+@property (readwrite, weak) IBOutlet NSTextField *localDiffOptsField;
+@property (readwrite, weak) IBOutlet NSTextField *globalDiffOptsField;
+@property (readwrite, weak) IBOutlet NSButton *localPullRebaseCheckbox;
+@property (readwrite, weak) IBOutlet NSButton *globalPullRebaseCheckbox;
+@property (readwrite, weak) IBOutlet NSTextField *localDefaultBranchField;
+@property (readwrite, weak) IBOutlet NSTextField *globalDefaultBranchField;
+@property (readwrite, weak) IBOutlet NSButton *localGpgSignCheckbox;
+@property (readwrite, weak) IBOutlet NSButton *globalGpgSignCheckbox;
+@property (readwrite, weak) IBOutlet NSTextField *localSigningKeyField;
+@property (readwrite, weak) IBOutlet NSTextField *globalSigningKeyField;
+
+- (IBAction)save:(id)sender;
+- (IBAction)cancelOperation:(id)sender;
+
+@end

--- a/Classes/Controllers/PBGitPrefsWindowController.m
+++ b/Classes/Controllers/PBGitPrefsWindowController.m
@@ -1,0 +1,252 @@
+//
+//  PBGitPrefsWindowController.m
+//  GitX
+//
+
+#import "PBGitPrefsWindowController.h"
+
+#import "PBGitRepository.h"
+
+typedef NS_ENUM(NSInteger, PBGitPrefsRowType) {
+	PBGitPrefsRowTypeString,
+	PBGitPrefsRowTypeBool,
+	PBGitPrefsRowTypeAutocrlf,
+};
+
+@interface PBGitPrefsRow : NSObject
+@property (nonatomic, copy) NSString *key;
+@property (nonatomic, assign) PBGitPrefsRowType type;
+@property (nonatomic, weak) NSControl *localControl;
+@property (nonatomic, weak) NSControl *globalControl;
+@end
+
+@implementation PBGitPrefsRow
+@end
+
+@interface PBGitPrefsWindowController ()
+@property (nonatomic, strong) NSDictionary<NSString *, NSString *> *loadedLocalConfig;
+@property (nonatomic, strong) NSDictionary<NSString *, NSString *> *loadedGlobalConfig;
+@end
+
+@implementation PBGitPrefsWindowController
+
+#pragma mark -
+#pragma mark PBGitPrefsWindowController
+
+// +showPrefsForRepository: hands back no reference for the caller to hold onto (matching
+// +[PBDiffWindowController showDiff:]'s style), so this class keeps itself alive here for as
+// long as its window is open, releasing itself once the window closes.
+static NSMutableArray<PBGitPrefsWindowController *> *_openPrefsWindowControllers;
+
++ (void)showPrefsForRepository:(PBGitRepository *)repository
+{
+	if (!_openPrefsWindowControllers) {
+		_openPrefsWindowControllers = [NSMutableArray array];
+	}
+
+	PBGitPrefsWindowController *controller = [[self alloc] initWithWindowNibName:@"PBGitPrefsWindowController"];
+	controller.repository = repository;
+	[_openPrefsWindowControllers addObject:controller];
+
+	[[NSNotificationCenter defaultCenter] addObserverForName:NSWindowWillCloseNotification
+													   object:controller.window
+														queue:nil
+												   usingBlock:^(NSNotification *note) {
+													   [_openPrefsWindowControllers removeObject:controller];
+												   }];
+
+	[controller showWindow:self];
+}
+
+- (IBAction)showWindow:(id)sender
+{
+	(void)[self window]; // force the nib (and our outlets) to load before -loadValues runs
+	[self loadValues];
+	[super showWindow:sender];
+}
+
+#pragma mark DBPrefsWindowController overrides
+
+- (void)setupToolbar
+{
+	NSString *repoLabel = [NSString stringWithFormat:NSLocalizedString(@"%@ Repository", @"Git Preferences: repository-scoped pane label"), self.repository.projectName];
+	[self addView:self.repositoryPrefsView label:repoLabel image:[NSImage imageNamed:NSImageNameFolder]];
+	[self addView:self.globalPrefsView label:NSLocalizedString(@"Global (All Repositories)", @"Git Preferences: global pane label") image:[NSImage imageNamed:NSImageNameNetwork]];
+}
+
+#pragma mark Row list
+
+- (NSArray<PBGitPrefsRow *> *)rows
+{
+	PBGitPrefsRow *(^makeRow)(NSString *, PBGitPrefsRowType, NSControl *, NSControl *) =
+		^PBGitPrefsRow *(NSString *key, PBGitPrefsRowType type, NSControl *local, NSControl *global) {
+			PBGitPrefsRow *row = [PBGitPrefsRow new];
+			row.key = key;
+			row.type = type;
+			row.localControl = local;
+			row.globalControl = global;
+			return row;
+		};
+
+	return @[
+		makeRow(@"user.name", PBGitPrefsRowTypeString, self.localUserNameField, self.globalUserNameField),
+		makeRow(@"user.email", PBGitPrefsRowTypeString, self.localUserEmailField, self.globalUserEmailField),
+		makeRow(@"core.editor", PBGitPrefsRowTypeString, self.localCoreEditorField, self.globalCoreEditorField),
+		makeRow(@"core.autocrlf", PBGitPrefsRowTypeAutocrlf, self.localAutocrlfPopUp, self.globalAutocrlfPopUp),
+		makeRow(@"merge.summary", PBGitPrefsRowTypeBool, self.localMergeSummaryCheckbox, self.globalMergeSummaryCheckbox),
+		makeRow(@"merge.verbosity", PBGitPrefsRowTypeString, self.localMergeVerbosityField, self.globalMergeVerbosityField),
+		makeRow(@"merge.diffstat", PBGitPrefsRowTypeBool, self.localMergeDiffstatCheckbox, self.globalMergeDiffstatCheckbox),
+		makeRow(@"merge.tool", PBGitPrefsRowTypeString, self.localMergeToolField, self.globalMergeToolField),
+		makeRow(@"diff.tool", PBGitPrefsRowTypeString, self.localDiffToolField, self.globalDiffToolField),
+		makeRow(@"gui.diffopts", PBGitPrefsRowTypeString, self.localDiffOptsField, self.globalDiffOptsField),
+		makeRow(@"pull.rebase", PBGitPrefsRowTypeBool, self.localPullRebaseCheckbox, self.globalPullRebaseCheckbox),
+		makeRow(@"init.defaultBranch", PBGitPrefsRowTypeString, self.localDefaultBranchField, self.globalDefaultBranchField),
+		makeRow(@"commit.gpgsign", PBGitPrefsRowTypeBool, self.localGpgSignCheckbox, self.globalGpgSignCheckbox),
+		makeRow(@"user.signingkey", PBGitPrefsRowTypeString, self.localSigningKeyField, self.globalSigningKeyField),
+	];
+}
+
+#pragma mark Loading
+
+- (void)loadValues
+{
+	[self setErrorText:@""];
+
+	NSError *error = nil;
+	self.loadedLocalConfig = [self.repository gitConfigDictionaryForScope:PBGitConfigScopeLocal error:&error];
+	if (!self.loadedLocalConfig) {
+		[self setErrorText:error.localizedDescription ?: @""];
+		return;
+	}
+
+	self.loadedGlobalConfig = [self.repository gitConfigDictionaryForScope:PBGitConfigScopeGlobal error:&error];
+	if (!self.loadedGlobalConfig) {
+		[self setErrorText:error.localizedDescription ?: @""];
+		return;
+	}
+
+	for (PBGitPrefsRow *row in self.rows) {
+		[self setControl:row.localControl toValue:self.loadedLocalConfig[row.key] type:row.type];
+		[self setControl:row.globalControl toValue:self.loadedGlobalConfig[row.key] type:row.type];
+	}
+}
+
+- (void)setControl:(NSControl *)control toValue:(NSString *)value type:(PBGitPrefsRowType)type
+{
+	switch (type) {
+		case PBGitPrefsRowTypeString: {
+			NSTextField *field = (NSTextField *)control;
+			field.stringValue = value ?: @"";
+			break;
+		}
+		case PBGitPrefsRowTypeBool: {
+			NSButton *checkbox = (NSButton *)control;
+			if (value == nil) {
+				checkbox.state = NSControlStateValueMixed;
+			} else {
+				checkbox.state = [self boolValueForConfigString:value] ? NSControlStateValueOn : NSControlStateValueOff;
+			}
+			break;
+		}
+		case PBGitPrefsRowTypeAutocrlf: {
+			NSPopUpButton *popUp = (NSPopUpButton *)control;
+			NSString *title = value.length ? value : @"(not set)";
+			if (![popUp itemWithTitle:title]) title = @"(not set)";
+			[popUp selectItemWithTitle:title];
+			break;
+		}
+	}
+}
+
+// git treats a bare "key" record (no "=value") from `git config --null --list` as boolean true.
+- (BOOL)boolValueForConfigString:(NSString *)value
+{
+	if (value.length == 0) return YES;
+	return [value caseInsensitiveCompare:@"true"] == NSOrderedSame || [value isEqualToString:@"1"] || [value caseInsensitiveCompare:@"yes"] == NSOrderedSame;
+}
+
+#pragma mark Saving
+
+- (IBAction)save:(id)sender
+{
+	[self setErrorText:@""];
+
+	for (PBGitPrefsRow *row in self.rows) {
+		NSError *error = nil;
+		if (![self saveGlobalValueForRow:row error:&error]) {
+			[self setErrorText:error.localizedDescription ?: @""];
+			return;
+		}
+		if (![self saveLocalValueForRow:row error:&error]) {
+			[self setErrorText:error.localizedDescription ?: @""];
+			return;
+		}
+	}
+
+	[self close];
+}
+
+- (void)setErrorText:(NSString *)text
+{
+	[self.repositoryErrorMessage setStringValue:text];
+	[self.globalErrorMessage setStringValue:text];
+}
+
+- (BOOL)saveGlobalValueForRow:(PBGitPrefsRow *)row error:(NSError **)error
+{
+	NSString *newValue = [self stringValueForControl:row.globalControl type:row.type];
+	if ([self stringValue:newValue isEqualToConfigValue:self.loadedGlobalConfig[row.key]]) return YES;
+
+	return [self.repository setGitConfigValue:newValue forKey:row.key scope:PBGitConfigScopeGlobal error:error];
+}
+
+- (BOOL)saveLocalValueForRow:(PBGitPrefsRow *)row error:(NSError **)error
+{
+	NSString *newValue = [self stringValueForControl:row.localControl type:row.type];
+	if ([self stringValue:newValue isEqualToConfigValue:self.loadedLocalConfig[row.key]]) return YES;
+
+	// git-gui's save_config: when the new local value equals the (originally loaded) global value,
+	// unset the local override instead of writing a redundant duplicate, so the repository falls
+	// back to the global value.
+	NSString *effectiveNewValue = [self stringValue:newValue isEqualToConfigValue:self.loadedGlobalConfig[row.key]] ? nil : newValue;
+
+	return [self.repository setGitConfigValue:effectiveNewValue forKey:row.key scope:PBGitConfigScopeLocal error:error];
+}
+
+- (NSString *)stringValueForControl:(NSControl *)control type:(PBGitPrefsRowType)type
+{
+	switch (type) {
+		case PBGitPrefsRowTypeString: {
+			NSTextField *field = (NSTextField *)control;
+			return field.stringValue;
+		}
+		case PBGitPrefsRowTypeBool: {
+			NSButton *checkbox = (NSButton *)control;
+			if (checkbox.state == NSControlStateValueMixed) return nil;
+			return (checkbox.state == NSControlStateValueOn) ? @"true" : @"false";
+		}
+		case PBGitPrefsRowTypeAutocrlf: {
+			NSPopUpButton *popUp = (NSPopUpButton *)control;
+			NSString *title = popUp.selectedItem.title;
+			return [title isEqualToString:@"(not set)"] ? nil : title;
+		}
+	}
+	return nil;
+}
+
+- (BOOL)stringValue:(NSString *)newValue isEqualToConfigValue:(NSString *)oldValue
+{
+	NSString *normalizedNew = newValue.length ? newValue : nil;
+	NSString *normalizedOld = oldValue.length ? oldValue : nil;
+	if (normalizedNew == nil || normalizedOld == nil) return (normalizedNew == normalizedOld);
+	return [normalizedNew isEqualToString:normalizedOld];
+}
+
+#pragma mark IBActions
+
+- (IBAction)cancelOperation:(id)sender
+{
+	[self close];
+}
+
+@end

--- a/Classes/Controllers/PBGitWindowController.h
+++ b/Classes/Controllers/PBGitWindowController.h
@@ -60,6 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (IBAction)cherryPick:(id)sender;
 - (IBAction)resetSoft:(id)sender;
 
+- (IBAction)showGitPrefsWindow:(id)sender;
+
 - (IBAction)showAddRemoteSheet:(id)sender GITX_DEPRECATED;
 - (IBAction)addRemote:(id)sender;
 - (IBAction)fetchRemote:(id)sender;

--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -14,6 +14,7 @@
 #import "PBGitXMessageSheet.h"
 #import "PBGitSidebarController.h"
 #import "PBAddRemoteSheet.h"
+#import "PBGitPrefsWindowController.h"
 #import "PBCreateBranchSheet.h"
 #import "PBCreateTagSheet.h"
 #import "PBGitDefaults.h"
@@ -455,6 +456,11 @@
 		return (branchCommits.count == 1 ? branchCommits.firstObject : nil);
 	}
 	return nil;
+}
+
+- (IBAction)showGitPrefsWindow:(id)sender
+{
+	[PBGitPrefsWindowController showPrefsForRepository:self.repository];
 }
 
 - (IBAction)showAddRemoteSheet:(id)sender

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -28,6 +28,11 @@ typedef enum branchFilterTypes {
 	kGitXSelectedBranchFilter
 } PBGitXBranchFilterType;
 
+typedef NS_ENUM(NSInteger, PBGitConfigScope) {
+	PBGitConfigScopeLocal,   // this repository's effective config (system+global+local merged, as git itself sees it)
+	PBGitConfigScopeGlobal,  // ~/.gitconfig only
+};
+
 @class PBGitWindowController;
 @class PBGitCommit;
 @class PBGitIndex;
@@ -74,6 +79,9 @@ typedef enum branchFilterTypes {
 - (BOOL)createTag:(NSString *)tagName message:(NSString *)message atRefish:(id<PBGitRefish>)commitSHA error:(NSError **)error;
 - (BOOL)deleteRemote:(PBGitRef *)ref error:(NSError **)error;
 - (BOOL)deleteRef:(PBGitRef *)ref error:(NSError **)error;
+
+- (NSDictionary<NSString *, NSString *> *)gitConfigDictionaryForScope:(PBGitConfigScope)scope error:(NSError **)error;
+- (BOOL)setGitConfigValue:(NSString *)value forKey:(NSString *)key scope:(PBGitConfigScope)scope error:(NSError **)error;
 
 - (BOOL)stashPop:(PBGitStash *)stash error:(NSError **)error;
 - (BOOL)stashApply:(PBGitStash *)stash error:(NSError **)error;

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -690,6 +690,68 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return trackingBranchRef;
 }
 
+#pragma mark Git Configuration
+
+- (NSDictionary<NSString *, NSString *> *)gitConfigDictionaryForScope:(PBGitConfigScope)scope error:(NSError **)error
+{
+	NSMutableArray *arguments = [NSMutableArray arrayWithObject:@"config"];
+	if (scope == PBGitConfigScopeGlobal) {
+		[arguments addObject:@"--global"];
+	}
+	[arguments addObjectsFromArray:@[ @"--null", @"--list" ]];
+
+	NSError *taskError = nil;
+	NSString *output = [self outputOfTaskWithArguments:arguments error:&taskError];
+	if (output == nil) {
+		PBReturnError(error, NSLocalizedString(@"Reading git configuration failed", @""), taskError.localizedFailureReason ?: taskError.localizedDescription, taskError);
+		return nil;
+	}
+
+	NSMutableDictionary<NSString *, NSString *> *result = [NSMutableDictionary dictionary];
+	for (NSString *record in [output componentsSeparatedByString:@"\0"]) {
+		if (record.length == 0) continue;
+
+		NSRange newlineRange = [record rangeOfString:@"\n"];
+		if (newlineRange.location == NSNotFound) {
+			result[record] = @"";
+		} else {
+			NSString *key = [record substringToIndex:newlineRange.location];
+			NSString *value = [record substringFromIndex:(newlineRange.location + 1)];
+			result[key] = value;
+		}
+	}
+	return result;
+}
+
+- (BOOL)setGitConfigValue:(NSString *)value forKey:(NSString *)key scope:(PBGitConfigScope)scope error:(NSError **)error
+{
+	NSMutableArray *arguments = [NSMutableArray arrayWithObject:@"config"];
+	if (scope == PBGitConfigScopeGlobal) {
+		[arguments addObject:@"--global"];
+	}
+
+	if (value.length == 0) {
+		[arguments addObjectsFromArray:@[ @"--unset", key ]];
+	} else {
+		[arguments addObjectsFromArray:@[ key, value ]];
+	}
+
+	NSError *taskError = nil;
+	BOOL success = [self launchTaskWithArguments:arguments error:&taskError];
+	if (success) return YES;
+
+	// git config --unset exits 5 when the key was already unset; that's not a failure for us.
+	if (value.length == 0
+		&& [taskError.domain isEqualToString:PBTaskErrorDomain]
+		&& taskError.code == PBTaskNonZeroExitCodeError
+		&& [taskError.userInfo[PBTaskTerminationStatusKey] intValue] == 5) {
+		return YES;
+	}
+
+	PBReturnError(error, NSLocalizedString(@"Writing git configuration failed", @""), taskError.localizedFailureReason ?: taskError.localizedDescription, taskError);
+	return NO;
+}
+
 #pragma mark Repository commands
 
 - (BOOL)addRemote:(NSString *)remoteName withURL:(NSString *)URLString error:(NSError **)error

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		4A5D761714A9A99E00DF6C68 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4A5D760314A9A99E00DF6C68 /* InfoPlist.strings */; };
 		4A5D761814A9A99E00DF6C68 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4A5D760514A9A99E00DF6C68 /* MainMenu.xib */; };
 		4A5D761914A9A99E00DF6C68 /* PBAddRemoteSheet.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4A5D760714A9A99E00DF6C68 /* PBAddRemoteSheet.xib */; };
+		DBE616549B1FF136833E3A00 /* PBGitPrefsWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 43596E13613459F5AF93DABE /* PBGitPrefsWindowController.xib */; };
 		4A5D761A14A9A99E00DF6C68 /* PBCloneRepositoryPanel.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4A5D760914A9A99E00DF6C68 /* PBCloneRepositoryPanel.xib */; };
 		4A5D761C14A9A99E00DF6C68 /* PBCreateBranchSheet.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4A5D760D14A9A99E00DF6C68 /* PBCreateBranchSheet.xib */; };
 		4A5D761D14A9A99E00DF6C68 /* PBCreateTagSheet.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4A5D760F14A9A99E00DF6C68 /* PBCreateTagSheet.xib */; };
@@ -114,6 +115,7 @@
 		4A5D772214A9A9CC00DF6C68 /* PBEasyFS.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D76B014A9A9CC00DF6C68 /* PBEasyFS.m */; };
 		4A5D772514A9A9CC00DF6C68 /* GLFileView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D76B714A9A9CC00DF6C68 /* GLFileView.m */; };
 		4A5D772614A9A9CC00DF6C68 /* PBAddRemoteSheet.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D76B914A9A9CC00DF6C68 /* PBAddRemoteSheet.m */; };
+		5691FE0CD491549CA139B773 /* PBGitPrefsWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = D575BEA38C6E3AD3D04CF823 /* PBGitPrefsWindowController.m */; };
 		4A5D772714A9A9CC00DF6C68 /* PBCloneRepositoryPanel.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D76BB14A9A9CC00DF6C68 /* PBCloneRepositoryPanel.m */; };
 		4A5D772A14A9A9CC00DF6C68 /* PBCommitHookFailedSheet.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D76C114A9A9CC00DF6C68 /* PBCommitHookFailedSheet.m */; };
 		4A5D772B14A9A9CC00DF6C68 /* PBCommitMessageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5D76C314A9A9CC00DF6C68 /* PBCommitMessageView.m */; };
@@ -490,6 +492,8 @@
 		4A5D763114A9A9CC00DF6C68 /* PBGitHistoryController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = PBGitHistoryController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		4A5D763414A9A9CC00DF6C68 /* PBGitSidebarController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBGitSidebarController.h; sourceTree = "<group>"; };
 		4A5D763514A9A9CC00DF6C68 /* PBGitSidebarController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBGitSidebarController.m; sourceTree = "<group>"; };
+		8736B905E4C25A4A561B38DC /* PBGitPrefsWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBGitPrefsWindowController.h; sourceTree = "<group>"; };
+		D575BEA38C6E3AD3D04CF823 /* PBGitPrefsWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBGitPrefsWindowController.m; sourceTree = "<group>"; };
 		4A5D763614A9A9CC00DF6C68 /* PBGitWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBGitWindowController.h; sourceTree = "<group>"; };
 		4A5D763714A9A9CC00DF6C68 /* PBGitWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = PBGitWindowController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		4A5D763814A9A9CC00DF6C68 /* PBHistorySearchController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBHistorySearchController.h; sourceTree = "<group>"; };
@@ -640,6 +644,7 @@
 		4D5AB8822286DE5D003CD3CE /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = ../en.lproj/PBCloneRepositoryPanel.xib; sourceTree = "<group>"; };
 		4D5AB8832286DE5E003CD3CE /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = ../en.lproj/PBCreateBranchSheet.xib; sourceTree = "<group>"; };
 		4D5AB8842286DE5F003CD3CE /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = ../en.lproj/PBCreateTagSheet.xib; sourceTree = "<group>"; };
+		777BD317AE77F9AF30DCB923 /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = ../en.lproj/PBGitPrefsWindowController.xib; sourceTree = "<group>"; };
 		4D5AB8852286DE61003CD3CE /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = ../en.lproj/PBRemoteProgressSheet.xib; sourceTree = "<group>"; };
 		4D5AB8862286DE62003CD3CE /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = ../en.lproj/Preferences.xib; sourceTree = "<group>"; };
 		4D5AB8872286DE64003CD3CE /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = ../en.lproj/RepositoryWindow.xib; sourceTree = "<group>"; };
@@ -944,6 +949,7 @@
 				4A5D760914A9A99E00DF6C68 /* PBCloneRepositoryPanel.xib */,
 				4A5D760D14A9A99E00DF6C68 /* PBCreateBranchSheet.xib */,
 				4A5D760F14A9A99E00DF6C68 /* PBCreateTagSheet.xib */,
+				43596E13613459F5AF93DABE /* PBGitPrefsWindowController.xib */,
 				4A5D761114A9A99E00DF6C68 /* PBRemoteProgressSheet.xib */,
 				4A5D761314A9A99E00DF6C68 /* Preferences.xib */,
 				4A5D761514A9A99E00DF6C68 /* RepositoryWindow.xib */,
@@ -1008,6 +1014,8 @@
 				4A5D762F14A9A9CC00DF6C68 /* PBGitCommitController.m */,
 				4A5D763014A9A9CC00DF6C68 /* PBGitHistoryController.h */,
 				4A5D763114A9A9CC00DF6C68 /* PBGitHistoryController.m */,
+				8736B905E4C25A4A561B38DC /* PBGitPrefsWindowController.h */,
+				D575BEA38C6E3AD3D04CF823 /* PBGitPrefsWindowController.m */,
 				4A5D763414A9A9CC00DF6C68 /* PBGitSidebarController.h */,
 				4A5D763514A9A9CC00DF6C68 /* PBGitSidebarController.m */,
 				4A5D763614A9A9CC00DF6C68 /* PBGitWindowController.h */,
@@ -1579,6 +1587,7 @@
 				97CF01FA18A6C5BB00E30F2B /* empty_file.pdf in Resources */,
 				4A5D761814A9A99E00DF6C68 /* MainMenu.xib in Resources */,
 				4A5D761914A9A99E00DF6C68 /* PBAddRemoteSheet.xib in Resources */,
+				DBE616549B1FF136833E3A00 /* PBGitPrefsWindowController.xib in Resources */,
 				978357BD189C19A000ADC689 /* PushTemplate.pdf in Resources */,
 				4A5D761A14A9A99E00DF6C68 /* PBCloneRepositoryPanel.xib in Resources */,
 				7EDCE8EE2EBEFEEF0062CE78 /* AppIcon.icon in Resources */,
@@ -1670,6 +1679,7 @@
 				4A5D76E414A9A9CC00DF6C68 /* PBDiffWindowController.m in Sources */,
 				4A5D76E514A9A9CC00DF6C68 /* PBGitCommitController.m in Sources */,
 				4A5D76E614A9A9CC00DF6C68 /* PBGitHistoryController.m in Sources */,
+				5691FE0CD491549CA139B773 /* PBGitPrefsWindowController.m in Sources */,
 				4A5D76E814A9A9CC00DF6C68 /* PBGitSidebarController.m in Sources */,
 				508E268D1FD317FC00CE9FE0 /* PBSidebarTableViewCell.m in Sources */,
 				4DECFBB21E662962004C3A6F /* ObjectiveGit+PBCategories.m in Sources */,
@@ -1852,6 +1862,14 @@
 				4D5AB8812286DE5B003CD3CE /* en */,
 			);
 			name = PBAddRemoteSheet.xib;
+			sourceTree = "<group>";
+		};
+		43596E13613459F5AF93DABE /* PBGitPrefsWindowController.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				777BD317AE77F9AF30DCB923 /* en */,
+			);
+			name = PBGitPrefsWindowController.xib;
 			sourceTree = "<group>";
 		};
 		4A5D760914A9A99E00DF6C68 /* PBCloneRepositoryPanel.xib */ = {

--- a/Resources/en.lproj/MainMenu.xib
+++ b/Resources/en.lproj/MainMenu.xib
@@ -36,6 +36,11 @@
                                     <action selector="openPreferencesWindow:" target="-1" id="wRi-Ra-7Ua"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Git Preferences…" id="6C1-Gp-Prf">
+                                <connections>
+                                    <action selector="showGitPrefsWindow:" target="-1" id="6C1-Gp-Act"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Check for Updates…" id="919">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>

--- a/Resources/en.lproj/PBGitPrefsWindowController.xib
+++ b/Resources/en.lproj/PBGitPrefsWindowController.xib
@@ -1,0 +1,643 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9060" systemVersion="15D21" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9060"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="PBGitPrefsWindowController">
+            <connections>
+                <outlet property="globalAutocrlfPopUp" destination="95" id="150"/>
+                <outlet property="globalCoreEditorField" destination="91" id="151"/>
+                <outlet property="globalDefaultBranchField" destination="132" id="152"/>
+                <outlet property="globalDiffOptsField" destination="124" id="153"/>
+                <outlet property="globalDiffToolField" destination="120" id="154"/>
+                <outlet property="globalErrorMessage" destination="142" id="155"/>
+                <outlet property="globalGpgSignCheckbox" destination="136" id="156"/>
+                <outlet property="globalMergeDiffstatCheckbox" destination="112" id="157"/>
+                <outlet property="globalMergeSummaryCheckbox" destination="104" id="158"/>
+                <outlet property="globalMergeToolField" destination="116" id="159"/>
+                <outlet property="globalMergeVerbosityField" destination="108" id="160"/>
+                <outlet property="globalPrefsView" destination="80" id="161"/>
+                <outlet property="globalPullRebaseCheckbox" destination="128" id="162"/>
+                <outlet property="globalSigningKeyField" destination="140" id="163"/>
+                <outlet property="globalUserEmailField" destination="87" id="164"/>
+                <outlet property="globalUserNameField" destination="83" id="165"/>
+                <outlet property="localAutocrlfPopUp" destination="25" id="166"/>
+                <outlet property="localCoreEditorField" destination="21" id="167"/>
+                <outlet property="localDefaultBranchField" destination="62" id="168"/>
+                <outlet property="localDiffOptsField" destination="54" id="169"/>
+                <outlet property="localDiffToolField" destination="50" id="170"/>
+                <outlet property="localGpgSignCheckbox" destination="66" id="171"/>
+                <outlet property="localMergeDiffstatCheckbox" destination="42" id="172"/>
+                <outlet property="localMergeSummaryCheckbox" destination="34" id="173"/>
+                <outlet property="localMergeToolField" destination="46" id="174"/>
+                <outlet property="localMergeVerbosityField" destination="38" id="175"/>
+                <outlet property="localPullRebaseCheckbox" destination="58" id="176"/>
+                <outlet property="localSigningKeyField" destination="70" id="177"/>
+                <outlet property="localUserEmailField" destination="17" id="178"/>
+                <outlet property="localUserNameField" destination="13" id="179"/>
+                <outlet property="repositoryErrorMessage" destination="72" id="180"/>
+                <outlet property="repositoryPrefsView" destination="10" id="181"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application"/>
+        <customView id="10">
+    <rect key="frame" x="0.0" y="0.0" width="520" height="491"/>
+    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+    <subviews>
+        <textField verticalHuggingPriority="750" id="11">
+        <rect key="frame" x="20" y="455" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="User Name:" id="12">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="13">
+        <rect key="frame" x="220" y="453" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="14">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="15">
+        <rect key="frame" x="20" y="427" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Email Address:" id="16">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="17">
+        <rect key="frame" x="220" y="425" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="18">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="19">
+        <rect key="frame" x="20" y="399" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Editor:" id="20">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="21">
+        <rect key="frame" x="220" y="397" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="22">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="23">
+        <rect key="frame" x="20" y="371" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Line Ending Conversion:" id="24">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <popUpButton verticalHuggingPriority="750" id="25">
+        <rect key="frame" x="220" y="369" width="150" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <popUpButtonCell key="cell" type="push" title="(not set)" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="28" id="26">
+            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+            <font key="font" metaFont="system"/>
+            <menu key="menu" title="OtherViews" id="27">
+                <items>
+                    <menuItem title="(not set)" state="on" id="28"/>
+                    <menuItem title="false" id="29"/>
+                    <menuItem title="true" id="30"/>
+                    <menuItem title="input" id="31"/>
+                </items>
+            </menu>
+        </popUpButtonCell>
+    </popUpButton>
+        <textField verticalHuggingPriority="750" id="32">
+        <rect key="frame" x="20" y="343" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Summarize Merge Commits:" id="33">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <button verticalHuggingPriority="750" id="34">
+        <rect key="frame" x="220" y="341" width="280" height="18"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="35">
+            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+            <font key="font" metaFont="system"/>
+        </buttonCell>
+    </button>
+        <textField verticalHuggingPriority="750" id="36">
+        <rect key="frame" x="20" y="315" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Merge Verbosity:" id="37">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="38">
+        <rect key="frame" x="220" y="313" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="39">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="40">
+        <rect key="frame" x="20" y="287" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Show Diffstat After Merge:" id="41">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <button verticalHuggingPriority="750" id="42">
+        <rect key="frame" x="220" y="285" width="280" height="18"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="43">
+            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+            <font key="font" metaFont="system"/>
+        </buttonCell>
+    </button>
+        <textField verticalHuggingPriority="750" id="44">
+        <rect key="frame" x="20" y="259" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Merge Tool:" id="45">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="46">
+        <rect key="frame" x="220" y="257" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="47">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="48">
+        <rect key="frame" x="20" y="231" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Diff Tool:" id="49">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="50">
+        <rect key="frame" x="220" y="229" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="51">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="52">
+        <rect key="frame" x="20" y="203" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Additional Diff Parameters:" id="53">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="54">
+        <rect key="frame" x="220" y="201" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="55">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="56">
+        <rect key="frame" x="20" y="175" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Rebase on Pull:" id="57">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <button verticalHuggingPriority="750" id="58">
+        <rect key="frame" x="220" y="173" width="280" height="18"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="59">
+            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+            <font key="font" metaFont="system"/>
+        </buttonCell>
+    </button>
+        <textField verticalHuggingPriority="750" id="60">
+        <rect key="frame" x="20" y="147" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Default Branch Name:" id="61">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="62">
+        <rect key="frame" x="220" y="145" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="63">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="64">
+        <rect key="frame" x="20" y="119" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Sign Commits (GPG):" id="65">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <button verticalHuggingPriority="750" id="66">
+        <rect key="frame" x="220" y="117" width="280" height="18"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="67">
+            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+            <font key="font" metaFont="system"/>
+        </buttonCell>
+    </button>
+        <textField verticalHuggingPriority="750" id="68">
+        <rect key="frame" x="20" y="91" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Signing Key:" id="69">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="70">
+        <rect key="frame" x="220" y="89" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="71">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="72">
+        <rect key="frame" x="20" y="56" width="480" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="" id="73">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <button verticalHuggingPriority="750" id="74">
+        <rect key="frame" x="404" y="16" width="96" height="32"/>
+        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+        <buttonCell key="cell" type="push" title="Save" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="75">
+            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+            <font key="font" metaFont="system"/>
+            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+        </buttonCell>
+        <connections>
+            <action selector="save:" target="-2" id="76"/>
+        </connections>
+    </button>
+        <button verticalHuggingPriority="750" id="77">
+        <rect key="frame" x="300" y="16" width="96" height="32"/>
+        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+        <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="78">
+            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+            <font key="font" metaFont="system"/>
+            <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+        </buttonCell>
+        <connections>
+            <action selector="cancelOperation:" target="-2" id="79"/>
+        </connections>
+    </button>
+    </subviews>
+</customView>
+        <customView id="80">
+    <rect key="frame" x="0.0" y="0.0" width="520" height="491"/>
+    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+    <subviews>
+        <textField verticalHuggingPriority="750" id="81">
+        <rect key="frame" x="20" y="455" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="User Name:" id="82">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="83">
+        <rect key="frame" x="220" y="453" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="84">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="85">
+        <rect key="frame" x="20" y="427" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Email Address:" id="86">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="87">
+        <rect key="frame" x="220" y="425" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="88">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="89">
+        <rect key="frame" x="20" y="399" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Editor:" id="90">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="91">
+        <rect key="frame" x="220" y="397" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="92">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="93">
+        <rect key="frame" x="20" y="371" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Line Ending Conversion:" id="94">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <popUpButton verticalHuggingPriority="750" id="95">
+        <rect key="frame" x="220" y="369" width="150" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <popUpButtonCell key="cell" type="push" title="(not set)" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="98" id="96">
+            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+            <font key="font" metaFont="system"/>
+            <menu key="menu" title="OtherViews" id="97">
+                <items>
+                    <menuItem title="(not set)" state="on" id="98"/>
+                    <menuItem title="false" id="99"/>
+                    <menuItem title="true" id="100"/>
+                    <menuItem title="input" id="101"/>
+                </items>
+            </menu>
+        </popUpButtonCell>
+    </popUpButton>
+        <textField verticalHuggingPriority="750" id="102">
+        <rect key="frame" x="20" y="343" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Summarize Merge Commits:" id="103">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <button verticalHuggingPriority="750" id="104">
+        <rect key="frame" x="220" y="341" width="280" height="18"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="105">
+            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+            <font key="font" metaFont="system"/>
+        </buttonCell>
+    </button>
+        <textField verticalHuggingPriority="750" id="106">
+        <rect key="frame" x="20" y="315" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Merge Verbosity:" id="107">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="108">
+        <rect key="frame" x="220" y="313" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="109">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="110">
+        <rect key="frame" x="20" y="287" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Show Diffstat After Merge:" id="111">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <button verticalHuggingPriority="750" id="112">
+        <rect key="frame" x="220" y="285" width="280" height="18"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="113">
+            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+            <font key="font" metaFont="system"/>
+        </buttonCell>
+    </button>
+        <textField verticalHuggingPriority="750" id="114">
+        <rect key="frame" x="20" y="259" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Merge Tool:" id="115">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="116">
+        <rect key="frame" x="220" y="257" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="117">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="118">
+        <rect key="frame" x="20" y="231" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Diff Tool:" id="119">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="120">
+        <rect key="frame" x="220" y="229" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="121">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="122">
+        <rect key="frame" x="20" y="203" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Additional Diff Parameters:" id="123">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="124">
+        <rect key="frame" x="220" y="201" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="125">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="126">
+        <rect key="frame" x="20" y="175" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Rebase on Pull:" id="127">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <button verticalHuggingPriority="750" id="128">
+        <rect key="frame" x="220" y="173" width="280" height="18"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="129">
+            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+            <font key="font" metaFont="system"/>
+        </buttonCell>
+    </button>
+        <textField verticalHuggingPriority="750" id="130">
+        <rect key="frame" x="20" y="147" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Default Branch Name:" id="131">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="132">
+        <rect key="frame" x="220" y="145" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="133">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="134">
+        <rect key="frame" x="20" y="119" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Sign Commits (GPG):" id="135">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <button verticalHuggingPriority="750" id="136">
+        <rect key="frame" x="220" y="117" width="280" height="18"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="137">
+            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+            <font key="font" metaFont="system"/>
+        </buttonCell>
+    </button>
+        <textField verticalHuggingPriority="750" id="138">
+        <rect key="frame" x="20" y="91" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Signing Key:" id="139">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="140">
+        <rect key="frame" x="220" y="89" width="280" height="22"/>
+        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="141">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <textField verticalHuggingPriority="750" id="142">
+        <rect key="frame" x="20" y="56" width="480" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="" id="143">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <button verticalHuggingPriority="750" id="144">
+        <rect key="frame" x="404" y="16" width="96" height="32"/>
+        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+        <buttonCell key="cell" type="push" title="Save" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="145">
+            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+            <font key="font" metaFont="system"/>
+            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+        </buttonCell>
+        <connections>
+            <action selector="save:" target="-2" id="146"/>
+        </connections>
+    </button>
+        <button verticalHuggingPriority="750" id="147">
+        <rect key="frame" x="300" y="16" width="96" height="32"/>
+        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+        <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="148">
+            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+            <font key="font" metaFont="system"/>
+            <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+        </buttonCell>
+        <connections>
+            <action selector="cancelOperation:" target="-2" id="149"/>
+        </connections>
+    </button>
+    </subviews>
+</customView>
+    </objects>
+</document>


### PR DESCRIPTION
## Summary

Add a "Git Preferences" window to GitX (GitX menu → Git Preferences…) \
to view and edit common git configuration values, like - 
- user name/email
- merge and diff tools
- line-ending handling
- pull/merge behavior
- commit signing

at both the repository-level and the global-level (`~/.gitconfig`), \
via 2 tabs in one window with a toolbar pane switcher matching GitX's existing app-settings window.

Read and write config the same way git-gui itself does it \
(`git config [--global] --null --list` for bulk reads per scope, \
`git config [--global] <key> <value>` / `--unset` for writes), \
including its behavior of falling back to the global value instead of storing a redundant local override.

## Suggested UI for the Git-Parameters Window

<img width="527" height="522" alt="gitx-PR_#56x_GitX-Git-Parameters" src="https://github.com/user-attachments/assets/6bd5ca0a-986b-47d4-b4ad-5bdbe9fc461a" />

(The "Global" tab is selected here)

 
## Test plan

- Open a repository in GitX, choose GitX → Git Preferences…, and confirm
  values load correctly on both the "This Repository" and "Global" panes.
- Edit a value on each pane, Save, and confirm via `git config
  --local/--global --get <key>` that it landed in the correct file.
- Cancel without saving and confirm nothing was written.