### PR TITLE
Add tests for the index refresh and staging wiring

### DIFF
--- a/Classes/git/PBGitIndex.m
+++ b/Classes/git/PBGitIndex.m
@@ -155,26 +155,43 @@ NS_ENUM(NSUInteger, PBGitIndexOperation){
 	});
 }
 
-- (void)refresh
+// Guard against concurrent refresh calls — remember the request and re-run it
+// once the in-flight refresh finishes, so that the last event of a burst is
+// never the one that gets dropped
+- (BOOL)beginRefreshOrDeferIt
 {
-	//
-	// Guard against concurrent refresh calls — remember the request and re-run
-	// once the in-flight refresh finishes, so that the last event of a burst is
-	// never the one that gets dropped
-	__block BOOL shouldSkip = NO;
+	__block BOOL mayRefresh = NO;
 	dispatch_sync(_indexRefreshQueue, ^{
 		if (self->_refreshInProgress) {
 			self->_refreshPending = YES;
-			shouldSkip = YES;
 			return;
 		}
 		self->_refreshInProgress = YES;
 		self->_refreshPending = NO;
+		mayRefresh = YES;
 	});
 
-	if (shouldSkip) {
+	return mayRefresh;
+}
+
+// Read and clear the deferred request together with the in-progress flag, so a
+// request arriving as the refresh ends cannot be lost between the two
+- (BOOL)endRefreshTakingDeferred
+{
+	__block BOOL refreshAgain = NO;
+	dispatch_sync(_indexRefreshQueue, ^{
+		self->_refreshInProgress = NO;
+		refreshAgain = self->_refreshPending;
+		self->_refreshPending = NO;
+	});
+
+	return refreshAgain;
+}
+
+- (void)refresh
+{
+	if (![self beginRefreshOrDeferIt])
 		return;
-	}
 
 	_stagedChanges = nil;
 	_unstagedChanges = nil;
@@ -202,12 +219,7 @@ NS_ENUM(NSUInteger, PBGitIndexOperation){
 		// this is the earliest an observer can be told the index changed
 		[self postIndexUpdated];
 
-		__block BOOL refreshAgain = NO;
-		dispatch_sync(self->_indexRefreshQueue, ^{
-			self->_refreshInProgress = NO;
-			refreshAgain = self->_refreshPending;
-			self->_refreshPending = NO;
-		});
+		BOOL refreshAgain = [self endRefreshTakingDeferred];
 
 		[self postIndexRefreshFinished];
 

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		63E155858B2CC783EE10F1D7 /* PBGitRevListRaceConditionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0044 /* PBGitRevListRaceConditionTests.m */; };
 		7A1C4E2B90D3F5A6C1B80011 /* PBGitRepositoryFetchArgumentsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */; };
 		63E155858B2CC783EE10F1D8 /* PBGitIndexReconcileTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */; };
+		63E155858B2CC783EE10F1D9 /* PBGitIndexRefreshTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */; };
 		643952771603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 643952761603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m */; };
 		6C25810B1C2720E60080A89A /* GitXCommitCopier.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C25810A1C2720E60080A89A /* GitXCommitCopier.m */; };
 		6C4855C81D57DCFC0027A7B4 /* PBTerminalUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C4855C71D57DCFC0027A7B4 /* PBTerminalUtil.m */; };
@@ -687,6 +688,7 @@
 		689D57B4A78CEF3B32EB0044 /* PBGitRevListRaceConditionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitRevListRaceConditionTests.m; path = GitXTests/PBGitRevListRaceConditionTests.m; sourceTree = "<group>"; };
 		7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitRepositoryFetchArgumentsTests.m; path = GitXTests/PBGitRepositoryFetchArgumentsTests.m; sourceTree = "<group>"; };
 		689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitIndexReconcileTests.m; path = GitXTests/PBGitIndexReconcileTests.m; sourceTree = "<group>"; };
+		689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitIndexRefreshTests.m; path = GitXTests/PBGitIndexRefreshTests.m; sourceTree = "<group>"; };
 		6C2581091C2720E60080A89A /* GitXCommitCopier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitXCommitCopier.h; sourceTree = "<group>"; };
 		6C25810A1C2720E60080A89A /* GitXCommitCopier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXCommitCopier.m; sourceTree = "<group>"; };
 		6C4855C61D57DCFC0027A7B4 /* PBTerminalUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBTerminalUtil.h; sourceTree = "<group>"; };
@@ -805,6 +807,7 @@
 				689D57B4A78CEF3B32EB0044 /* PBGitRevListRaceConditionTests.m */,
 				7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */,
 				689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */,
+				689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */,
 			);
 			name = GitXTests;
 			sourceTree = "<group>";
@@ -1739,6 +1742,7 @@
 				63E155858B2CC783EE10F1D7 /* PBGitRevListRaceConditionTests.m in Sources */,
 				7A1C4E2B90D3F5A6C1B80011 /* PBGitRepositoryFetchArgumentsTests.m in Sources */,
 				63E155858B2CC783EE10F1D8 /* PBGitIndexReconcileTests.m in Sources */,
+				63E155858B2CC783EE10F1D9 /* PBGitIndexRefreshTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2224,6 +2228,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/Classes/git",
+					"$(SRCROOT)/Classes/Util",
 					"$(SRCROOT)/Classes",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
@@ -2306,6 +2311,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/Classes/git",
+					"$(SRCROOT)/Classes/Util",
 					"$(SRCROOT)/Classes",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;

--- a/GitXTests/PBGitIndexRefreshTests.m
+++ b/GitXTests/PBGitIndexRefreshTests.m
@@ -1,0 +1,224 @@
+//
+//  PBGitIndexRefreshTests.m
+//  GitXTests
+//
+
+#import <XCTest/XCTest.h>
+#import "PBGitIndex.h"
+#import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
+#import "PBChangedFile.h"
+
+// Exposes the refresh bookkeeping and the per-command notification sender, so
+// the wiring around a refresh can be driven without a repository or a git
+// process, the same way the other suites here reach their seams.
+@interface PBGitIndex (RefreshTesting)
+- (BOOL)beginRefreshOrDeferIt;
+- (BOOL)endRefreshTakingDeferred;
+- (void)postIndexRefreshSuccess:(BOOL)success message:(nullable NSString *)message;
+@end
+
+// -[PBGitRepository init] only allocates two empty collections and reads one
+// default - no libgit2, no working directory, no repository watcher - so a stub
+// needs to stand in for nothing more than the one call staging makes.
+@interface PBStubRepository : PBGitRepository
+@property (nonatomic, assign) BOOL gitAcceptsTheChange;
+@property (nonatomic, strong) NSMutableArray<NSArray<NSString *> *> *launchedArguments;
+@property (nonatomic, strong) NSMutableArray<NSString *> *launchedInput;
+@end
+
+@implementation PBStubRepository
+
+- (instancetype)init
+{
+	if (!(self = [super init]))
+		return nil;
+
+	_gitAcceptsTheChange = YES;
+	_launchedArguments = [NSMutableArray array];
+	_launchedInput = [NSMutableArray array];
+
+	return self;
+}
+
+- (BOOL)launchTaskWithArguments:(nullable NSArray *)arguments input:(nullable NSString *)inputString error:(NSError **)error
+{
+	[self.launchedArguments addObject:arguments ?: @[]];
+	[self.launchedInput addObject:inputString ?: @""];
+
+	return self.gitAcceptsTheChange;
+}
+
+@end
+
+// Records the read-back that staging asks for, instead of performing it.
+@interface PBRecordingIndex : PBGitIndex
+@property (nonatomic, assign) NSUInteger refreshCount;
+@end
+
+@implementation PBRecordingIndex
+
+- (void)refresh
+{
+	self.refreshCount++;
+}
+
+@end
+
+static NSString *const kHeadSHA = @"e69de29bb2d1d6434b8b29ae775ad8c2e48c5391";
+
+@interface PBGitIndexRefreshTests : XCTestCase
+@property (nonatomic, strong) PBStubRepository *repository;
+@property (nonatomic, strong) PBRecordingIndex *gitIndex;
+@end
+
+@implementation PBGitIndexRefreshTests
+
+- (void)setUp
+{
+	[super setUp];
+
+	// The index holds its repository weakly, so the test case owns them both
+	self.repository = [[PBStubRepository alloc] init];
+	self.gitIndex = [[PBRecordingIndex alloc] initWithRepository:self.repository];
+}
+
+- (PBChangedFile *)trackedFile
+{
+	PBChangedFile *file = [[PBChangedFile alloc] initWithPath:@"a.txt"];
+	file.status = MODIFIED;
+	file.commitBlobMode = @"100644";
+	file.commitBlobSHA = kHeadSHA;
+
+	return file;
+}
+
+#pragma mark Staging reads the index back
+
+// The flags set straight after update-index are what git was asked for, not
+// what it recorded. A path that has since moved or vanished is staged as a
+// deletion, which used to leave the view claiming something git disagreed with
+// until the whole application was restarted.
+- (void)testStagingAsksGitAndThenReadsTheIndexBack
+{
+	PBChangedFile *file = [self trackedFile];
+
+	XCTAssertTrue([self.gitIndex stageFiles:@[ file ]]);
+
+	XCTAssertEqualObjects(self.repository.launchedArguments,
+						  (@[ @[ @"update-index", @"--add", @"--remove", @"-z", @"--stdin" ] ]));
+	XCTAssertTrue(file.hasStagedChanges);
+	XCTAssertEqual(self.gitIndex.refreshCount, 1u,
+				   @"the flags above are optimistic, so git has to be asked what it actually recorded");
+}
+
+- (void)testUnstagingAsksGitAndThenReadsTheIndexBack
+{
+	PBChangedFile *file = [self trackedFile];
+
+	XCTAssertTrue([self.gitIndex unstageFiles:@[ file ]]);
+
+	XCTAssertEqualObjects(self.repository.launchedArguments,
+						  (@[ @[ @"update-index", @"-z", @"--index-info" ] ]));
+	NSString *expectedIndexInfo = [NSString stringWithFormat:@"100644 %@\ta.txt", kHeadSHA];
+	XCTAssertTrue([self.repository.launchedInput.firstObject hasPrefix:expectedIndexInfo]);
+	XCTAssertTrue(file.hasUnstagedChanges);
+	XCTAssertEqual(self.gitIndex.refreshCount, 1u);
+}
+
+// update-index reads its input NUL-separated, so the terminator is part of the
+// contract rather than decoration.
+- (void)testStagedPathsReachGitNulTerminated
+{
+	[self.gitIndex stageFiles:@[ [self trackedFile] ]];
+
+	NSString *input = self.repository.launchedInput.firstObject;
+	XCTAssertTrue([input hasPrefix:@"a.txt"]);
+	XCTAssertEqual(input.length, 6u);
+	XCTAssertEqual([input characterAtIndex:input.length - 1], (unichar)0);
+}
+
+// A rejected update-index changed nothing, so there is nothing to read back and
+// the failure has to surface rather than be papered over with a refresh.
+- (void)testNothingIsReadBackWhenGitRejectedTheChange
+{
+	self.repository.gitAcceptsTheChange = NO;
+	PBChangedFile *file = [self trackedFile];
+
+	XCTAssertFalse([self.gitIndex stageFiles:@[ file ]]);
+
+	XCTAssertEqual(self.repository.launchedArguments.count, 1u);
+	XCTAssertFalse(file.hasStagedChanges, @"nothing was staged, so nothing should look staged");
+	XCTAssertEqual(self.gitIndex.refreshCount, 0u);
+}
+
+#pragma mark A refresh announces the index only once it has been reconciled
+
+// Each of the three commands reports on its own, long before the file list has
+// been rebuilt from all three of them. Announcing an index update from there
+// served observers the previous refresh's contents.
+- (void)testACommandResultDoesNotAnnounceAnIndexUpdate
+{
+	XCTestExpectation *statusReported = [self expectationForNotification:PBGitIndexIndexRefreshStatus
+																	  object:self.gitIndex
+																	 handler:nil];
+	XCTestExpectation *indexAnnounced = [self expectationForNotification:PBGitIndexIndexUpdated
+																	  object:self.gitIndex
+																	 handler:nil];
+	indexAnnounced.inverted = YES;
+
+	[self.gitIndex postIndexRefreshSuccess:YES message:@"diff-index success"];
+
+	[self waitForExpectations:@[ statusReported, indexAnnounced ] timeout:1.0];
+}
+
+- (void)testAFailedCommandDoesNotAnnounceAnIndexUpdateEither
+{
+	XCTestExpectation *failureReported = [self expectationForNotification:PBGitIndexIndexRefreshFailed
+																	   object:self.gitIndex
+																	  handler:nil];
+	XCTestExpectation *indexAnnounced = [self expectationForNotification:PBGitIndexIndexUpdated
+																	  object:self.gitIndex
+																	 handler:nil];
+	indexAnnounced.inverted = YES;
+
+	[self.gitIndex postIndexRefreshSuccess:NO message:@"diff-index failed"];
+
+	[self waitForExpectations:@[ failureReported, indexAnnounced ] timeout:1.0];
+}
+
+#pragma mark Overlapping refreshes coalesce
+
+// A refresh requested while one was running used to be discarded outright.
+// Rebasing from a terminal produces a burst of events, so the discarded one was
+// most likely the settling event carrying the state the user ends up looking at.
+- (void)testARequestArrivingDuringARefreshIsDeferredNotDropped
+{
+	XCTAssertTrue([self.gitIndex beginRefreshOrDeferIt], @"the first request should run");
+	XCTAssertFalse([self.gitIndex beginRefreshOrDeferIt], @"a second request must not run alongside the first");
+
+	XCTAssertTrue([self.gitIndex endRefreshTakingDeferred], @"the deferred request still has to be run");
+}
+
+- (void)testABurstOfRequestsCollapsesIntoASingleRerun
+{
+	XCTAssertTrue([self.gitIndex beginRefreshOrDeferIt]);
+
+	for (NSUInteger i = 0; i < 5; i++)
+		XCTAssertFalse([self.gitIndex beginRefreshOrDeferIt]);
+
+	XCTAssertTrue([self.gitIndex endRefreshTakingDeferred], @"a burst is worth exactly one re-run");
+
+	XCTAssertTrue([self.gitIndex beginRefreshOrDeferIt], @"which then runs as an ordinary refresh");
+	XCTAssertFalse([self.gitIndex endRefreshTakingDeferred], @"and settles, rather than refreshing forever");
+}
+
+- (void)testAnUncontestedRefreshEndsWithoutSchedulingAnother
+{
+	XCTAssertTrue([self.gitIndex beginRefreshOrDeferIt]);
+	XCTAssertFalse([self.gitIndex endRefreshTakingDeferred]);
+
+	XCTAssertTrue([self.gitIndex beginRefreshOrDeferIt], @"the guard has to be clear once a refresh has ended");
+}
+
+@end


### PR DESCRIPTION
Follows up on #571, where you asked for tests covering those changes.

Of the three commits that landed there, only `777e6784` carried tests, and
they cover the pure reconcile seam rather than what surrounds it. This adds
nine cases for the rest:

- **Staging reads the index back** (`24849b90`) - staging and unstaging ask
  git and then re-read, a rejected `update-index` reads nothing back, and
  staged paths reach git NUL-terminated
- **A refresh announces the index only once it has been reconciled** - the
  ordering change folded into `777e6784`; neither the success nor the
  failure arm of a per-command result may announce an index update
- **Overlapping refreshes coalesce** (`74197e56`) - a request arriving
  during a refresh is deferred rather than discarded, and a burst collapses
  into exactly one re-run

### Notes for review

No repository on disk, no git process, no FSEvents, no async settling. That
works because `-[PBGitRepository init]` touches nothing outside itself, and
the two collaborators that would otherwise reach the filesystem are ordinary
overridable methods, so test-local subclasses record the calls instead of
making them. The whole suite runs in about two seconds.

One production change: the refresh guard in `-refresh` and its other half in
the completion block are extracted into `-beginRefreshOrDeferIt` and
`-endRefreshTakingDeferred`, so the coalescing contract can be asserted
directly. Same logic, same serial queue, just named.

Being straight about what the coalescing cases are: a contract test for the
state machine, not a reproduction of the original bug. Losing the settling
event of a rebase burst only reproduces against a real repository on disk,
and was verified by hand for #571. The other two groups do fail against the
pre-fix code.

The GitXTests target gains a header search path for `Classes/Util`, which
`PBGitRepository_PBGitBinarySupport.h` needs.

### Test plan

- `xcodebuild test -workspace GitX.xcworkspace -scheme GitX -only-testing:GitXTests`
  - 23 tests pass, 14 existing plus 9 new, in ~2s
- Each new case was checked to be load-bearing by breaking the behaviour it
  guards and confirming it goes red:
  - removing the `[self refresh]` after `update-index` fails the two staging
    cases on the read-back count
  - restoring `[self postIndexUpdated]` in `postIndexRefreshSuccess:message:`
    trips both inverted expectations
  - dropping the deferred request instead of re-running it fails both
    coalescing cases, while the "nothing was deferred" case correctly stays
    green
