### PR TITLE
Add Fetch and Prune menu items

### DIFF
--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -1041,6 +1041,10 @@
 	NSString *fetchTitle = hasRemote ? [NSString stringWithFormat:NSLocalizedString(@"Fetch “%@”", @"Contextual Menu Item to fetch the selected remote"), remoteName] : NSLocalizedString(@"Fetch", @"Inactive Contextual Menu Item for fetching");
 	[items addObject:[NSMenuItem pb_itemWithTitle:fetchTitle action:@selector(fetchRemote:) enabled:hasRemote]];
 
+	// fetch and prune
+	NSString *fetchPruneTitle = hasRemote ? [NSString stringWithFormat:NSLocalizedString(@"Fetch “%@” and Prune", @"Contextual Menu Item to fetch the selected remote and prune deleted remote branches"), remoteName] : NSLocalizedString(@"Fetch and Prune", @"Inactive Contextual Menu Item for fetching with prune");
+	[items addObject:[NSMenuItem pb_itemWithTitle:fetchPruneTitle action:@selector(fetchRemoteAndPrune:) enabled:hasRemote]];
+
 	// pull
 	NSString *pullTitle = hasRemote ? [NSString stringWithFormat:NSLocalizedString(@"Pull “%@” and Update “%@”", @"Contextual Menu Item to pull the remote and update the selected branch"), remoteName, headRefName] : NSLocalizedString(@"Pull", @"Inactive Contextual Menu Item for pulling");
 	[items addObject:[NSMenuItem pb_itemWithTitle:pullTitle action:@selector(pullRemote:) enabled:hasRemote]];

--- a/Classes/Controllers/PBGitWindowController.h
+++ b/Classes/Controllers/PBGitWindowController.h
@@ -65,7 +65,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (IBAction)showAddRemoteSheet:(id)sender GITX_DEPRECATED;
 - (IBAction)addRemote:(id)sender;
 - (IBAction)fetchRemote:(id)sender;
+- (IBAction)fetchRemoteAndPrune:(id)sender;
 - (IBAction)fetchAllRemotes:(id)sender;
+- (IBAction)fetchAllRemotesAndPrune:(id)sender;
 
 - (IBAction)pullRemote:(id)sender;
 - (IBAction)pullRebaseRemote:(id)sender;
@@ -89,6 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setHistorySearch:(NSString *)searchString mode:(PBHistorySearchMode)mode;
 
 - (void)performFetchForRef:(nullable PBGitRef *)ref;
+- (void)performFetchForRef:(nullable PBGitRef *)ref forcePrune:(BOOL)forcePrune;
 - (void)performPullForBranch:(PBGitRef *)branchRef remote:(nullable PBGitRef *)remoteRef rebase:(BOOL)rebase;
 - (void)performPushForBranch:(nullable PBGitRef *)branchRef toRemote:(nullable PBGitRef *)remoteRef;
 

--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -585,7 +585,7 @@
 
 - (IBAction)fetchRemote:(id)sender
 {
-	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXBranchType, kGitXRemoteType ]];
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXBranchType, kGitXRemoteBranchType, kGitXRemoteType ]];
 	if (!refish || ![refish isKindOfClass:[PBGitRef class]])
 		return;
 

--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -96,6 +96,8 @@
 		return ![self.repository isBareRepository];
 	} else if (menuItem.action == @selector(fetchRemote:)) {
 		return [self validateMenuItem:menuItem remoteTitle:@"Fetch “%@”" plainTitle:@"Fetch"];
+	} else if (menuItem.action == @selector(fetchRemoteAndPrune:)) {
+		return [self validateMenuItem:menuItem remoteTitle:@"Fetch “%@” and Prune" plainTitle:@"Fetch and Prune"];
 	} else if (menuItem.action == @selector(pullRemote:)) {
 		return [self validateMenuItem:menuItem remoteTitle:@"Pull From “%@”" plainTitle:@"Pull"];
 	} else if (menuItem.action == @selector(pullRebaseRemote:)) {
@@ -282,6 +284,11 @@
 
 - (void)performFetchForRef:(PBGitRef *)ref
 {
+	[self performFetchForRef:ref forcePrune:NO];
+}
+
+- (void)performFetchForRef:(PBGitRef *)ref forcePrune:(BOOL)forcePrune
+{
 	NSString *desc = nil;
 	if (ref == nil) {
 		desc = [NSString stringWithFormat:@"Fetching all remotes"];
@@ -289,6 +296,9 @@
 		desc = [NSString stringWithFormat:@"Fetching branches from remote %@", ref.remoteName];
 	} else {
 		desc = [NSString stringWithFormat:@"Fetching tracking branch for %@", ref.shortName];
+	}
+	if (forcePrune) {
+		desc = [desc stringByAppendingString:@", pruning deleted branches"];
 	}
 
 	PBRemoteProgressSheet *progressSheet = [PBRemoteProgressSheet progressSheetWithTitle:@"Fetching remote…"
@@ -298,7 +308,7 @@
 	[progressSheet
 		beginProgressSheetForBlock:^{
 			NSError *error = nil;
-			BOOL success = [self.repository fetchRemoteForRef:ref error:&error];
+			BOOL success = [self.repository fetchRemoteForRef:ref forcePrune:forcePrune error:&error];
 			return (success ? nil : error);
 		}
 		completionHandler:^(NSError *error) {
@@ -592,9 +602,23 @@
 	[self performFetchForRef:refish];
 }
 
+- (IBAction)fetchRemoteAndPrune:(id)sender
+{
+	id<PBGitRefish> refish = [self refishForSender:sender refishTypes:@[ kGitXBranchType, kGitXRemoteBranchType, kGitXRemoteType ]];
+	if (!refish || ![refish isKindOfClass:[PBGitRef class]])
+		return;
+
+	[self performFetchForRef:refish forcePrune:YES];
+}
+
 - (IBAction)fetchAllRemotes:(id)sender
 {
 	[self performFetchForRef:nil];
+}
+
+- (IBAction)fetchAllRemotesAndPrune:(id)sender
+{
+	[self performFetchForRef:nil forcePrune:YES];
 }
 
 - (IBAction)pullRemote:(id)sender

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -66,6 +66,7 @@ typedef NS_ENUM(NSInteger, PBGitConfigScope) {
 
 - (BOOL)addRemote:(NSString *)remoteName withURL:(NSString *)URLString error:(NSError **)error;
 - (BOOL)fetchRemoteForRef:(PBGitRef *)ref error:(NSError **)error;
+- (BOOL)fetchRemoteForRef:(PBGitRef *)ref forcePrune:(BOOL)forcePrune error:(NSError **)error;
 - (BOOL)pullBranch:(PBGitRef *)branchRef fromRemote:(PBGitRef *)remoteRef rebase:(BOOL)rebase error:(NSError **)error;
 - (BOOL)pushBranch:(PBGitRef *)branchRef toRemote:(PBGitRef *)remoteRef error:(NSError **)error;
 

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -767,7 +767,35 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 	return [task launchTask:error];
 }
 
++ (NSArray<NSString *> *)fetchArgumentsForTarget:(NSString *)fetchArg forcePrune:(BOOL)forcePrune
+{
+	NSMutableArray *arguments = [NSMutableArray arrayWithObject:@"fetch"];
+	if (forcePrune) {
+		[arguments addObject:@"--prune"];
+	} else {
+		switch ([PBGitDefaults pruneOnFetch]) {
+			case PBPruneOnFetchAlways:
+				[arguments addObject:@"--prune"];
+				break;
+			case PBPruneOnFetchNever:
+				[arguments addObject:@"--no-prune"];
+				break;
+			case PBPruneOnFetchUseGitConfig:
+				// Leave it to git, so fetch.prune and remote.<name>.prune decide.
+				break;
+		}
+	}
+	[arguments addObject:fetchArg];
+
+	return arguments;
+}
+
 - (BOOL)fetchRemoteForRef:(PBGitRef *)ref error:(NSError **)error
+{
+	return [self fetchRemoteForRef:ref forcePrune:NO error:error];
+}
+
+- (BOOL)fetchRemoteForRef:(PBGitRef *)ref forcePrune:(BOOL)forcePrune error:(NSError **)error
 {
 	NSString *fetchArg = nil;
 	if (ref == nil) {
@@ -780,19 +808,7 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 		fetchArg = ref.remoteName;
 	}
 
-	NSMutableArray *arguments = [NSMutableArray arrayWithObject:@"fetch"];
-	switch ([PBGitDefaults pruneOnFetch]) {
-		case PBPruneOnFetchAlways:
-			[arguments addObject:@"--prune"];
-			break;
-		case PBPruneOnFetchNever:
-			[arguments addObject:@"--no-prune"];
-			break;
-		case PBPruneOnFetchUseGitConfig:
-			// Leave it to git, so fetch.prune and remote.<name>.prune decide.
-			break;
-	}
-	[arguments addObject:fetchArg];
+	NSArray *arguments = [[self class] fetchArgumentsForTarget:fetchArg forcePrune:forcePrune];
 
 	PBTask *task = [self taskWithArguments:arguments];
 	NSError *taskError = nil;

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		50DCC65A20111E4000999D3D /* PBGitRevisionRow.m in Sources */ = {isa = PBXBuildFile; fileRef = 50DCC65920111E4000999D3D /* PBGitRevisionRow.m */; };
 		551BF176112F3F4B00265053 /* gitx_askpasswd in Resources */ = {isa = PBXBuildFile; fileRef = 551BF111112F371800265053 /* gitx_askpasswd */; };
 		63E155858B2CC783EE10F1D7 /* PBGitRevListRaceConditionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0044 /* PBGitRevListRaceConditionTests.m */; };
+		7A1C4E2B90D3F5A6C1B80011 /* PBGitRepositoryFetchArgumentsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */; };
 		643952771603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 643952761603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m */; };
 		6C25810B1C2720E60080A89A /* GitXCommitCopier.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C25810A1C2720E60080A89A /* GitXCommitCopier.m */; };
 		6C4855C81D57DCFC0027A7B4 /* PBTerminalUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C4855C71D57DCFC0027A7B4 /* PBTerminalUtil.m */; };
@@ -683,6 +684,7 @@
 		643952751603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBSourceViewGitSubmoduleItem.h; sourceTree = "<group>"; };
 		643952761603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBSourceViewGitSubmoduleItem.m; sourceTree = "<group>"; };
 		689D57B4A78CEF3B32EB0044 /* PBGitRevListRaceConditionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitRevListRaceConditionTests.m; path = GitXTests/PBGitRevListRaceConditionTests.m; sourceTree = "<group>"; };
+		7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitRepositoryFetchArgumentsTests.m; path = GitXTests/PBGitRepositoryFetchArgumentsTests.m; sourceTree = "<group>"; };
 		6C2581091C2720E60080A89A /* GitXCommitCopier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitXCommitCopier.h; sourceTree = "<group>"; };
 		6C25810A1C2720E60080A89A /* GitXCommitCopier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXCommitCopier.m; sourceTree = "<group>"; };
 		6C4855C61D57DCFC0027A7B4 /* PBTerminalUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBTerminalUtil.h; sourceTree = "<group>"; };
@@ -799,6 +801,7 @@
 			isa = PBXGroup;
 			children = (
 				689D57B4A78CEF3B32EB0044 /* PBGitRevListRaceConditionTests.m */,
+				7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */,
 			);
 			name = GitXTests;
 			sourceTree = "<group>";
@@ -1731,6 +1734,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				63E155858B2CC783EE10F1D7 /* PBGitRevListRaceConditionTests.m in Sources */,
+				7A1C4E2B90D3F5A6C1B80011 /* PBGitRepositoryFetchArgumentsTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2209,6 +2213,9 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "-";
+				FRAMEWORK_SEARCH_PATHS = "\"$(PROJECT_DIR)\"";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = Resources/GitX_Prefix.pch;
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2288,6 +2295,9 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "-";
+				FRAMEWORK_SEARCH_PATHS = "\"$(PROJECT_DIR)\"";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = Resources/GitX_Prefix.pch;
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",

--- a/GitXTests/PBGitRepositoryFetchArgumentsTests.m
+++ b/GitXTests/PBGitRepositoryFetchArgumentsTests.m
@@ -1,0 +1,71 @@
+//
+//  PBGitRepositoryFetchArgumentsTests.m
+//  GitXTests
+//
+
+#import <XCTest/XCTest.h>
+#import "PBGitRepository.h"
+#import "PBGitDefaults.h"
+
+// Exposes the argument builder shared by both fetch entry points, so the
+// preference/override matrix can be checked without launching git.
+@interface PBGitRepository (FetchArgumentsTesting)
++ (NSArray<NSString *> *)fetchArgumentsForTarget:(NSString *)fetchArg forcePrune:(BOOL)forcePrune;
+@end
+
+@interface PBGitRepositoryFetchArgumentsTests : XCTestCase
+@end
+
+@implementation PBGitRepositoryFetchArgumentsTests
+
+- (void)setPruneOnFetchSetting:(PBPruneOnFetchSetting)setting
+{
+	[[NSUserDefaults standardUserDefaults] setInteger:setting forKey:@"PBPruneOnFetch"];
+	XCTAssertEqual([PBGitDefaults pruneOnFetch], setting);
+}
+
+- (void)tearDown
+{
+	[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"PBPruneOnFetch"];
+	[super tearDown];
+}
+
+// Without an explicit override the preference alone decides, as it has since
+// prune-on-fetch was introduced.
+- (void)testPreferenceDecidesWhenPruneIsNotForced
+{
+	[self setPruneOnFetchSetting:PBPruneOnFetchUseGitConfig];
+	XCTAssertEqualObjects([PBGitRepository fetchArgumentsForTarget:@"origin" forcePrune:NO], (@[ @"fetch", @"origin" ]));
+
+	[self setPruneOnFetchSetting:PBPruneOnFetchAlways];
+	XCTAssertEqualObjects([PBGitRepository fetchArgumentsForTarget:@"origin" forcePrune:NO], (@[ @"fetch", @"--prune", @"origin" ]));
+
+	[self setPruneOnFetchSetting:PBPruneOnFetchNever];
+	XCTAssertEqualObjects([PBGitRepository fetchArgumentsForTarget:@"origin" forcePrune:NO], (@[ @"fetch", @"--no-prune", @"origin" ]));
+}
+
+// The "Fetch … and Prune" menu items are an explicit user action, so they must
+// prune in every preference state - including "Never prune".
+- (void)testForcedPruneOverridesEveryPreferenceState
+{
+	NSArray *expected = @[ @"fetch", @"--prune", @"origin" ];
+
+	[self setPruneOnFetchSetting:PBPruneOnFetchUseGitConfig];
+	XCTAssertEqualObjects([PBGitRepository fetchArgumentsForTarget:@"origin" forcePrune:YES], expected);
+
+	[self setPruneOnFetchSetting:PBPruneOnFetchAlways];
+	XCTAssertEqualObjects([PBGitRepository fetchArgumentsForTarget:@"origin" forcePrune:YES], expected);
+
+	[self setPruneOnFetchSetting:PBPruneOnFetchNever];
+	XCTAssertEqualObjects([PBGitRepository fetchArgumentsForTarget:@"origin" forcePrune:YES], expected);
+}
+
+// git rejects flags placed after the remote, so the ordering is load-bearing.
+- (void)testFlagPrecedesTheFetchTarget
+{
+	[self setPruneOnFetchSetting:PBPruneOnFetchNever];
+	XCTAssertEqualObjects([PBGitRepository fetchArgumentsForTarget:@"--all" forcePrune:YES], (@[ @"fetch", @"--prune", @"--all" ]));
+	XCTAssertEqualObjects([PBGitRepository fetchArgumentsForTarget:@"--all" forcePrune:NO], (@[ @"fetch", @"--no-prune", @"--all" ]));
+}
+
+@end

--- a/Resources/en.lproj/MainMenu.xib
+++ b/Resources/en.lproj/MainMenu.xib
@@ -402,10 +402,22 @@
                                     <action selector="fetchRemote:" target="-1" id="zxl-J9-UiW"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Fetch and Prune" id="Pr1-Fe-tch">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="fetchRemoteAndPrune:" target="-1" id="Pr2-Fe-tch"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Fetch All" id="OAK-L4-wE7">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="fetchAllRemotes:" target="-1" id="gQf-4H-0cg"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Fetch All and Prune" id="Pr3-Fe-tch">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="fetchAllRemotesAndPrune:" target="-1" id="Pr4-Fe-tch"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="CDX-1D-7tK"/>


### PR DESCRIPTION
Expose prune as a command of its own, so a one-off prune no longer means
flipping the global "Prune on fetch" preference back and forth.

- Offer `Fetch "origin" and Prune` in the ref context menus, right after
  the plain fetch item, and add `Fetch and Prune` plus `Fetch All and
  Prune` to the Repository menu.
- Thread a force-prune override down to the fetch task. An explicit
  invocation passes `--prune` in every preference state, including
  "Never prune", since a deliberate action should beat a default.
- Fix a pre-existing silent no-op first, in its own commit: the fetch
  action rejected remote-branch refs, so an enabled `Fetch "origin"` on
  a remote branch did nothing at all - no fetch, no sheet, no error.

Test plan:

- New GitXTests cover the fetch argument matrix: the preference alone
  decides without the override, the override wins in all three
  preference states, and the flag precedes the remote name.
- Repository menu checked through accessibility on a Debug build:
  `Fetch`, `Fetch and Prune`, `Fetch All`, `Fetch All and Prune`, in
  that order, with the new nib connections in place.
- Not verified locally: the retitled `Fetch "origin" and Prune` with a
  live sidebar selection, and an end-to-end prune dropping a stale
  remote branch. GitX windows are not reachable by accessibility on
  this machine.
