### PR TITLE
Fix remote-branch delete doing nothing, and expose prune-on-fetch

### DIFF
--- a/Classes/Controllers/DBPrefsWindowController.m
+++ b/Classes/Controllers/DBPrefsWindowController.m
@@ -175,7 +175,6 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 	}
 
 	NSString *identifier = [self defaultViewIdentifier];
-	[[[self window] toolbar] setSelectedItemIdentifier:identifier];
 	[self displayViewForIdentifier:identifier animate:NO];
 
 	[[self window] center];
@@ -221,6 +220,12 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 
 - (void)displayViewForIdentifier:(NSString *)identifier animate:(BOOL)animate
 {
+	// Keep the toolbar's selection on the pane actually being shown. AppKit moves the selection
+	// itself when an item is clicked, but not when it is activated from the keyboard, which leaves
+	// the previously selected tab drawn as selected while a different pane is displayed. Setting it
+	// here covers every route into a pane, including the initial one from -showWindow:.
+	[[[self window] toolbar] setSelectedItemIdentifier:identifier];
+
 	// Find the view we want to display.
 	NSView *newView = [toolbarViews objectForKey:identifier];
 
@@ -247,7 +252,14 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 		frame.origin.y = NSHeight([contentSubview frame]) - NSHeight([newView bounds]);
 		[newView setFrame:frame];
 		[contentSubview addSubview:newView];
-		[[self window] setInitialFirstResponder:newView];
+
+		// A pane's container view never accepts focus itself, so pointing the window at it leaves
+		// Tab with no way into a freshly shown pane: the window stays first responder and the key
+		// view loop is never entered. Recalculate the loop now that the pane is in the hierarchy
+		// and start it at the first control that will actually take focus.
+		[[self window] recalculateKeyViewLoop];
+		NSView *firstKeyView = [newView nextValidKeyView];
+		[[self window] setInitialFirstResponder:(firstKeyView ?: newView)];
 
 		if (animate && [self crossFade])
 			[self crossFadeView:oldView withView:newView];

--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -1083,8 +1083,14 @@
 	BOOL isStash = [[ref ref] hasPrefix:@"refs/stash"];
 	BOOL isDeleteEnabled = !(isDetachedHead || isHead || isStash);
 	if (isDeleteEnabled) {
-		NSString *deleteFormat = ref.isRemote ? NSLocalizedString(@"Delete “%@”…", @"Contextual Menu Item to delete a local ref (e.g. branch)") : NSLocalizedString(@"Remove “%@”…", @"Contextual Menu Item to remove a remote");
-		NSString *deleteItemTitle = [NSString stringWithFormat:deleteFormat, refName];
+		NSString *deleteItemTitle = nil;
+		if (ref.isRemoteBranch) {
+			deleteItemTitle = [NSString stringWithFormat:NSLocalizedString(@"Delete “%@” on “%@”…", @"Contextual Menu Item to delete the selected branch on its remote"), ref.remoteBranchName, remoteName];
+		} else if (isRemote) {
+			deleteItemTitle = [NSString stringWithFormat:NSLocalizedString(@"Delete “%@”…", @"Contextual Menu Item to delete a remote"), refName];
+		} else {
+			deleteItemTitle = [NSString stringWithFormat:NSLocalizedString(@"Remove “%@”…", @"Contextual Menu Item to remove a local ref (e.g. branch)"), refName];
+		}
 		NSMenuItem *deleteItem = [NSMenuItem pb_itemWithTitle:deleteItemTitle action:@selector(deleteRef:) enabled:YES];
 		[items addObject:deleteItem];
 	}

--- a/Classes/Controllers/PBGitPrefsWindowController.h
+++ b/Classes/Controllers/PBGitPrefsWindowController.h
@@ -42,6 +42,8 @@
 @property (readwrite, weak) IBOutlet NSTextField *globalDiffOptsField;
 @property (readwrite, weak) IBOutlet NSButton *localPullRebaseCheckbox;
 @property (readwrite, weak) IBOutlet NSButton *globalPullRebaseCheckbox;
+@property (readwrite, weak) IBOutlet NSButton *localFetchPruneCheckbox;
+@property (readwrite, weak) IBOutlet NSButton *globalFetchPruneCheckbox;
 @property (readwrite, weak) IBOutlet NSTextField *localDefaultBranchField;
 @property (readwrite, weak) IBOutlet NSTextField *globalDefaultBranchField;
 @property (readwrite, weak) IBOutlet NSButton *localGpgSignCheckbox;

--- a/Classes/Controllers/PBGitPrefsWindowController.m
+++ b/Classes/Controllers/PBGitPrefsWindowController.m
@@ -5,6 +5,8 @@
 
 #import "PBGitPrefsWindowController.h"
 
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
 #import "PBGitRepository.h"
 
 typedef NS_ENUM(NSInteger, PBGitPrefsRowType) {
@@ -67,11 +69,22 @@ static NSMutableArray<PBGitPrefsWindowController *> *_openPrefsWindowControllers
 
 #pragma mark DBPrefsWindowController overrides
 
+static const NSUInteger kMaxProjectNameLength = 25;
+
 - (void)setupToolbar
 {
-	NSString *repoLabel = [NSString stringWithFormat:NSLocalizedString(@"%@ Repository", @"Git Preferences: repository-scoped pane label"), self.repository.projectName];
-	[self addView:self.repositoryPrefsView label:repoLabel image:[NSImage imageNamed:NSImageNameFolder]];
-	[self addView:self.globalPrefsView label:NSLocalizedString(@"Global (All Repositories)", @"Git Preferences: global pane label") image:[NSImage imageNamed:NSImageNameNetwork]];
+	NSString *projectName = self.repository.projectName;
+	if (projectName.length > kMaxProjectNameLength) {
+		// Expanded to whole composed characters so the cut never lands inside one.
+		NSRange range = [projectName rangeOfComposedCharacterSequencesForRange:NSMakeRange(0, kMaxProjectNameLength)];
+		projectName = [[projectName substringWithRange:range] stringByAppendingString:@"…"];
+	}
+
+	NSImage *icon = [[NSWorkspace sharedWorkspace] iconForContentType:UTTypePlainText];
+
+	NSString *repoLabel = [NSString stringWithFormat:NSLocalizedString(@"%@ Prefs.", @"Git Preferences: repository-scoped pane label"), projectName];
+	[self addView:self.repositoryPrefsView label:repoLabel image:icon];
+	[self addView:self.globalPrefsView label:NSLocalizedString(@"Global Prefs.", @"Git Preferences: global pane label") image:icon];
 }
 
 #pragma mark Row list
@@ -100,6 +113,7 @@ static NSMutableArray<PBGitPrefsWindowController *> *_openPrefsWindowControllers
 		makeRow(@"diff.tool", PBGitPrefsRowTypeString, self.localDiffToolField, self.globalDiffToolField),
 		makeRow(@"gui.diffopts", PBGitPrefsRowTypeString, self.localDiffOptsField, self.globalDiffOptsField),
 		makeRow(@"pull.rebase", PBGitPrefsRowTypeBool, self.localPullRebaseCheckbox, self.globalPullRebaseCheckbox),
+		makeRow(@"fetch.prune", PBGitPrefsRowTypeBool, self.localFetchPruneCheckbox, self.globalFetchPruneCheckbox),
 		makeRow(@"init.defaultBranch", PBGitPrefsRowTypeString, self.localDefaultBranchField, self.globalDefaultBranchField),
 		makeRow(@"commit.gpgsign", PBGitPrefsRowTypeBool, self.localGpgSignCheckbox, self.globalGpgSignCheckbox),
 		makeRow(@"user.signingkey", PBGitPrefsRowTypeString, self.localSigningKeyField, self.globalSigningKeyField),

--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -388,6 +388,54 @@
 					}];
 }
 
+- (void)performDeleteForRemoteBranch:(PBGitRef *)ref
+{
+	if (![ref isRemoteBranch])
+		return;
+
+	NSString *branchName = [ref remoteBranchName];
+	NSString *remoteName = [ref remoteName];
+
+	NSAlert *alert = [[NSAlert alloc] init];
+	alert.messageText = [NSString stringWithFormat:NSLocalizedString(@"Delete branch “%@” from remote “%@”?", @"Delete remote branch alert - message"), branchName, remoteName];
+	alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"This deletes the branch on remote “%@” for everyone using it. GitX cannot undo this.", @"Delete remote branch alert - informative text"), remoteName];
+	[alert addButtonWithTitle:NSLocalizedString(@"Delete", @"Delete remote branch alert - confirm button")];
+	[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"Delete remote branch alert - cancel and default button")];
+	[self makeCancelTheDefaultButtonForDestructiveAlert:alert];
+
+	// No suppression identifier: -confirmDialog:… skips the dialog entirely once an identifier has
+	// been suppressed, and a server side delete must never happen without an explicit confirmation.
+	[self confirmDialog:alert
+		suppressionIdentifier:nil
+					forAction:^{
+						NSString *description = [NSString stringWithFormat:@"Deleting branch '%@' from remote %@", branchName, remoteName];
+						PBRemoteProgressSheet *progressSheet = [PBRemoteProgressSheet progressSheetWithTitle:@"Deleting remote branch…"
+																								 description:description
+																							windowController:self];
+
+						[progressSheet
+							beginProgressSheetForBlock:^{
+								NSError *error = nil;
+								BOOL success = [self.repository deleteRemoteBranch:ref error:&error];
+								return (success ? nil : error);
+							}
+							completionHandler:^(NSError *error) {
+								if (error) {
+									[self showErrorSheet:error];
+								}
+							}];
+					}];
+}
+
+// -confirmDialog:… treats the first button as the confirming one, so the destructive button has to
+// stay first. Move the return key onto the cancel button so a stray Return does not delete.
+- (void)makeCancelTheDefaultButtonForDestructiveAlert:(NSAlert *)alert
+{
+	alert.buttons.firstObject.keyEquivalent = @"";
+	alert.buttons.firstObject.hasDestructiveAction = YES;
+	alert.buttons.lastObject.keyEquivalent = @"\r";
+}
+
 - (NSArray<NSURL *> *)selectedURLsFromSender:(id)sender
 {
 	NSArray *selectedFiles = [sender representedObject];
@@ -503,19 +551,25 @@
 
 - (IBAction)deleteRef:(id)sender
 {
-	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXBranchType, kGitXRemoteType, kGitXTagType ]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXBranchType, kGitXRemoteBranchType, kGitXRemoteType, kGitXTagType ]];
 	if (!refish || ![refish isKindOfClass:[PBGitRef class]])
 		return;
 
 	PBGitRef *ref = (PBGitRef *)refish;
+
+	if ([ref isRemoteBranch]) {
+		[self performDeleteForRemoteBranch:ref];
+		return;
+	}
 
 	NSString *ref_desc = [NSString stringWithFormat:@"%@ '%@'", [ref refishType], [ref shortName]];
 
 	NSAlert *alert = [[NSAlert alloc] init];
 	alert.messageText = [NSString stringWithFormat:@"Delete %@?", ref_desc];
 	alert.informativeText = [NSString stringWithFormat:@"Are you sure you want to remove the %@?", ref_desc];
-	[alert addButtonWithTitle:NSLocalizedString(@"Delete", @"Delete ref alert - default button")];
-	[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"Delete ref alert - cancel button")];
+	[alert addButtonWithTitle:NSLocalizedString(@"Delete", @"Delete ref alert - confirm button")];
+	[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"Delete ref alert - cancel and default button")];
+	[self makeCancelTheDefaultButtonForDestructiveAlert:alert];
 
 	[self confirmDialog:alert
 		suppressionIdentifier:@"Delete Ref"

--- a/Classes/git/PBGitDefaults.h
+++ b/Classes/git/PBGitDefaults.h
@@ -7,6 +7,13 @@
 //
 
 #define kDialogAcceptDroppedRef @"Accept Dropped Ref"
+
+typedef NS_ENUM(NSInteger, PBPruneOnFetchSetting) {
+	PBPruneOnFetchUseGitConfig = 0,
+	PBPruneOnFetchAlways = 1,
+	PBPruneOnFetchNever = 2,
+};
+
 @interface PBGitDefaults : NSObject {
 }
 
@@ -29,6 +36,7 @@
 + (NSInteger)historySearchMode;
 + (void)setHistorySearchMode:(NSInteger)mode;
 + (BOOL)useRepositoryWatcher;
++ (PBPruneOnFetchSetting)pruneOnFetch;
 + (NSString *)terminalHandler;
 
 

--- a/Classes/git/PBGitDefaults.m
+++ b/Classes/git/PBGitDefaults.m
@@ -30,6 +30,7 @@
 #define kHistorySearchMode @"PBHistorySearchMode"
 #define kSuppressedDialogWarnings @"Suppressed Dialog Warnings"
 #define kUseRepositoryWatcher @"PBUseRepositoryWatcher"
+#define kPruneOnFetch @"PBPruneOnFetch"
 #define kTerminalHandler @"PBTerminalHandler"
 
 @implementation PBGitDefaults
@@ -65,6 +66,8 @@
 					  forKey:kHistorySearchMode];
 	[defaultValues setObject:[NSNumber numberWithBool:YES]
 					  forKey:kUseRepositoryWatcher];
+	[defaultValues setObject:[NSNumber numberWithInteger:PBPruneOnFetchUseGitConfig]
+					  forKey:kPruneOnFetch];
 	[defaultValues setObject:@"com.apple.Terminal"
 					  forKey:kTerminalHandler];
 	[[NSUserDefaults standardUserDefaults] registerDefaults:defaultValues];
@@ -226,6 +229,11 @@
 + (BOOL)useRepositoryWatcher
 {
 	return [[NSUserDefaults standardUserDefaults] boolForKey:kUseRepositoryWatcher];
+}
+
++ (PBPruneOnFetchSetting)pruneOnFetch
+{
+	return [[NSUserDefaults standardUserDefaults] integerForKey:kPruneOnFetch];
 }
 
 + (NSString *)terminalHandler

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -78,6 +78,7 @@ typedef NS_ENUM(NSInteger, PBGitConfigScope) {
 - (BOOL)createBranch:(NSString *)branchName atRefish:(id<PBGitRefish>)ref error:(NSError **)error;
 - (BOOL)createTag:(NSString *)tagName message:(NSString *)message atRefish:(id<PBGitRefish>)commitSHA error:(NSError **)error;
 - (BOOL)deleteRemote:(PBGitRef *)ref error:(NSError **)error;
+- (BOOL)deleteRemoteBranch:(PBGitRef *)ref error:(NSError **)error;
 - (BOOL)deleteRef:(PBGitRef *)ref error:(NSError **)error;
 
 - (NSDictionary<NSString *, NSString *> *)gitConfigDictionaryForScope:(PBGitConfigScope)scope error:(NSError **)error;

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -780,7 +780,21 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 		fetchArg = ref.remoteName;
 	}
 
-	PBTask *task = [self taskWithArguments:@[ @"fetch", fetchArg ]];
+	NSMutableArray *arguments = [NSMutableArray arrayWithObject:@"fetch"];
+	switch ([PBGitDefaults pruneOnFetch]) {
+		case PBPruneOnFetchAlways:
+			[arguments addObject:@"--prune"];
+			break;
+		case PBPruneOnFetchNever:
+			[arguments addObject:@"--no-prune"];
+			break;
+		case PBPruneOnFetchUseGitConfig:
+			// Leave it to git, so fetch.prune and remote.<name>.prune decide.
+			break;
+	}
+	[arguments addObject:fetchArg];
+
+	PBTask *task = [self taskWithArguments:arguments];
 	NSError *taskError = nil;
 	BOOL success = [task launchTask:&taskError];
 	if (!success) {

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -1098,6 +1098,33 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return YES;
 }
 
+- (BOOL)deleteRemoteBranch:(PBGitRef *)ref error:(NSError **)error
+{
+	if (!ref || ![ref isRemoteBranch]) {
+		NSString *desc = NSLocalizedString(@"Delete remote branch failed", @"PBGitRepository - delete remote branch error description");
+		NSString *reason = NSLocalizedString(@"The ref to delete is not a remote branch.", @"PBGitRepostory - delete remote branch error reason for a non remote branch ref");
+		return PBReturnError(error, desc, reason, nil);
+	}
+
+	NSString *remoteName = [ref remoteName];
+	NSString *branchName = [ref remoteBranchName];
+	PBTask *task = [self taskWithArguments:@[ @"push", remoteName, @"--delete", branchName ]];
+
+	NSError *taskError = nil;
+	BOOL success = [task launchTask:&taskError];
+	if (!success) {
+		NSString *desc = NSLocalizedString(@"Delete remote branch failed", @"PBGitRepository - delete remote branch error description");
+		NSString *reason = [NSString stringWithFormat:NSLocalizedString(@"An error occurred while deleting branch \"%@\" from remote \"%@\".", @"PBGitRepostory - delete remote branch error reason"), branchName, remoteName];
+		PBReturnError(error, desc, reason, taskError);
+	}
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[self reloadRefs];
+	});
+
+	return success;
+}
+
 - (NSString *)performDiff:(PBGitCommit *)startCommit against:(PBGitCommit *)diffCommit forFiles:(NSArray *)filePaths
 {
 	NSParameterAssert(startCommit);
@@ -1133,6 +1160,9 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 {
 	if (!ref)
 		return NO;
+
+	if ([ref refishType] == kGitXRemoteBranchType)
+		return [self deleteRemoteBranch:ref error:error];
 
 	if ([ref refishType] == kGitXRemoteType)
 		return [self deleteRemote:ref error:error];

--- a/Resources/en.lproj/PBGitPrefsWindowController.xib
+++ b/Resources/en.lproj/PBGitPrefsWindowController.xib
@@ -13,6 +13,7 @@
                 <outlet property="globalDiffOptsField" destination="124" id="153"/>
                 <outlet property="globalDiffToolField" destination="120" id="154"/>
                 <outlet property="globalErrorMessage" destination="142" id="155"/>
+                <outlet property="globalFetchPruneCheckbox" destination="188" id="190"/>
                 <outlet property="globalGpgSignCheckbox" destination="136" id="156"/>
                 <outlet property="globalMergeDiffstatCheckbox" destination="112" id="157"/>
                 <outlet property="globalMergeSummaryCheckbox" destination="104" id="158"/>
@@ -28,6 +29,7 @@
                 <outlet property="localDefaultBranchField" destination="62" id="168"/>
                 <outlet property="localDiffOptsField" destination="54" id="169"/>
                 <outlet property="localDiffToolField" destination="50" id="170"/>
+                <outlet property="localFetchPruneCheckbox" destination="184" id="191"/>
                 <outlet property="localGpgSignCheckbox" destination="66" id="171"/>
                 <outlet property="localMergeDiffstatCheckbox" destination="42" id="172"/>
                 <outlet property="localMergeSummaryCheckbox" destination="34" id="173"/>
@@ -44,11 +46,11 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application"/>
         <customView id="10">
-    <rect key="frame" x="0.0" y="0.0" width="520" height="491"/>
+    <rect key="frame" x="0.0" y="0.0" width="572" height="519"/>
     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
     <subviews>
         <textField verticalHuggingPriority="750" id="11">
-        <rect key="frame" x="20" y="455" width="190" height="17"/>
+        <rect key="frame" x="20" y="483" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="User Name:" id="12">
             <font key="font" metaFont="system"/>
@@ -57,7 +59,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="13">
-        <rect key="frame" x="220" y="453" width="280" height="22"/>
+        <rect key="frame" x="220" y="481" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="14">
             <font key="font" metaFont="system"/>
@@ -66,7 +68,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="15">
-        <rect key="frame" x="20" y="427" width="190" height="17"/>
+        <rect key="frame" x="20" y="455" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Email Address:" id="16">
             <font key="font" metaFont="system"/>
@@ -75,7 +77,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="17">
-        <rect key="frame" x="220" y="425" width="280" height="22"/>
+        <rect key="frame" x="220" y="453" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="18">
             <font key="font" metaFont="system"/>
@@ -84,7 +86,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="19">
-        <rect key="frame" x="20" y="399" width="190" height="17"/>
+        <rect key="frame" x="20" y="427" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Editor:" id="20">
             <font key="font" metaFont="system"/>
@@ -93,7 +95,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="21">
-        <rect key="frame" x="220" y="397" width="280" height="22"/>
+        <rect key="frame" x="220" y="425" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="22">
             <font key="font" metaFont="system"/>
@@ -102,7 +104,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="23">
-        <rect key="frame" x="20" y="371" width="190" height="17"/>
+        <rect key="frame" x="20" y="399" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Line Ending Conversion:" id="24">
             <font key="font" metaFont="system"/>
@@ -111,7 +113,7 @@
         </textFieldCell>
     </textField>
         <popUpButton verticalHuggingPriority="750" id="25">
-        <rect key="frame" x="220" y="369" width="150" height="22"/>
+        <rect key="frame" x="220" y="397" width="150" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <popUpButtonCell key="cell" type="push" title="(not set)" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="28" id="26">
             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -127,7 +129,7 @@
         </popUpButtonCell>
     </popUpButton>
         <textField verticalHuggingPriority="750" id="32">
-        <rect key="frame" x="20" y="343" width="190" height="17"/>
+        <rect key="frame" x="20" y="315" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Summarize Merge Commits:" id="33">
             <font key="font" metaFont="system"/>
@@ -136,7 +138,7 @@
         </textFieldCell>
     </textField>
         <button verticalHuggingPriority="750" id="34">
-        <rect key="frame" x="220" y="341" width="280" height="18"/>
+        <rect key="frame" x="220" y="313" width="332" height="18"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="35">
             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -144,7 +146,7 @@
         </buttonCell>
     </button>
         <textField verticalHuggingPriority="750" id="36">
-        <rect key="frame" x="20" y="315" width="190" height="17"/>
+        <rect key="frame" x="20" y="287" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Merge Verbosity:" id="37">
             <font key="font" metaFont="system"/>
@@ -153,7 +155,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="38">
-        <rect key="frame" x="220" y="313" width="280" height="22"/>
+        <rect key="frame" x="220" y="285" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="39">
             <font key="font" metaFont="system"/>
@@ -162,7 +164,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="40">
-        <rect key="frame" x="20" y="287" width="190" height="17"/>
+        <rect key="frame" x="20" y="259" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Show Diffstat After Merge:" id="41">
             <font key="font" metaFont="system"/>
@@ -171,7 +173,7 @@
         </textFieldCell>
     </textField>
         <button verticalHuggingPriority="750" id="42">
-        <rect key="frame" x="220" y="285" width="280" height="18"/>
+        <rect key="frame" x="220" y="257" width="332" height="18"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="43">
             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -179,7 +181,7 @@
         </buttonCell>
     </button>
         <textField verticalHuggingPriority="750" id="44">
-        <rect key="frame" x="20" y="259" width="190" height="17"/>
+        <rect key="frame" x="20" y="231" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Merge Tool:" id="45">
             <font key="font" metaFont="system"/>
@@ -188,7 +190,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="46">
-        <rect key="frame" x="220" y="257" width="280" height="22"/>
+        <rect key="frame" x="220" y="229" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="47">
             <font key="font" metaFont="system"/>
@@ -197,7 +199,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="48">
-        <rect key="frame" x="20" y="231" width="190" height="17"/>
+        <rect key="frame" x="20" y="203" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Diff Tool:" id="49">
             <font key="font" metaFont="system"/>
@@ -206,7 +208,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="50">
-        <rect key="frame" x="220" y="229" width="280" height="22"/>
+        <rect key="frame" x="220" y="201" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="51">
             <font key="font" metaFont="system"/>
@@ -215,7 +217,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="52">
-        <rect key="frame" x="20" y="203" width="190" height="17"/>
+        <rect key="frame" x="20" y="175" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Additional Diff Parameters:" id="53">
             <font key="font" metaFont="system"/>
@@ -224,7 +226,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="54">
-        <rect key="frame" x="220" y="201" width="280" height="22"/>
+        <rect key="frame" x="220" y="173" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="55">
             <font key="font" metaFont="system"/>
@@ -233,7 +235,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="56">
-        <rect key="frame" x="20" y="175" width="190" height="17"/>
+        <rect key="frame" x="20" y="371" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Rebase on Pull:" id="57">
             <font key="font" metaFont="system"/>
@@ -242,7 +244,7 @@
         </textFieldCell>
     </textField>
         <button verticalHuggingPriority="750" id="58">
-        <rect key="frame" x="220" y="173" width="280" height="18"/>
+        <rect key="frame" x="220" y="369" width="332" height="18"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="59">
             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -259,7 +261,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="62">
-        <rect key="frame" x="220" y="145" width="280" height="22"/>
+        <rect key="frame" x="220" y="145" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="63">
             <font key="font" metaFont="system"/>
@@ -277,7 +279,7 @@
         </textFieldCell>
     </textField>
         <button verticalHuggingPriority="750" id="66">
-        <rect key="frame" x="220" y="117" width="280" height="18"/>
+        <rect key="frame" x="220" y="117" width="332" height="18"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="67">
             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -294,7 +296,7 @@
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="70">
-        <rect key="frame" x="220" y="89" width="280" height="22"/>
+        <rect key="frame" x="220" y="89" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="71">
             <font key="font" metaFont="system"/>
@@ -302,8 +304,25 @@
             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
         </textFieldCell>
     </textField>
+        <textField verticalHuggingPriority="750" id="182">
+        <rect key="frame" x="20" y="343" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Prune on Fetch:" id="183">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <button verticalHuggingPriority="750" id="184">
+        <rect key="frame" x="220" y="341" width="332" height="18"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="185">
+            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+            <font key="font" metaFont="system"/>
+        </buttonCell>
+    </button>
         <textField verticalHuggingPriority="750" id="72">
-        <rect key="frame" x="20" y="56" width="480" height="17"/>
+        <rect key="frame" x="20" y="56" width="532" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="" id="73">
             <font key="font" metaFont="system"/>
@@ -312,7 +331,7 @@
         </textFieldCell>
     </textField>
         <button verticalHuggingPriority="750" id="74">
-        <rect key="frame" x="404" y="16" width="96" height="32"/>
+        <rect key="frame" x="456" y="16" width="96" height="32"/>
         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
         <buttonCell key="cell" type="push" title="Save" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="75">
             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -326,7 +345,7 @@ DQ
         </connections>
     </button>
         <button verticalHuggingPriority="750" id="77">
-        <rect key="frame" x="300" y="16" width="96" height="32"/>
+        <rect key="frame" x="352" y="16" width="96" height="32"/>
         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
         <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="78">
             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -342,11 +361,11 @@ Gw
     </subviews>
 </customView>
         <customView id="80">
-    <rect key="frame" x="0.0" y="0.0" width="520" height="491"/>
+    <rect key="frame" x="0.0" y="0.0" width="572" height="519"/>
     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
     <subviews>
         <textField verticalHuggingPriority="750" id="81">
-        <rect key="frame" x="20" y="455" width="190" height="17"/>
+        <rect key="frame" x="20" y="483" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="User Name:" id="82">
             <font key="font" metaFont="system"/>
@@ -355,7 +374,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="83">
-        <rect key="frame" x="220" y="453" width="280" height="22"/>
+        <rect key="frame" x="220" y="481" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="84">
             <font key="font" metaFont="system"/>
@@ -364,7 +383,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="85">
-        <rect key="frame" x="20" y="427" width="190" height="17"/>
+        <rect key="frame" x="20" y="455" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Email Address:" id="86">
             <font key="font" metaFont="system"/>
@@ -373,7 +392,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="87">
-        <rect key="frame" x="220" y="425" width="280" height="22"/>
+        <rect key="frame" x="220" y="453" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="88">
             <font key="font" metaFont="system"/>
@@ -382,7 +401,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="89">
-        <rect key="frame" x="20" y="399" width="190" height="17"/>
+        <rect key="frame" x="20" y="427" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Editor:" id="90">
             <font key="font" metaFont="system"/>
@@ -391,7 +410,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="91">
-        <rect key="frame" x="220" y="397" width="280" height="22"/>
+        <rect key="frame" x="220" y="425" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="92">
             <font key="font" metaFont="system"/>
@@ -400,7 +419,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="93">
-        <rect key="frame" x="20" y="371" width="190" height="17"/>
+        <rect key="frame" x="20" y="399" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Line Ending Conversion:" id="94">
             <font key="font" metaFont="system"/>
@@ -409,7 +428,7 @@ Gw
         </textFieldCell>
     </textField>
         <popUpButton verticalHuggingPriority="750" id="95">
-        <rect key="frame" x="220" y="369" width="150" height="22"/>
+        <rect key="frame" x="220" y="397" width="150" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <popUpButtonCell key="cell" type="push" title="(not set)" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="98" id="96">
             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -425,7 +444,7 @@ Gw
         </popUpButtonCell>
     </popUpButton>
         <textField verticalHuggingPriority="750" id="102">
-        <rect key="frame" x="20" y="343" width="190" height="17"/>
+        <rect key="frame" x="20" y="315" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Summarize Merge Commits:" id="103">
             <font key="font" metaFont="system"/>
@@ -434,7 +453,7 @@ Gw
         </textFieldCell>
     </textField>
         <button verticalHuggingPriority="750" id="104">
-        <rect key="frame" x="220" y="341" width="280" height="18"/>
+        <rect key="frame" x="220" y="313" width="332" height="18"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="105">
             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -442,7 +461,7 @@ Gw
         </buttonCell>
     </button>
         <textField verticalHuggingPriority="750" id="106">
-        <rect key="frame" x="20" y="315" width="190" height="17"/>
+        <rect key="frame" x="20" y="287" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Merge Verbosity:" id="107">
             <font key="font" metaFont="system"/>
@@ -451,7 +470,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="108">
-        <rect key="frame" x="220" y="313" width="280" height="22"/>
+        <rect key="frame" x="220" y="285" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="109">
             <font key="font" metaFont="system"/>
@@ -460,7 +479,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="110">
-        <rect key="frame" x="20" y="287" width="190" height="17"/>
+        <rect key="frame" x="20" y="259" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Show Diffstat After Merge:" id="111">
             <font key="font" metaFont="system"/>
@@ -469,7 +488,7 @@ Gw
         </textFieldCell>
     </textField>
         <button verticalHuggingPriority="750" id="112">
-        <rect key="frame" x="220" y="285" width="280" height="18"/>
+        <rect key="frame" x="220" y="257" width="332" height="18"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="113">
             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -477,7 +496,7 @@ Gw
         </buttonCell>
     </button>
         <textField verticalHuggingPriority="750" id="114">
-        <rect key="frame" x="20" y="259" width="190" height="17"/>
+        <rect key="frame" x="20" y="231" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Merge Tool:" id="115">
             <font key="font" metaFont="system"/>
@@ -486,7 +505,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="116">
-        <rect key="frame" x="220" y="257" width="280" height="22"/>
+        <rect key="frame" x="220" y="229" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="117">
             <font key="font" metaFont="system"/>
@@ -495,7 +514,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="118">
-        <rect key="frame" x="20" y="231" width="190" height="17"/>
+        <rect key="frame" x="20" y="203" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Diff Tool:" id="119">
             <font key="font" metaFont="system"/>
@@ -504,7 +523,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="120">
-        <rect key="frame" x="220" y="229" width="280" height="22"/>
+        <rect key="frame" x="220" y="201" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="121">
             <font key="font" metaFont="system"/>
@@ -513,7 +532,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="122">
-        <rect key="frame" x="20" y="203" width="190" height="17"/>
+        <rect key="frame" x="20" y="175" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Additional Diff Parameters:" id="123">
             <font key="font" metaFont="system"/>
@@ -522,7 +541,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="124">
-        <rect key="frame" x="220" y="201" width="280" height="22"/>
+        <rect key="frame" x="220" y="173" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="125">
             <font key="font" metaFont="system"/>
@@ -531,7 +550,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="126">
-        <rect key="frame" x="20" y="175" width="190" height="17"/>
+        <rect key="frame" x="20" y="371" width="190" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Rebase on Pull:" id="127">
             <font key="font" metaFont="system"/>
@@ -540,7 +559,7 @@ Gw
         </textFieldCell>
     </textField>
         <button verticalHuggingPriority="750" id="128">
-        <rect key="frame" x="220" y="173" width="280" height="18"/>
+        <rect key="frame" x="220" y="369" width="332" height="18"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="129">
             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -557,7 +576,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="132">
-        <rect key="frame" x="220" y="145" width="280" height="22"/>
+        <rect key="frame" x="220" y="145" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="133">
             <font key="font" metaFont="system"/>
@@ -575,7 +594,7 @@ Gw
         </textFieldCell>
     </textField>
         <button verticalHuggingPriority="750" id="136">
-        <rect key="frame" x="220" y="117" width="280" height="18"/>
+        <rect key="frame" x="220" y="117" width="332" height="18"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="137">
             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -592,7 +611,7 @@ Gw
         </textFieldCell>
     </textField>
         <textField verticalHuggingPriority="750" id="140">
-        <rect key="frame" x="220" y="89" width="280" height="22"/>
+        <rect key="frame" x="220" y="89" width="332" height="22"/>
         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="141">
             <font key="font" metaFont="system"/>
@@ -600,8 +619,25 @@ Gw
             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
         </textFieldCell>
     </textField>
+        <textField verticalHuggingPriority="750" id="186">
+        <rect key="frame" x="20" y="343" width="190" height="17"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Prune on Fetch:" id="187">
+            <font key="font" metaFont="system"/>
+            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+        </textFieldCell>
+    </textField>
+        <button verticalHuggingPriority="750" id="188">
+        <rect key="frame" x="220" y="341" width="332" height="18"/>
+        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <buttonCell key="cell" type="check" title="" bezelStyle="regularSquare" imagePosition="left" alignment="left" allowsMixedState="YES" inset="2" id="189">
+            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+            <font key="font" metaFont="system"/>
+        </buttonCell>
+    </button>
         <textField verticalHuggingPriority="750" id="142">
-        <rect key="frame" x="20" y="56" width="480" height="17"/>
+        <rect key="frame" x="20" y="56" width="532" height="17"/>
         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="" id="143">
             <font key="font" metaFont="system"/>
@@ -610,7 +646,7 @@ Gw
         </textFieldCell>
     </textField>
         <button verticalHuggingPriority="750" id="144">
-        <rect key="frame" x="404" y="16" width="96" height="32"/>
+        <rect key="frame" x="456" y="16" width="96" height="32"/>
         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
         <buttonCell key="cell" type="push" title="Save" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="145">
             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -624,7 +660,7 @@ DQ
         </connections>
     </button>
         <button verticalHuggingPriority="750" id="147">
-        <rect key="frame" x="300" y="16" width="96" height="32"/>
+        <rect key="frame" x="352" y="16" width="96" height="32"/>
         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
         <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="148">
             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>

--- a/Resources/en.lproj/Preferences.xib
+++ b/Resources/en.lproj/Preferences.xib
@@ -18,11 +18,38 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="1" userLabel="General">
-            <rect key="frame" x="0.0" y="0.0" width="500" height="250"/>
+            <rect key="frame" x="0.0" y="0.0" width="500" height="276"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="164">
+                    <rect key="frame" x="103" y="119" width="110" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Prune on fetch:" id="165">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="166">
+                    <rect key="frame" x="217" y="116" width="195" height="22"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <popUpButtonCell key="cell" type="push" title="Use git config (fetch.prune)" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="169" id="167">
+                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="smallSystem"/>
+                        <menu key="menu" title="OtherViews" id="168">
+                            <items>
+                                <menuItem title="Use git config (fetch.prune)" state="on" tag="0" id="169"/>
+                                <menuItem title="Always prune" tag="1" id="170"/>
+                                <menuItem title="Never prune" tag="2" id="171"/>
+                            </items>
+                        </menu>
+                    </popUpButtonCell>
+                    <connections>
+                        <binding destination="28" name="selectedTag" keyPath="values.PBPruneOnFetch" id="172"/>
+                    </connections>
+                </popUpButton>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="114">
-                    <rect key="frame" x="103" y="191" width="273" height="18"/>
+                    <rect key="frame" x="103" y="217" width="273" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show whitespace differences" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="115">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -33,7 +60,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="153">
-                    <rect key="frame" x="103" y="213" width="273" height="18"/>
+                    <rect key="frame" x="103" y="239" width="273" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Watch for changes in repositories" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="154">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -44,7 +71,7 @@
                     </connections>
                 </button>
                 <button toolTip="Reset to 'No executable set'" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="77">
-                    <rect key="frame" x="378" y="91" width="16" height="16"/>
+                    <rect key="frame" x="416" y="91" width="16" height="16"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="bevel" bezelStyle="regularSquare" image="NSStopProgressFreestandingTemplate" imagePosition="left" alignment="left" alternateImage="NSStopProgressFreestandingTemplate" state="on" imageScaling="proportionallyDown" inset="2" id="78">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -71,7 +98,7 @@ or drag it from the Finder.</string>
                     </textFieldCell>
                 </textField>
                 <pathControl focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="45">
-                    <rect key="frame" x="195" y="88" width="179" height="22"/>
+                    <rect key="frame" x="217" y="88" width="195" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <pathCell key="cell" controlSize="small" selectable="YES" editable="YES" focusRingType="none" alignment="left" pathStyle="popUp" id="46">
                         <font key="font" metaFont="smallSystem"/>
@@ -101,7 +128,7 @@ or drag it from the Finder.</string>
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="126">
-                    <rect key="frame" x="103" y="169" width="279" height="18"/>
+                    <rect key="frame" x="103" y="195" width="279" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show column guides in commit message" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="127">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -112,7 +139,7 @@ or drag it from the Finder.</string>
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="128">
-                    <rect key="frame" x="124" y="145" width="196" height="17"/>
+                    <rect key="frame" x="124" y="171" width="196" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Display body guide at column:" id="129">
                         <font key="font" metaFont="system"/>
@@ -121,7 +148,7 @@ or drag it from the Finder.</string>
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="130">
-                    <rect key="frame" x="337" y="142" width="41" height="22"/>
+                    <rect key="frame" x="337" y="168" width="41" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="131">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" formatWidth="-1" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="Sk0-yU-eAV"/>
@@ -138,7 +165,7 @@ or drag it from the Finder.</string>
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oHn-U1-E1H">
-                    <rect key="frame" x="376" y="139" width="19" height="28"/>
+                    <rect key="frame" x="376" y="165" width="19" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" maxValue="200" id="7mM-Lr-k9g"/>
                     <connections>
@@ -146,7 +173,7 @@ or drag it from the Finder.</string>
                     </connections>
                 </stepper>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="145">
-                    <rect key="frame" x="124" y="119" width="211" height="17"/>
+                    <rect key="frame" x="124" y="145" width="211" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Display subject guide at column:" id="148">
                         <font key="font" metaFont="system"/>
@@ -155,7 +182,7 @@ or drag it from the Finder.</string>
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="146">
-                    <rect key="frame" x="337" y="116" width="41" height="22"/>
+                    <rect key="frame" x="337" y="142" width="41" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="147">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" formatWidth="-1" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="Rih-TW-mKW"/>
@@ -172,7 +199,7 @@ or drag it from the Finder.</string>
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8S8-EY-tZ9">
-                    <rect key="frame" x="376" y="113" width="19" height="28"/>
+                    <rect key="frame" x="376" y="139" width="19" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" maxValue="200" id="MFg-eF-42q"/>
                     <connections>


### PR DESCRIPTION
Deleting a branch under a remote in the sidebar did nothing at all, and separately, branches deleted upstream never disappeared from the sidebar.

## The delete bug

`-deleteRef:` filtered the sender's ref through `refishForSender:refishTypes:` with `@[branch, remote, tag]`. A ref under a remote reports `kGitXRemoteBranchType`, which was not in that list, so the method returned before ever reaching git: no confirmation dialog, no error, nothing logged. The remote node itself is `kGitXRemoteType`, which is why "Delete origin..." worked and made the failure look inconsistent rather than total.

Remote branches now run `git push <remote> --delete <branch>` through the same progress sheet as push and pull. The routing in `PBGitRepository -deleteRef:` checks for a remote branch *before* the remote check, because `isRemote` is true both for `refs/remotes/origin` and for `refs/remotes/origin/branch`; without that ordering a branch delete would have removed the entire remote.

Because this now deletes on the server, the confirmation passes a `nil` suppression identifier. `-confirmDialog:suppressionIdentifier:forAction:` skips the dialog outright once an identifier has been suppressed, so sharing `"Delete Ref"` with local deletes would have let anyone who ticked "do not show again" trigger silent server-side deletes. Both delete alerts also default to Cancel now, with Delete marked destructive.

## The stale refs

GitX ran `git fetch <remote>` with no `--prune`, and nothing in the codebase pruned. Since GitX shells out to plain git with no `-c` overrides, `fetch.prune` already worked; it simply had no UI. Two layers now:

- `fetch.prune` is a row in the Git Preferences dialog, repository and global, tri-state like the other booleans there.
- A General preference chooses "Use git config (fetch.prune)" (the default), "Always prune", or "Never prune", passing `--prune` / `--no-prune` / nothing. The default keeps the git config setting authoritative.

## Git Preferences dialog, while we were in there

- The panes are 10% wider, so a long project name no longer pushes the toolbar items off the edge, and the project name in the pane label is capped at 25 characters.
- Following git-gui, which titles the dialog "… Preferences" and names only the scope per section, the pane labels are now `<repo> Prefs.` and `Global Prefs.`. This window has no room for a title of its own, so the labels carry both.
- Both panes share the plain text document icon, matching the full colour style of the App Settings toolbar.
- `Rebase on Pull` and `Prune on Fetch` sit together, just above `Summarize Merge Commits`.

## Test plan

- Against a scratch remote, verified the exact commands: `git push origin --delete <branch>` removes the branch upstream and drops the local tracking ref on its own; a plain fetch leaves a stale ref, `--prune` removes it, `fetch.prune=true` prunes on a plain fetch, and `--no-prune` keeps the stale ref even with `fetch.prune=true`.
- Both xibs compile with no new ibtool diagnostics, checked by diffing notices against the base.
- Each commit builds independently.
- Not yet verified on screen: the two new preference panes and the delete dialogs. Worth a look when running, particularly the General pane and the two Git Preferences panes, which grew by 28pt.

## Keyboard focus in the preference windows

Found while reviewing the panes above, and shared by both preference windows since they are both built on `DBPrefsWindowController`.

- **App Settings ignored the keyboard until it was clicked.** The panel does become key, but nothing inside it did: `initialFirstResponder` was set to the pane's container view, which never accepts focus, so Tab went to the window and stopped. Git Preferences escaped this by luck of geometry, its first control being a plain text field. Fixed by recalculating the key view loop once the pane is in the hierarchy and starting it at the first control that actually takes focus. This also means that after switching panes, Tab continues into the pane on display instead of restarting at the first toolbar item.
- **The wrong tab stayed drawn as selected.** `setSelectedItemIdentifier:` was only called when the window opened. AppKit moves the selection itself when an item is clicked, but not when it is activated from the keyboard, so the previously selected tab kept its selected styling while a different pane was displayed. The selection is now set wherever a pane is displayed, which covers every route in.

The focus ring is still dropped on every pane swap, unchanged from before. Return is deliberately left alone; note that in Git Preferences it triggers Save and closes the dialog, since Save carries the Return key equivalent.

Measured by driving the app from the keyboard, before and after:

| | before | after |
|---|---|---|
| App Settings, first Tab | window, never moves | first checkbox |
| Space on a focused tab | pane switches | pane switches, selection follows it |
| Tab after switching panes | first toolbar item | first control of the pane on display |
