### PR TITLE
Run the unit tests on every build

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -81,6 +81,19 @@ jobs:
         run: |
           brew unlink openssl@3
           
+      # The unit tests need no signing, no screenshot repo and no network, so
+      # unlike the screenshot pipeline below they can run on every build
+      - name: Run unit tests
+        if: ${{ matrix.abi == 'arm64' }}
+        run: |
+          xcodebuild test \
+            -workspace GitX.xcworkspace \
+            -scheme GitX \
+            -only-testing:GitXTests \
+            -destination "platform=macOS,arch=${{ matrix.abi }}" \
+            ARCHS="${{ matrix.abi }}" \
+            CODE_SIGN_IDENTITY="-"
+
       # Test (only on arm64 to avoid tripling CI time)
       - name: Prepare screenshot comparison
         if: ${{ env.variableSet != '' && matrix.abi == 'arm64' && github.event_name == 'pull_request' }}


### PR DESCRIPTION
The unit tests merged in #576 do not run in CI. Neither do the ones merged before them. \
This adds a step so that they do.

## Why they never run

`.github/workflows/BuildPR.yml` runs `GitXTests` from a step gated on:

```yaml
if: ${{ env.variableSet != '' && matrix.abi == 'arm64' && github.event_name == 'pull_request' }}
```

with `variableSet: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}`. \
That condition is correct for the block it belongs to. \
The screenshot pipeline genuinely needs the signing certificate, the pinned repo snapshot at `52ff1051`, and `CLASSIC_TOKEN` / `SCREENSHOT_USER` / `SCREENSHOT_PASSWORD` to compare, and 1960c6cc applied the same guard to all seven of those steps at once.

The unit tests were swept along with them by sitting in the same block, and they need none of it. \
The consequence is that the suite is skipped exactly where it would be most useful:

- **Fork pull requests** \
   GitHub withholds secrets from them, so `variableSet` is empty. \
   #576 was raised from a fork, \
   so the tests it added have never executed in CI even once.
- **Pushes to master** \
   Not `pull_request` events, so the second condition fails as well.

What is left is a suite that runs only for branches pushed inside `gitx/gitx`.

## The change

One step, thirteen lines, nothing removed and nothing else touched:

```yaml
      - name: Run unit tests
        if: ${{ matrix.abi == 'arm64' }}
        run: |
          xcodebuild test \
            -workspace GitX.xcworkspace \
            -scheme GitX \
            -only-testing:GitXTests \
            ...
```

- `-only-testing:GitXTests` keeps it to the unit target, so the UI tests and the screenshots stay entirely within the existing gated block.
- `CODE_SIGN_IDENTITY="-"` signs ad-hoc, which is why no certificate is needed. 

It sits just before the screenshot pipeline so that a unit failure stops the job before the expensive steps run.

## What it costs

- Where the current test step is **skipped** (fork PRs, master pushes): one Debug build of GitX.app on the arm64 runner, plus about 2 seconds of tests.
- Where it already **runs**: about 2 seconds, since the Debug build is shared with the existing step.

Only the arm64 job runs it, matching the existing "only on arm64 to avoid tripling CI time" policy.

## Test plan

- `xcodebuild test -workspace GitX.xcworkspace -scheme GitX -only-testing:GitXTests -destination "platform=macOS,arch=arm64" ARCHS="arm64" CODE_SIGN_IDENTITY="-"` - the exact command the step runs. \
   23 tests, 0 failures, 2.0s of testing.
- Workflow parses, and the new step is picked up with the intended condition while all eight screenshot steps keep theirs unchanged.
- This PR is itself raised from a fork, so its own CI run is the check that matters: the new step should execute where the old one is skipped.

## Two things I could not verify, and one option

I ran the command on macOS 15.7.9 locally, not on `macos-26` with Xcode 26.3, so the runner is the one thing I cannot reproduce. If it needs a `-destination` tweak there I am happy to follow up.

I also left the existing `Run tests` step alone rather than narrowing it to `-only-testing:GitXUITests`. That would stop the unit tests running twice on internal PRs, but the UI and screenshot path does not start on my machine ("Timed out while enabling automation mode"), and I would rather not reshape a pipeline I cannot exercise. Happy to add it if you would prefer that in the same PR.
