### PR TITLE
Fix phantom "detached HEAD" entry stuck in the sidebar

### DIFF
--- a/Classes/Controllers/PBGitSidebarController.m
+++ b/Classes/Controllers/PBGitSidebarController.m
@@ -40,6 +40,7 @@
 - (PBSourceViewItem *)addRevSpec:(PBGitRevSpecifier *)revSpec;
 - (PBSourceViewItem *)itemForRev:(PBGitRevSpecifier *)rev;
 - (void)removeRevSpec:(PBGitRevSpecifier *)rev;
+- (void)reloadPreservingSelection;
 - (void)updateActionMenu;
 - (void)updateRemoteControls;
 @end
@@ -74,9 +75,7 @@
 					options:0
 					  block:^(MAKVONotification *notification) {
 						  PBGitSidebarController *observer = notification.observer;
-						  NSInteger row = observer.sourceView.selectedRow;
-						  [observer.sourceView reloadData];
-						  [observer.sourceView selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
+						  [observer reloadPreservingSelection];
 						  [observer selectCurrentBranch];
 					  }];
 
@@ -118,9 +117,7 @@
 					options:0
 					  block:^(MAKVONotification *notification) {
 						  PBGitSidebarController *observer = notification.observer;
-						  NSInteger row = observer.sourceView.selectedRow;
-						  [observer.sourceView reloadData];
-						  [observer.sourceView selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
+						  [observer reloadPreservingSelection];
 					  }];
 
 	[sourceView setTarget:self];
@@ -157,6 +154,19 @@
 	[sourceView selectRowIndexes:index byExtendingSelection:NO];
 }
 
+- (void)reloadPreservingSelection
+{
+	PBSourceViewItem *selectedItem = [sourceView itemAtRow:[sourceView selectedRow]];
+
+	[sourceView reloadData];
+
+	NSInteger row = [sourceView rowForItem:selectedItem];
+	if (row == -1)
+		return;
+
+	[sourceView selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
+}
+
 - (void)selectCurrentBranch
 {
 	PBGitRepository *repository = self.repository;
@@ -170,7 +180,7 @@
 	if (@available(macOS 10.12, *))
 		dispatch_assert_queue(dispatch_get_main_queue());
 
-	PBSourceViewItem *item = [self addRevSpec:rev];
+	PBSourceViewItem *item = [self itemForRev:rev];
 	if (item) {
 		[sourceView PBExpandItem:item expandParents:YES];
 		NSIndexSet *index = [NSIndexSet indexSetWithIndex:[sourceView rowForItem:item]];

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -255,9 +255,16 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 		[oldBranches removeObject:revSpec];
 	}
 
+	BOOL prunedCurrentBranch = NO;
 	for (PBGitRevSpecifier *branch in oldBranches)
-		if ([branch isSimpleRef] && ![branch isEqual:[self headRef]])
+		if ([branch isSimpleRef] && ![branch isEqual:[self headRef]]) {
+			if ([branch isEqual:self.currentBranch])
+				prunedCurrentBranch = YES;
 			[self removeBranch:branch];
+		}
+
+	if (prunedCurrentBranch)
+		[self readCurrentBranch];
 
 
 	[self loadSubmodules];
@@ -757,6 +764,7 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 
 	dispatch_async(dispatch_get_main_queue(), ^{
 		[self reloadRefs];
+		[self readCurrentBranch];
 	});
 
 	return success;


### PR DESCRIPTION
## Summary

Rebasing a series of local branches from a terminal while GitX watched the
repository leaves a `"detached HEAD"` row permanently at the top of the BRANCHES
list, long after every rebase has finished and HEAD is attached again. Selecting
other branches does not clear it, because by then the row is no longer backed by
the model at all. Confirmed by instrumenting `reloadRefs` and the sidebar, the
chain is: `reloadRefs` legitimately injects a synthetic `HEAD` ref while a rebase
has HEAD detached, and its title sorts first in BRANCHES; the sidebar's observers
then re-select a captured row *index* across a `reloadData` that has already
dropped the selection, so the stale index lands on the newly inserted row and
silently assigns `currentBranch = HEAD`; when the rebase ends, the prune loop
removes the ref but only guards `headRef`, leaving `currentBranch` dangling, and
nothing reconciles it because the FSEvent refresh path calls `reloadRefs` and only
`reloadRefs`; finally `selectCurrentBranch` feeds that dangling spec into
`addRevSpec:`, rebuilding the row as an orphan that no `branches` KVO removal can
ever delete. The commit message carries the step-by-step detail.

- Re-select by **item** rather than by row index in the `currentBranch` and `refs`
  observers, via a new `reloadPreservingSelection` helper. This keeps 6e92c1a0's
  intent of recomputing the checked-out badge on every refresh, without silently
  reassigning the user's selected branch whenever a row is inserted or removed
- Reset a pruned `currentBranch` through `readCurrentBranch` at the end of
  `reloadRefs`, so an externally moved or deleted HEAD heals itself. Guarded on the
  branch actually having been pruned, since `setCurrentBranch:` reaches
  `reloadRefs` again through `updateHistory`
- Look the row up with `itemForRev:` in `selectCurrentBranch`, so a sidebar row can
  never outlive its model entry; row creation stays in the `branches` KVO insertion
  path
- Call `readCurrentBranch` after `reloadRefs` in `pullBranch:fromRemote:rebase:`,
  matching checkout, merge, cherry-pick, reset and rebase. GitX's own Pull and
  Rebase runs on a background queue, so it has the same mid-rebase window

## Test plan

Reproduced first on an instrumented build against a scratch repo to confirm each
link in the chain, then re-run after the fix:

- External `git checkout --detach` followed by re-attach: the row appears while HEAD
  is genuinely detached and disappears afterwards. Before the fix it survived, with
  `currentBranch` stuck at the `HEAD` spec and the scope bar reading `"detached HEAD"`.
- Delete the branch GitX has selected, from a terminal: the row is removed and
  `currentBranch` self-heals to the checked-out branch instead of dangling.
- A five-branch external `git pull --rebase origin main` loop, and a conflicted
  rebase followed by `git rebase --abort`: HEAD rows created and removed in balance,
  no dangling `currentBranch` at any point, and the sidebar selection never moves on
  its own.

## More Info

See attached screenshot

<img width="404" height="234" alt="gitx-PR_#569_Detached-HEAD" src="https://github.com/user-attachments/assets/ba8894c8-b6a1-45f2-ab7c-9e5b4eb365ff" />
