### PR TITLE
Fix the history list selection fighting the sidebar branch

### DIFF
--- a/Classes/Controllers/PBGitHistoryController.h
+++ b/Classes/Controllers/PBGitHistoryController.h
@@ -39,7 +39,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)hasNonlinearPath;
 - (NSMenu *)tableColumnMenu;
-- (void)selectCommit:(GTOID *)commit;
+- (BOOL)selectCommit:(GTOID *)commit;
+- (void)selectCurrentBranchTip;
 - (void)updateQuicklookForce:(BOOL)force;
 
 - (void)setHistorySearch:(NSString *)searchString mode:(PBHistorySearchMode)mode;

--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -27,6 +27,7 @@
 #import "PBGitRevisionRow.h"
 #import "PBGitRevisionCell.h"
 #import "PBGitStash.h"
+#import "PBGitSidebarController.h"
 
 #define kHistorySelectedDetailIndexKey @"PBHistorySelectedDetailIndex"
 #define kHistoryDetailViewIndex 0
@@ -187,6 +188,7 @@
 	[commitList registerForDraggedTypes:[NSArray arrayWithObject:@"PBGitRef"]];
 
 	commitList.target = self;
+	commitList.action = @selector(didClickCommitList:);
 	commitList.doubleAction = @selector(didDoubleClickCommitList:);
 
 	[upperToolbarView setTopShade:237/255.0f bottomShade:216/255.0f];
@@ -822,26 +824,46 @@
 	return YES;
 }
 
-- (void)didDoubleClickCommitList:(id)sender
+// The ref label under the last mouse-down in the history list, or nil when the
+// click landed anywhere else on the row
+- (PBGitRef *)clickedRefInCommitList
 {
 	NSPoint location = [commitList mouseDownPoint];
 	NSInteger row = [commitList rowAtPoint:location];
 	NSInteger column = [commitList columnAtPoint:location];
 
+	if (row == -1 || column == -1)
+		return nil;
+
 	PBGitRevisionCell *cell = (PBGitRevisionCell *)[commitList viewAtColumn:column row:row makeIfNecessary:NO];
+	if (![cell respondsToSelector:@selector(indexAtX:)])
+		return nil;
+
+	NSRect cellFrame = [commitList frameOfCellAtColumn:column row:row];
+	int index = [cell indexAtX:(location.x - cellFrame.origin.x)];
+	if (index == -1)
+		return nil;
+
 	PBGitCommit *commit = [[commitController arrangedObjects] objectAtIndex:row];
 
-	int index = -1;
-	if ([cell respondsToSelector:@selector(indexAtX:)]) {
-		NSRect cellFrame = [commitList frameOfCellAtColumn:column row:row];
-		CGFloat deltaX = location.x - cellFrame.origin.x;
-		index = [cell indexAtX:deltaX];
-	}
+	return [[commit refs] objectAtIndex:index];
+}
 
-	if (index == -1)
+// Clicking a branch label is a statement about which branch you are looking at,
+// so let the sidebar follow it. Clicking anywhere else on the row leaves the
+// sidebar alone.
+- (void)didClickCommitList:(id)sender
+{
+	PBGitRef *ref = [self clickedRefInCommitList];
+	if (!(ref.isBranch || ref.isRemoteBranch))
 		return;
 
-	PBGitRef *ref = [[commit refs] objectAtIndex:index];
+	[self.windowController.sidebarViewController selectBranchForRef:ref];
+}
+
+- (void)didDoubleClickCommitList:(id)sender
+{
+	PBGitRef *ref = [self clickedRefInCommitList];
 	if (!ref)
 		return;
 

--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -59,6 +59,7 @@
 }
 
 @property (nonatomic, assign) BOOL awaitingBranchSelection;
+@property (nonatomic, strong) GTOID *lastSelectedOID;
 
 - (void)updateBranchFilterMatrix;
 - (void)restoreFileBrowserSelection;
@@ -216,11 +217,29 @@
 	[self updateStatus];
 
 	GTOID *commitOID = [self OIDToReselect];
-	if (!commitOID)
+	if (!commitOID) {
+		[self restoreSelectionAfterUpdate];
 		return;
+	}
 
 	if ([self selectCommit:commitOID])
 		self.awaitingBranchSelection = NO;
+}
+
+// Reading the list in again replaces the commit objects, and the array
+// controller drops a selection whose objects are gone. The commit the user
+// picked is still in the list, so put it back rather than leaving the history
+// with nothing selected at all.
+- (void)restoreSelectionAfterUpdate
+{
+	if (!self.lastSelectedOID || commitController.selectedObjects.count)
+		return;
+
+	NSArray *commits = [self selectedObjectsForOID:self.lastSelectedOID];
+	if (!commits.count)
+		return;
+
+	[commitController setSelectedObjects:commits];
 }
 
 // Picking a branch in the sidebar is a request to look at that branch, so the
@@ -268,6 +287,9 @@
 	if (![self.selectedCommits isEqualToArray:newSelectedCommits]) {
 		self.selectedCommits = newSelectedCommits;
 	}
+
+	if (newSelectedCommits.count)
+		self.lastSelectedOID = newSelectedCommits.firstObject.OID;
 
 	PBGitCommit *firstSelectedCommit = self.selectedCommits.firstObject;
 

--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -58,6 +58,8 @@
 	NSArray<PBGitCommit *> *selectedCommits;
 }
 
+@property (nonatomic, assign) BOOL awaitingBranchSelection;
+
 - (void)updateBranchFilterMatrix;
 - (void)restoreFileBrowserSelection;
 - (void)saveFileBrowserSelection;
@@ -128,6 +130,8 @@
 					options:0
 					  block:^(MAKVONotification *notification) {
 						  PBGitHistoryController *observer = notification.observer;
+						  observer.awaitingBranchSelection = YES;
+
 						  // Reset the sorting
 						  if ([[observer.commitController sortDescriptors] count]) {
 							  [observer.commitController setSortDescriptors:[NSArray array]];
@@ -155,6 +159,7 @@
 					  }];
 
 	forceSelectionUpdate = YES;
+	self.awaitingBranchSelection = YES;
 	NSSize cellSpacing = [commitList intercellSpacing];
 	cellSpacing.height = 0;
 	[commitList setIntercellSpacing:cellSpacing];
@@ -210,10 +215,36 @@
 {
 	[self updateStatus];
 
+	GTOID *commitOID = [self OIDToReselect];
+	if (!commitOID)
+		return;
+
+	if ([self selectCommit:commitOID])
+		self.awaitingBranchSelection = NO;
+}
+
+// Picking a branch in the sidebar is a request to look at that branch, so the
+// history list owes it its tip again - including when the same branch is
+// clicked a second time to get back to it.
+- (void)selectCurrentBranchTip
+{
+	self.awaitingBranchSelection = YES;
+	[self reselectCommitAfterUpdate];
+}
+
+// The commit the history list still owes the sidebar, or nil when the list
+// should keep whatever the user has selected. A branch tip stays owed until it
+// has actually been shown, which can take several updates while the list is
+// still being read in.
+- (GTOID *)OIDToReselect
+{
+	if (!self.awaitingBranchSelection)
+		return nil;
+
 	if ([self.repository.currentBranch isSimpleRef])
-		[self selectCommit:[self.repository OIDForRef:self.repository.currentBranch.ref]];
-	else
-		[self selectCommit:self.firstCommit.OID];
+		return [self.repository OIDForRef:self.repository.currentBranch.ref];
+
+	return self.firstCommit.OID;
 }
 
 - (NSTableRowView *)tableView:(NSTableView *)tableView rowViewForRow:(NSInteger)row
@@ -570,28 +601,31 @@
 - (NSArray *)selectedObjectsForOID:(GTOID *)commitOID
 {
 	NSPredicate *selection = [NSPredicate predicateWithFormat:@"OID == %@", commitOID];
-	NSArray *selectionCommits = [[commitController content] filteredArrayUsingPredicate:selection];
 
-	if ((selectionCommits.count == 0) && [self firstCommit] != nil) {
-		selectionCommits = @[ [self firstCommit] ];
-	}
-
-	return selectionCommits;
+	return [[commitController content] filteredArrayUsingPredicate:selection];
 }
 
-- (void)selectCommit:(GTOID *)commitOID
+- (BOOL)selectCommit:(GTOID *)commitOID
 {
 	if (!forceSelectionUpdate && [[[commitController.selectedObjects lastObject] OID] isEqual:commitOID]) {
-		return;
+		return YES;
 	}
 
 	NSArray *selectedObjects = [self selectedObjectsForOID:commitOID];
+	BOOL foundRequestedCommit = (selectedObjects.count > 0);
+
+	if (!foundRequestedCommit && [self firstCommit] != nil) {
+		selectedObjects = @[ [self firstCommit] ];
+	}
+
 	[commitController setSelectedObjects:selectedObjects];
 
 	NSInteger oldIndex = [[commitController selectionIndexes] firstIndex];
 	[self scrollSelectionToTopOfViewFrom:oldIndex];
 
 	forceSelectionUpdate = NO;
+
+	return foundRequestedCommit;
 }
 
 - (BOOL)hasNonlinearPath

--- a/Classes/Controllers/PBGitSidebarController.h
+++ b/Classes/Controllers/PBGitSidebarController.h
@@ -16,6 +16,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class PBGitRef;
+
 @interface PBGitSidebarController : PBViewController
 
 - (void)selectStage;
@@ -30,6 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) PBSourceViewItem *remotes;
 @property (readonly) NSOutlineView *sourceView;
 @property (readonly) NSView *sourceListControlsView;
+
+- (void)selectBranchForRef:(PBGitRef *)ref;
 
 @end
 

--- a/Classes/Controllers/PBGitSidebarController.m
+++ b/Classes/Controllers/PBGitSidebarController.m
@@ -191,6 +191,25 @@
 	}
 }
 
+// Moving the outline selection is the only way to change which branch is
+// focused: writing to currentBranch from outside is undone by the
+// reloadPreservingSelection that the change itself triggers.
+- (void)selectBranchForRef:(PBGitRef *)ref
+{
+	PBSourceViewItem *item = [self itemForRev:[[PBGitRevSpecifier alloc] initWithRef:ref]];
+	if (!item)
+		return;
+
+	[sourceView PBExpandItem:item expandParents:YES];
+
+	NSInteger row = [sourceView rowForItem:item];
+	if (row == -1)
+		return;
+
+	[sourceView selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
+	[self.windowController.historyViewController selectCurrentBranchTip];
+}
+
 - (PBSourceViewItem *)itemForRev:(PBGitRevSpecifier *)rev
 {
 	PBSourceViewItem *foundItem = nil;

--- a/Classes/Controllers/PBGitSidebarController.m
+++ b/Classes/Controllers/PBGitSidebarController.m
@@ -121,6 +121,7 @@
 					  }];
 
 	[sourceView setTarget:self];
+	[sourceView setAction:@selector(clicked:)];
 	[sourceView setDoubleAction:@selector(doubleClicked:)];
 
 	[self menuNeedsUpdate:[actionButton menu]];
@@ -291,6 +292,15 @@
 
 	[self updateActionMenu];
 	[self updateRemoteControls];
+}
+
+- (void)clicked:(id)object
+{
+	PBSourceViewItem *item = [sourceView itemAtRow:[sourceView clickedRow]];
+	if (![item revSpecifier])
+		return;
+
+	[self.windowController.historyViewController selectCurrentBranchTip];
 }
 
 - (void)doubleClicked:(id)object

--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -32,7 +32,7 @@
 @interface PBGitWindowController () {
 	__weak PBViewController *contentController;
 
-	PBGitSidebarController *_sidebarController;
+	PBGitSidebarController *_sidebarViewController;
 	PBGitHistoryController *_historyViewController;
 	PBGitCommitController *_commitViewController;
 
@@ -134,13 +134,13 @@
 	[[self window] setFrameUsingName:@"GitX"];
 	[[self window] setRepresentedURL:self.repository.workingDirectoryURL];
 
-	_sidebarController = [[PBGitSidebarController alloc] initWithRepository:self.repository superController:self];
+	_sidebarViewController = [[PBGitSidebarController alloc] initWithRepository:self.repository superController:self];
 	_historyViewController = [[PBGitHistoryController alloc] initWithRepository:self.repository superController:self];
 	_commitViewController = [[PBGitCommitController alloc] initWithRepository:self.repository superController:self];
 
-	[[_sidebarController view] setFrame:[sourceSplitView bounds]];
-	[sourceSplitView addSubview:_sidebarController.view];
-	[sourceListControlsView addSubview:_sidebarController.sourceListControlsView];
+	[[_sidebarViewController view] setFrame:[sourceSplitView bounds]];
+	[sourceSplitView addSubview:_sidebarViewController.view];
+	[sourceListControlsView addSubview:_sidebarViewController.sourceListControlsView];
 
 	[[statusField cell] setBackgroundStyle:NSBackgroundStyleRaised];
 	[progressIndicator setUsesThreadedAnimation:YES];
@@ -181,12 +181,12 @@
 
 - (void)showCommitView:(id)sender
 {
-	[_sidebarController selectStage];
+	[_sidebarViewController selectStage];
 }
 
 - (void)showHistoryView:(id)sender
 {
-	[_sidebarController selectCurrentBranch];
+	[_sidebarViewController selectCurrentBranch];
 }
 
 - (void)showCommitHookFailedSheet:(NSString *)messageText infoText:(NSString *)infoText commitController:(PBGitCommitController *)controller

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		4A40159914067B7A00DB9C07 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A40159814067B7A00DB9C07 /* AppKit.framework */; };
 		4A467EEE1546D1CD00F8902B /* ObjectiveGit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A4EF0AF142CBAD5001B8CDF /* ObjectiveGit.framework */; };
 		4A4EF0BB142CBBC2001B8CDF /* ObjectiveGit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A4EF0AF142CBAD5001B8CDF /* ObjectiveGit.framework */; };
+		A3F71C46D2894B0E9C5A7F12 /* ObjectiveGit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A4EF0AF142CBAD5001B8CDF /* ObjectiveGit.framework */; };
 		4A5D75C114A9A90500DF6C68 /* Credits.html in Resources */ = {isa = PBXBuildFile; fileRef = 4A5D757D14A9A90500DF6C68 /* Credits.html */; };
 		4A5D75DE14A9A90500DF6C68 /* mainSplitterBar.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 4A5D759B14A9A90500DF6C68 /* mainSplitterBar.tiff */; };
 		4A5D75DF14A9A90500DF6C68 /* mainSplitterDimple.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 4A5D759C14A9A90500DF6C68 /* mainSplitterDimple.tiff */; };
@@ -155,6 +156,7 @@
 		7A1C4E2B90D3F5A6C1B80011 /* PBGitRepositoryFetchArgumentsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */; };
 		63E155858B2CC783EE10F1D8 /* PBGitIndexReconcileTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */; };
 		63E155858B2CC783EE10F1D9 /* PBGitIndexRefreshTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */; };
+		7C41A9E2B5D340E1A7F26C08 /* PBGitHistorySelectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E9D3B41C86F42A7B10D5E33 /* PBGitHistorySelectionTests.m */; };
 		1D8C4F70A93E42B6BE7C0D95 /* PBGitWindowWiringTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */; };
 		643952771603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 643952761603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m */; };
 		6C25810B1C2720E60080A89A /* GitXCommitCopier.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C25810A1C2720E60080A89A /* GitXCommitCopier.m */; };
@@ -690,6 +692,7 @@
 		7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitRepositoryFetchArgumentsTests.m; path = GitXTests/PBGitRepositoryFetchArgumentsTests.m; sourceTree = "<group>"; };
 		689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitIndexReconcileTests.m; path = GitXTests/PBGitIndexReconcileTests.m; sourceTree = "<group>"; };
 		689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitIndexRefreshTests.m; path = GitXTests/PBGitIndexRefreshTests.m; sourceTree = "<group>"; };
+		5E9D3B41C86F42A7B10D5E33 /* PBGitHistorySelectionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitHistorySelectionTests.m; path = GitXTests/PBGitHistorySelectionTests.m; sourceTree = "<group>"; };
 		4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitWindowWiringTests.m; path = GitXTests/PBGitWindowWiringTests.m; sourceTree = "<group>"; };
 		6C2581091C2720E60080A89A /* GitXCommitCopier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitXCommitCopier.h; sourceTree = "<group>"; };
 		6C25810A1C2720E60080A89A /* GitXCommitCopier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXCommitCopier.m; sourceTree = "<group>"; };
@@ -760,6 +763,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A3F71C46D2894B0E9C5A7F12 /* ObjectiveGit.framework in Frameworks */,
 				9288179619F9AFBD9A6CBCC3 /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -810,6 +814,7 @@
 				7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */,
 				689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */,
 				689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */,
+				5E9D3B41C86F42A7B10D5E33 /* PBGitHistorySelectionTests.m */,
 				4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */,
 			);
 			name = GitXTests;
@@ -1746,6 +1751,7 @@
 				7A1C4E2B90D3F5A6C1B80011 /* PBGitRepositoryFetchArgumentsTests.m in Sources */,
 				63E155858B2CC783EE10F1D8 /* PBGitIndexReconcileTests.m in Sources */,
 				63E155858B2CC783EE10F1D9 /* PBGitIndexRefreshTests.m in Sources */,
+				7C41A9E2B5D340E1A7F26C08 /* PBGitHistorySelectionTests.m in Sources */,
 				1D8C4F70A93E42B6BE7C0D95 /* PBGitWindowWiringTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		7A1C4E2B90D3F5A6C1B80011 /* PBGitRepositoryFetchArgumentsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */; };
 		63E155858B2CC783EE10F1D8 /* PBGitIndexReconcileTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */; };
 		63E155858B2CC783EE10F1D9 /* PBGitIndexRefreshTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */; };
+		1D8C4F70A93E42B6BE7C0D95 /* PBGitWindowWiringTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */; };
 		643952771603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 643952761603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m */; };
 		6C25810B1C2720E60080A89A /* GitXCommitCopier.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C25810A1C2720E60080A89A /* GitXCommitCopier.m */; };
 		6C4855C81D57DCFC0027A7B4 /* PBTerminalUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C4855C71D57DCFC0027A7B4 /* PBTerminalUtil.m */; };
@@ -689,6 +690,7 @@
 		7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitRepositoryFetchArgumentsTests.m; path = GitXTests/PBGitRepositoryFetchArgumentsTests.m; sourceTree = "<group>"; };
 		689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitIndexReconcileTests.m; path = GitXTests/PBGitIndexReconcileTests.m; sourceTree = "<group>"; };
 		689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitIndexRefreshTests.m; path = GitXTests/PBGitIndexRefreshTests.m; sourceTree = "<group>"; };
+		4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitWindowWiringTests.m; path = GitXTests/PBGitWindowWiringTests.m; sourceTree = "<group>"; };
 		6C2581091C2720E60080A89A /* GitXCommitCopier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitXCommitCopier.h; sourceTree = "<group>"; };
 		6C25810A1C2720E60080A89A /* GitXCommitCopier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXCommitCopier.m; sourceTree = "<group>"; };
 		6C4855C61D57DCFC0027A7B4 /* PBTerminalUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBTerminalUtil.h; sourceTree = "<group>"; };
@@ -808,6 +810,7 @@
 				7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */,
 				689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */,
 				689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */,
+				4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */,
 			);
 			name = GitXTests;
 			sourceTree = "<group>";
@@ -1743,6 +1746,7 @@
 				7A1C4E2B90D3F5A6C1B80011 /* PBGitRepositoryFetchArgumentsTests.m in Sources */,
 				63E155858B2CC783EE10F1D8 /* PBGitIndexReconcileTests.m in Sources */,
 				63E155858B2CC783EE10F1D9 /* PBGitIndexRefreshTests.m in Sources */,
+				1D8C4F70A93E42B6BE7C0D95 /* PBGitWindowWiringTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GitXTests/PBGitHistorySelectionTests.m
+++ b/GitXTests/PBGitHistorySelectionTests.m
@@ -13,7 +13,25 @@
 // move the selection, and the flag the sidebar raises to ask for a move.
 @interface PBGitHistoryController (SelectionTesting)
 @property (nonatomic, assign) BOOL awaitingBranchSelection;
+@property (nonatomic, strong) GTOID *lastSelectedOID;
 - (GTOID *)OIDToReselect;
+- (void)restoreSelectionAfterUpdate;
+@end
+
+// The restore only reads OIDs off the commits, so it needs nothing of the real
+// PBGitCommit, which cannot be built without a commit in a repository.
+@interface PBStubCommit : NSObject
+@property (nonatomic, strong) GTOID *OID;
+@end
+
+@implementation PBStubCommit
++ (instancetype)commitWithSHA:(NSString *)SHA
+{
+	PBStubCommit *commit = [PBStubCommit new];
+	commit.OID = [GTOID oidWithSHA:SHA];
+
+	return commit;
+}
 @end
 
 // The history list reaches for its table view once it actually moves the
@@ -100,6 +118,42 @@ static NSString *const kBranchTipSHA = @"8031ee6a0000000000000000000000000000bee
 	[self.historyController selectCurrentBranchTip];
 
 	XCTAssertTrue(self.historyController.awaitingBranchSelection);
+	XCTAssertEqualObjects([self.historyController OIDToReselect], [GTOID oidWithSHA:kBranchTipSHA]);
+}
+
+// Checking a branch out rewrites the list, and the array controller drops a
+// selection whose objects have been replaced. The commit is still there under
+// the same OID, so it has to come back rather than leaving the history list
+// with nothing selected and no focus.
+- (void)testASelectionDroppedByARebuildComesBack
+{
+	NSString *pickedSHA = @"c12df1e80000000000000000000000000000cafe";
+	NSArrayController *commits = [[NSArrayController alloc] init];
+	commits.avoidsEmptySelection = NO;
+	commits.content = @[ [PBStubCommit commitWithSHA:kBranchTipSHA], [PBStubCommit commitWithSHA:pickedSHA] ];
+	[commits setSelectedObjects:@[]];
+	[self.historyController setValue:commits forKey:@"commitController"];
+
+	self.historyController.lastSelectedOID = [GTOID oidWithSHA:pickedSHA];
+	self.historyController.awaitingBranchSelection = NO;
+
+	[self.historyController restoreSelectionAfterUpdate];
+
+	XCTAssertEqualObjects([commits.selectedObjects.firstObject OID], [GTOID oidWithSHA:pickedSHA]);
+}
+
+// A branch change outranks it: there the list is meant to move.
+- (void)testAnOutstandingBranchChangeIsNotOverriddenByTheRestore
+{
+	NSArrayController *commits = [[NSArrayController alloc] init];
+	commits.avoidsEmptySelection = NO;
+	commits.content = @[ [PBStubCommit commitWithSHA:kBranchTipSHA] ];
+	[commits setSelectedObjects:@[]];
+	[self.historyController setValue:commits forKey:@"commitController"];
+
+	[self selectBranchInSidebar:@"refs/heads/branch_B" atOID:[GTOID oidWithSHA:kBranchTipSHA]];
+	self.historyController.awaitingBranchSelection = YES;
+
 	XCTAssertEqualObjects([self.historyController OIDToReselect], [GTOID oidWithSHA:kBranchTipSHA]);
 }
 

--- a/GitXTests/PBGitHistorySelectionTests.m
+++ b/GitXTests/PBGitHistorySelectionTests.m
@@ -1,0 +1,106 @@
+//
+//  PBGitHistorySelectionTests.m
+//  GitXTests
+//
+
+#import <XCTest/XCTest.h>
+#import "PBGitHistoryController.h"
+#import "PBGitRepository.h"
+#import "PBGitRevSpecifier.h"
+#import "PBGitRef.h"
+
+// Exposes the rule that decides whether a history list update is allowed to
+// move the selection, and the flag the sidebar raises to ask for a move.
+@interface PBGitHistoryController (SelectionTesting)
+@property (nonatomic, assign) BOOL awaitingBranchSelection;
+- (GTOID *)OIDToReselect;
+@end
+
+// The history list reaches for its table view once it actually moves the
+// selection, which a test has no nib for, so stop at the decision.
+@interface PBStubHistoryController : PBGitHistoryController
+@end
+
+@implementation PBStubHistoryController
+- (BOOL)selectCommit:(GTOID *)commitOID
+{
+	return NO;
+}
+@end
+
+static NSString *const kBranchTipSHA = @"8031ee6a0000000000000000000000000000beef";
+
+@interface PBGitHistorySelectionTests : XCTestCase
+@property (nonatomic, strong) PBGitRepository *repository;
+@property (nonatomic, strong) PBGitHistoryController *historyController;
+@end
+
+@implementation PBGitHistorySelectionTests
+
+- (void)setUp
+{
+	[super setUp];
+
+	// -[PBGitRepository init] and -[PBViewController initWithRepository:...]
+	// both stay in memory: no libgit2, and the nib is not loaded until the
+	// view is asked for, which these tests never do.
+	self.repository = [[PBGitRepository alloc] init];
+	self.historyController = [[PBStubHistoryController alloc] initWithRepository:self.repository superController:nil];
+}
+
+- (void)selectBranchInSidebar:(NSString *)refName atOID:(GTOID *)OID
+{
+	PBGitRef *ref = [PBGitRef refFromString:refName];
+	self.repository.refs = [@{OID : [@[ ref ] mutableCopy]} mutableCopy];
+	self.repository.currentBranch = [[PBGitRevSpecifier alloc] initWithRef:ref];
+}
+
+// The bug: checking a branch out from the history list, a fetch, or a commit
+// made in a terminal all end in a list update, and every one of them used to
+// drag the selection back to the tip of whatever the sidebar had highlighted.
+- (void)testAnUpdateOnItsOwnLeavesTheSelectionAlone
+{
+	[self selectBranchInSidebar:@"refs/heads/branch_B" atOID:[GTOID oidWithSHA:kBranchTipSHA]];
+	self.historyController.awaitingBranchSelection = NO;
+
+	XCTAssertNil([self.historyController OIDToReselect],
+				 @"a list update is not a reason to move the commit the user picked");
+}
+
+// Selecting a branch in the sidebar still moves the list to that branch's tip.
+- (void)testTheSidebarBranchTipIsOwedAfterABranchChange
+{
+	GTOID *tip = [GTOID oidWithSHA:kBranchTipSHA];
+	[self selectBranchInSidebar:@"refs/heads/branch_B" atOID:tip];
+	self.historyController.awaitingBranchSelection = YES;
+
+	XCTAssertEqualObjects([self.historyController OIDToReselect], tip);
+}
+
+// The tip stays owed across updates, because the list is read in a piece at a
+// time and the commit carrying the branch label may not have arrived yet.
+- (void)testTheTipStaysOwedUntilItIsActuallyShown
+{
+	GTOID *tip = [GTOID oidWithSHA:kBranchTipSHA];
+	[self selectBranchInSidebar:@"refs/heads/branch_B" atOID:tip];
+	self.historyController.awaitingBranchSelection = YES;
+
+	XCTAssertEqualObjects([self.historyController OIDToReselect], tip);
+	XCTAssertEqualObjects([self.historyController OIDToReselect], tip);
+}
+
+// Clicking a branch in the sidebar is how you ask to be taken back to its tip,
+// so it has to work on a branch that is already the selected one - nothing else
+// moves the list back once the user has clicked away from the tip.
+- (void)testClickingTheSelectedBranchAsksForItsTipAgain
+{
+	[self selectBranchInSidebar:@"refs/heads/branch_B" atOID:[GTOID oidWithSHA:kBranchTipSHA]];
+	self.historyController.awaitingBranchSelection = NO;
+
+	[self.historyController selectCurrentBranchTip];
+
+	XCTAssertTrue(self.historyController.awaitingBranchSelection);
+	XCTAssertEqualObjects([self.historyController OIDToReselect], [GTOID oidWithSHA:kBranchTipSHA]);
+}
+
+@end

--- a/GitXTests/PBGitWindowWiringTests.m
+++ b/GitXTests/PBGitWindowWiringTests.m
@@ -7,6 +7,16 @@
 #import "PBGitWindowController.h"
 #import "PBGitRepository.h"
 #import "PBGitSidebarController.h"
+#import "PBGitHistoryController.h"
+#import "PBGitCommit.h"
+#import "PBGitRef.h"
+#import "PBSourceViewItem.h"
+
+// -selectedRef is private to the window controller, so the test names it the
+// same way the other suites name the seams they drive.
+@interface PBGitWindowController (PBSelectedRefTests)
+- (PBGitRef *)selectedRef;
+@end
 
 // The window controller takes its repository from its document. A test has no
 // document, so it supplies the repository directly and lets everything else
@@ -36,7 +46,20 @@
 	NSURL *URL = [[NSURL fileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
 	[[NSFileManager defaultManager] createDirectoryAtURL:URL withIntermediateDirectories:YES attributes:nil error:NULL];
 
-	for (NSArray *arguments in @[ @[ @"init", @"-q" ], @[ @"commit", @"-q", @"--allow-empty", @"-m", @"root" ] ]) {
+	// branch_one ends up one commit ahead, so its tip carries a single branch
+	// label while the root commit carries two, plus a remote that gives the
+	// sidebar a REMOTES row to select.
+	NSArray *script = @[
+		@[ @"init", @"-q" ],
+		@[ @"symbolic-ref", @"HEAD", @"refs/heads/branch_one" ],
+		@[ @"commit", @"-q", @"--allow-empty", @"-m", @"root" ],
+		@[ @"branch", @"branch_two" ],
+		@[ @"branch", @"branch_three" ],
+		@[ @"update-ref", @"refs/remotes/origin/branch_one", @"HEAD" ],
+		@[ @"commit", @"-q", @"--allow-empty", @"-m", @"tip" ],
+	];
+
+	for (NSArray *arguments in script) {
 		NSTask *task = [[NSTask alloc] init];
 		task.executableURL = [NSURL fileURLWithPath:@"/usr/bin/git"];
 		task.currentDirectoryURL = URL;
@@ -96,6 +119,98 @@
 	PBGitSidebarController *sidebar = self.windowController.sidebarViewController;
 
 	XCTAssertNotNil(sidebar.view.superview, @"the sidebar reached through the property is the installed one");
+}
+
+- (NSInteger)sidebarRowForRefNamed:(NSString *)refName
+{
+	NSOutlineView *sourceView = self.windowController.sidebarViewController.sourceView;
+	for (NSInteger row = 0; row < sourceView.numberOfRows; row++) {
+		PBSourceViewItem *item = [sourceView itemAtRow:row];
+		if ([item.ref.ref isEqualToString:refName])
+			return row;
+	}
+	return -1;
+}
+
+- (void)focusSidebarOnRefNamed:(NSString *)refName
+{
+	NSOutlineView *sourceView = self.windowController.sidebarViewController.sourceView;
+
+	NSInteger row = [self sidebarRowForRefNamed:refName];
+	XCTAssertNotEqual(row, -1, @"%@ has to be on screen before it can be selected", refName);
+	[sourceView selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
+
+	XCTAssertTrue([self.windowController.window makeFirstResponder:sourceView]);
+}
+
+// The commit is read straight out of the repository because the revision list
+// loads asynchronously. Its labels are the real ones: -refs comes from the
+// repository's ref table, which is what the history list draws.
+- (PBGitCommit *)commitForRefNamed:(NSString *)refName
+{
+	PBGitRepository *repository = self.windowController.repository;
+
+	GTOID *OID = [repository OIDForRef:[PBGitRef refFromString:refName]];
+	XCTAssertNotNil(OID, @"%@ has to exist in the fixture", refName);
+
+	GTCommit *gtCommit = [repository.gtRepo lookUpObjectByOID:OID objectType:GTObjectTypeCommit error:NULL];
+	return [[PBGitCommit alloc] initWithRepository:repository andCommit:gtCommit];
+}
+
+// The array controller takes its content from the revision list, which would
+// refill it from disk on its own schedule. Detaching that binding first is what
+// lets the test decide which commit is on screen.
+- (void)focusHistoryListOnRefNamed:(NSString *)refName
+{
+	PBGitHistoryController *history = self.windowController.historyViewController;
+	PBGitCommit *commit = [self commitForRefNamed:refName];
+
+	XCTAssertTrue([self.windowController.window makeFirstResponder:(NSResponder *)history.commitList]);
+
+	[history.commitController unbind:NSContentArrayBinding];
+	[history.commitController setContent:@[ commit ]];
+	[history.commitController setSelectedObjects:@[ commit ]];
+
+	XCTAssertTrue(history.singleCommitSelected);
+}
+
+// Every ref action asks -selectedRef which ref it should work on. With the
+// sidebar unreachable that question could only ever be answered by the history
+// list, so a branch picked in the sidebar named nothing at all.
+- (void)testTheFocusedSidebarNamesTheBranchItHasSelected
+{
+	XCTAssertNil(self.windowController.selectedRef, @"with neither list focused nothing is named");
+
+	[self focusSidebarOnRefNamed:@"refs/heads/branch_two"];
+
+	XCTAssertEqualObjects(self.windowController.selectedRef.ref, @"refs/heads/branch_two");
+}
+
+// A row directly under REMOTES stands for the whole remote rather than for any
+// one of its branches, and fetch and pull are offered on that.
+- (void)testTheFocusedSidebarNamesAWholeRemoteByItsOwnRef
+{
+	[self focusSidebarOnRefNamed:@"refs/remotes/origin"];
+
+	XCTAssertEqualObjects(self.windowController.selectedRef.ref, @"refs/remotes/origin");
+}
+
+// The history list keeps answering as it always has: the branch label on the
+// selected commit, when there is exactly one.
+- (void)testTheFocusedHistoryListNamesTheBranchOnItsSelectedCommit
+{
+	[self focusHistoryListOnRefNamed:@"refs/heads/branch_one"];
+
+	XCTAssertEqualObjects(self.windowController.selectedRef.ref, @"refs/heads/branch_one");
+}
+
+// Two branches sit on the root commit, so the history list cannot say which one
+// an action was meant for and names neither.
+- (void)testACommitCarryingTwoBranchesNamesNeither
+{
+	[self focusHistoryListOnRefNamed:@"refs/heads/branch_two"];
+
+	XCTAssertNil(self.windowController.selectedRef);
 }
 
 @end

--- a/GitXTests/PBGitWindowWiringTests.m
+++ b/GitXTests/PBGitWindowWiringTests.m
@@ -1,0 +1,101 @@
+//
+//  PBGitWindowWiringTests.m
+//  GitXTests
+//
+
+#import <XCTest/XCTest.h>
+#import "PBGitWindowController.h"
+#import "PBGitRepository.h"
+#import "PBGitSidebarController.h"
+
+// The window controller takes its repository from its document. A test has no
+// document, so it supplies the repository directly and lets everything else
+// run as it does in the application.
+@interface PBStubWindowController : PBGitWindowController
+@property (nonatomic, strong) PBGitRepository *stubRepository;
+@end
+
+@implementation PBStubWindowController
+
+- (PBGitRepository *)repository
+{
+	return self.stubRepository;
+}
+
+@end
+
+@interface PBGitWindowWiringTests : XCTestCase
+@property (nonatomic, strong) PBStubWindowController *windowController;
+@property (nonatomic, strong) NSURL *repositoryURL;
+@end
+
+@implementation PBGitWindowWiringTests
+
+- (NSURL *)makeRepository
+{
+	NSURL *URL = [[NSURL fileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
+	[[NSFileManager defaultManager] createDirectoryAtURL:URL withIntermediateDirectories:YES attributes:nil error:NULL];
+
+	for (NSArray *arguments in @[ @[ @"init", @"-q" ], @[ @"commit", @"-q", @"--allow-empty", @"-m", @"root" ] ]) {
+		NSTask *task = [[NSTask alloc] init];
+		task.executableURL = [NSURL fileURLWithPath:@"/usr/bin/git"];
+		task.currentDirectoryURL = URL;
+		task.arguments = arguments;
+		task.environment = @{@"GIT_AUTHOR_NAME" : @"t", @"GIT_AUTHOR_EMAIL" : @"t@t",
+							 @"GIT_COMMITTER_NAME" : @"t", @"GIT_COMMITTER_EMAIL" : @"t@t",
+							 @"PATH" : @"/usr/bin:/bin"};
+		[task launchAndReturnError:NULL];
+		[task waitUntilExit];
+	}
+
+	return URL;
+}
+
+- (void)setUp
+{
+	[super setUp];
+
+	self.repositoryURL = [self makeRepository];
+
+	NSError *error = nil;
+	PBGitRepository *repository = [[PBGitRepository alloc] initWithURL:self.repositoryURL error:&error];
+	XCTAssertNotNil(repository, @"%@", error);
+
+	self.windowController = [[PBStubWindowController alloc] init];
+	self.windowController.stubRepository = repository;
+
+	// Asking for the window loads the nib, which is what runs -windowDidLoad
+	// and builds the three view controllers
+	XCTAssertNotNil(self.windowController.window);
+}
+
+- (void)tearDown
+{
+	[self.windowController close];
+	self.windowController = nil;
+	[[NSFileManager defaultManager] removeItemAtURL:self.repositoryURL error:NULL];
+
+	[super tearDown];
+}
+
+// -sidebarViewController returned nil for years because the window controller
+// assigned the sidebar to an ivar the property does not read. Nothing crashed:
+// messaging nil is silent, so only code that needed a real object noticed.
+- (void)testTheWindowHandsOutTheControllersItBuilt
+{
+	XCTAssertNotNil(self.windowController.sidebarViewController,
+					@"the sidebar has to be reachable, or every caller silently talks to nil");
+	XCTAssertNotNil(self.windowController.historyViewController);
+	XCTAssertNotNil(self.windowController.commitViewController);
+}
+
+// The property has to hand back the same sidebar that was put on screen, not
+// some second instance.
+- (void)testTheSidebarHandedOutIsTheOneOnScreen
+{
+	PBGitSidebarController *sidebar = self.windowController.sidebarViewController;
+
+	XCTAssertNotNil(sidebar.view.superview, @"the sidebar reached through the property is the installed one");
+}
+
+@end


### PR DESCRIPTION
Selecting a branch used to fight with selecting a commit: the history-list would drag its selection back to the sidebar's branch on any update, and the sidebar would not follow a branch clicked in the history-list.

## What did not work

### Making a branch active from the history-list

**Symptom**

- Select `branch_B` in the sidebar - the history-list focuses on that branch's tip-commit (_Figure 1_)
- Click (once) the green label of `branch_C` in the history-list - the history-list focuses on that line (_Figure 2_) \
   (the sidebar does not update-back - it is still focused on `branch_B`)
- Double-click the green `branch_C` label in the history-list - `branch_C` is checked out correctly, \
   but the history-list jumps back to `branch_B`'s commit -  not the one just clicked (_Figure 3_)

**_Figure 1:_** \
<img width="596" height="302" alt="Figure-1" src="https://github.com/user-attachments/assets/d719019e-90b2-4a12-828e-b6fc922e9c86" />

**_Figure 2:_** \
<img width="599" height="296" alt="Figure-2" src="https://github.com/user-attachments/assets/5ac93340-8696-4b53-ad80-e044198c1f92" />

**_Figure 3:_** \
<img width="596" height="298" alt="Figure-3" src="https://github.com/user-attachments/assets/628f4b83-0b38-4c56-a488-874814c3f1b4" />



**Cause**

The checkout makes the list update, and every update re-asserted the tip of whatever the sidebar had selected, discarding the commit the user picked.

### Clicking a branch label

**Symptom**

Single-clicking a green (or blue) branch-label selected the row, but the sidebar stayed on the previous branch, so the two views disagreed about which branch was being looked at.

## Behavior after the fix

- Double-clicking `branch_C`'s label checks it out and the list stays on the commit that carries the label.
- In the history-list, single-clicking any branch-label (green or blue) moves the sidebar to that branch.
- Clicking a commit in the history-list and then letting anything refresh the list - \
   a fetch, a `git switch` in a terminal, the repository watcher - \
   keeps that commit selected instead of snapping to a branch tip.
- Clicking a branch in the sidebar still takes you to its tip in the history-list, \
   including a second click on the branch already selected, \
   which is now the deliberate way to get back there.

## The commits

| commit | what |
|---|---|
| Point the sidebar property at the controller that exists | Pre-existing: `sidebarViewController` has returned nil since 2018 |
| Cover the window controller wiring with a test | Guards the seam above |
| Keep the history-list selection unless a branch is picked | The jump in scenario 1 |
| Put back a selection that reading the list in again dropped | Reading the list in replaces the commit objects, dropping the selection |
| Focus the sidebar on a branch label clicked in the history-list | Scenario 2 |

The first one is worth a look on its own: \
`60d23480` (2018) added the `sidebarViewController` property and converted working code onto it, \
but named the ivar `_sidebarController` while the property synthesizes `_sidebarViewController`. \
Two ivars, one of them never assigned. \
Nothing crashed because messaging nil is silent, and the one consumer had a fallback - so \
`-selectedRef` has been quietly taking its history-list branch even when the sidebar had focus. \
That is restored here, which is a behavior change beyond the reported bug and deliberate.

## Test plan

- 31 unit tests pass, up from 27 on master. New cases cover the reselect decision, the restore after a rebuild, and that a branch change still outranks the restore.
- Each new test was checked by reverting the behavior it guards and confirming it fails:
   - dropping the outstanding-change guard
   - removing the restore
   - restoring the 2018 ivar wiring
- Every commit in the series builds on its own.
- By hand against `branch_A/B/C`:
   - both scenarios above
   - a second click on the already-selected sidebar branch
   - `git switch` in a terminal while a commit is selected,
   - an ordinary click on a history row.

**Two things to know** 

- `PBGitWindowWiringTests` loads the real window nib and creates a repository under `NSTemporaryDirectory()`, so it is the first test here that touches the filesystem and needs a window server - the nib does not survive a repository with nothing in it. \
   (CI has since run it on `macos-26`: both cases pass, at a cost of 3.8s of the suite's 5.9s, which is the price of loading a real nib and shelling out to git on a shared runner)
- `GitXTests` now links `ObjectiveGit.framework`, which it needs to construct a `GTOID`.

