### PR TITLE
Fix keyboard navigation in toolbar-paned preference windows

### DIFF
--- a/Classes/Controllers/DBPrefsWindowController.m
+++ b/Classes/Controllers/DBPrefsWindowController.m
@@ -75,6 +75,7 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 	[contentSubview setAutoresizingMask:(NSViewMinYMargin | NSViewWidthSizable)];
 	[[[self window] contentView] addSubview:contentSubview];
 	[[self window] setShowsToolbarButton:NO];
+	[panel setAutorecalculatesKeyViewLoop:YES];
 }
 
 
@@ -180,6 +181,8 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 	[[self window] center];
 
 	[super showWindow:sender];
+
+	[[self window] makeFirstResponder:nil];
 }
 
 


### PR DESCRIPTION
## Summary

Restore keyboard navigation in GitX's toolbar-paned preference windows:
`DBPrefsWindowController` builds its `NSPanel` in code and never set
`autorecalculatesKeyViewLoop`, so no key view chain ever existed and Tab/Shift-Tab
did nothing. Because the panes are separate top-level views added as subviews at
runtime, Interface Builder's own key-view-loop computation never ran over them
either. This affects every window built on it, including the existing App Settings
window (`PBPrefsWindowController`).

- Turn on `autorecalculatesKeyViewLoop` in `-windowDidLoad` so AppKit derives
  Tab/Shift-Tab order from view geometry, recalculated each time a pane is swapped in
- Reset the first responder at the end of `-showWindow:`, mirroring the existing
  work-around in `-animationDidEnd:`, so a valid key view loop no longer causes the
  first control to grab focus when the window is shown

## Test plan

- Open GitX -> Settings..., and confirm Tab and Shift-Tab move focus forward and
  backward through the controls of the current pane in visual order.
- Confirm no control shows a focus ring when the window is opened, including on a
  second open after closing it with a control focused.
- Switch panes via the toolbar and confirm Tab follows the newly shown pane.
