### PR TITLE
Clear the mechanical AppKit deprecation warnings

### DIFF
--- a/Classes/Controllers/ApplicationController.m
+++ b/Classes/Controllers/ApplicationController.m
@@ -169,7 +169,7 @@ static OpenRecentController *recentsDialog = nil;
 	[panel setCanChooseDirectories:true];
 
 	[panel beginWithCompletionHandler:^(NSInteger result) {
-		if (result == NSFileHandlingPanelOKButton) {
+		if (result == NSModalResponseOK) {
 			PBRepositoryDocumentController *controller = [PBRepositoryDocumentController sharedDocumentController];
 			[controller openDocumentWithContentsOfURL:panel.URL
 											  display:true

--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -25,7 +25,7 @@
 
 #define FileChangesTableViewType @"GitFileChangedType"
 
-@interface PBGitCommitController () <NSTextViewDelegate, NSMenuDelegate> {
+@interface PBGitCommitController () <NSTextViewDelegate, NSMenuDelegate, NSMenuItemValidation> {
 	IBOutlet PBCommitMessageView *commitMessageView;
 
 	IBOutlet NSArrayController *unstagedFilesController;

--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -955,7 +955,7 @@
 - (BOOL)previewPanel:(id)panel handleEvent:(NSEvent *)event
 {
 	// redirect all key down events to the table view
-	if ([event type] == NSKeyDown) {
+	if ([event type] == NSEventTypeKeyDown) {
 		[fileBrowser keyDown:event];
 		return YES;
 	}

--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -33,7 +33,7 @@
 #define kHistoryDetailViewIndex 0
 #define kHistoryTreeViewIndex 1
 
-@interface PBGitHistoryController () <NSTableViewDelegate> {
+@interface PBGitHistoryController () <NSTableViewDelegate, NSMenuItemValidation> {
 	IBOutlet NSArrayController *commitController;
 	IBOutlet NSTreeController *treeController;
 	IBOutlet PBWebHistoryController *webHistoryController;

--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -29,7 +29,7 @@
 #import "PBGitStash.h"
 #import "PBGitCommit.h"
 
-@interface PBGitWindowController () {
+@interface PBGitWindowController () <NSMenuItemValidation> {
 	__weak PBViewController *contentController;
 
 	PBGitSidebarController *_sidebarViewController;

--- a/Classes/Controllers/PBHistorySearchController.m
+++ b/Classes/Controllers/PBHistorySearchController.m
@@ -496,11 +496,10 @@
 	panelRect.origin.y = windowFrame.origin.y + historyFrame.origin.y + ((historyFrame.size.height - kRewindPanelSize) / 2.0f);
 
 	NSPanel *panel = [[NSPanel alloc] initWithContentRect:panelRect
-												styleMask:NSBorderlessWindowMask
+												styleMask:NSWindowStyleMaskBorderless
 												  backing:NSBackingStoreBuffered
 													defer:YES];
 	[panel setIgnoresMouseEvents:YES];
-	[panel setOneShot:YES];
 	[panel setOpaque:NO];
 	[panel setBackgroundColor:[NSColor clearColor]];
 	[panel setHasShadow:NO];
@@ -550,7 +549,7 @@
 	NSImage *reversedRewindImage = [NSImage imageWithSize:rewindImage.size
 												  flipped:isReversed
 										   drawingHandler:^BOOL(NSRect destRect) {
-											   [rewindImage drawInRect:destRect fromRect:NSZeroRect operation:NSCompositeCopy fraction:1.0];
+											   [rewindImage drawInRect:destRect fromRect:NSZeroRect operation:NSCompositingOperationCopy fraction:1.0];
 											   return YES;
 										   }];
 	NSImageView *rewindImageView = [rewindPanel.contentView viewWithTag:kRewindPanelImageViewTag];

--- a/Classes/Controllers/PBRepositoryDocumentController.m
+++ b/Classes/Controllers/PBRepositoryDocumentController.m
@@ -36,7 +36,7 @@
 	[op setAllowsMultipleSelection:NO];
 	[op setMessage:NSLocalizedString(@"Initialize a repository here:", @"Message at the top of the repository initialisation file selection dialogue box")];
 	[op setTitle:NSLocalizedString(@"New Repository", @"Title of the repository initialisation file selection dialogue box")];
-	if ([op runModal] != NSFileHandlingPanelOKButton) {
+	if ([op runModal] != NSModalResponseOK) {
 		if (outError) {
 			*outError = [NSError errorWithDomain:NSCocoaErrorDomain code:NSUserCancelledError userInfo:nil];
 		}

--- a/Classes/Views/PBGitCommitTableViewCell.m
+++ b/Classes/Views/PBGitCommitTableViewCell.m
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle
 {
 	switch (backgroundStyle) {
-		case NSBackgroundStyleDark:
+		case NSBackgroundStyleEmphasized:
 			self.textField.textColor = NSColor.whiteColor;
 			break;
 		default:

--- a/Classes/Views/PBGitRevisionCell.m
+++ b/Classes/Views/PBGitRevisionCell.m
@@ -95,7 +95,7 @@ const BOOL SHUFFLE_COLORS = NO;
 	} else {
 		NSBezierPath *path = [NSBezierPath bezierPath];
 		[path setLineWidth:2];
-		[path setLineCapStyle:NSRoundLineCapStyle];
+		[path setLineCapStyle:NSLineCapStyleRound];
 		[path moveToPoint:source];
 		[path lineToPoint:center];
 		[path stroke];
@@ -203,7 +203,7 @@ const BOOL SHUFFLE_COLORS = NO;
 	NSMutableDictionary *attributes = [[NSMutableDictionary alloc] initWithCapacity:2];
 	NSMutableParagraphStyle *style = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
 
-	[style setAlignment:NSCenterTextAlignment];
+	[style setAlignment:NSTextAlignmentCenter];
 	[attributes setObject:style forKey:NSParagraphStyleAttributeName];
 
 	[attributes setObject:[NSFont systemFontOfSize:10] forKey:NSFontAttributeName];

--- a/Classes/Views/PBQLOutlineView.m
+++ b/Classes/Views/PBQLOutlineView.m
@@ -60,7 +60,7 @@
 
 - (NSMenu *)menuForEvent:(NSEvent *)theEvent
 {
-	if ([theEvent type] == NSRightMouseDown) {
+	if ([theEvent type] == NSEventTypeRightMouseDown) {
 		// get the current selections for the outline view.
 		NSIndexSet *selectedRowIndexes = [self selectedRowIndexes];
 

--- a/Classes/Views/PBSourceViewBadge.m
+++ b/Classes/Views/PBSourceViewBadge.m
@@ -26,7 +26,7 @@
 
 + (NSColor *)badgeColorForCell:(NSTableCellView *)cell
 {
-	if ([cell backgroundStyle] == NSBackgroundStyleDark)
+	if ([cell backgroundStyle] == NSBackgroundStyleEmphasized)
 		return [NSColor whiteColor];
 
 	if ([[cell window] isMainWindow])
@@ -38,7 +38,7 @@
 
 + (NSColor *)badgeTextColorForCell:(NSTableCellView *)cell
 {
-	if ([cell backgroundStyle] != NSBackgroundStyleDark)
+	if ([cell backgroundStyle] != NSBackgroundStyleEmphasized)
 		return [NSColor whiteColor];
 
 	if (![[cell window] isKeyWindow]) {
@@ -58,7 +58,7 @@
 	NSMutableDictionary *badgeTextAttributes = nil;
 	if (!badgeTextAttributes) {
 		NSMutableParagraphStyle *centerStyle = [[NSMutableParagraphStyle alloc] init];
-		[centerStyle setAlignment:NSCenterTextAlignment];
+		[centerStyle setAlignment:NSTextAlignmentCenter];
 
 		badgeTextAttributes = [NSMutableDictionary dictionary];
 		[badgeTextAttributes setObject:[NSFont boldSystemFontOfSize:[NSFont systemFontSize] - 2] forKey:NSFontAttributeName];

--- a/Classes/git/PBGitBinary.m
+++ b/Classes/git/PBGitBinary.m
@@ -50,7 +50,7 @@ static NSString *gitPath = nil;
 	if (!version)
 		return NO;
 
-	int c = [version compare:@"" MIN_GIT_VERSION options:NSNumericSearch];
+	NSComparisonResult c = [version compare:@"" MIN_GIT_VERSION options:NSNumericSearch];
 	if (c == NSOrderedSame || c == NSOrderedDescending) {
 		gitPath = path;
 		return YES;


### PR DESCRIPTION
Clear 17 deprecation warnings in GitX's own source by moving to the
API spellings the macOS SDK documents today, with no behaviour change.

- Swap eight renamed AppKit constants for their current names; the SDK
  declares each old name as an exact alias of the new one
  (`NSBackgroundStyleDark = NSBackgroundStyleEmphasized`, and so on),
  so every site is value-identical
- Drop the `setOneShot:` call on the search rewind panel, which the SDK
  documents as having no effect
- Adopt `NSMenuItemValidation` on the three classes implementing
  `validateMenuItem:`, which is where AppKit moved the method in
  macOS 11
- Hold the git version comparison in `PBGitBinary` in an
  `NSComparisonResult` rather than an `int`

These were picked out of a wider warning triage as the group that needs no judgement: 
every changed line is a rename or a protocol declaration.
The remaining deprecations in GitX (WebKit, pasteboard types, keyed archiving,
`NSConnection`, FSEvents) all need real decisions and are left alone.
The WebKit ones in particular belong to PR #535, 
and nothing here touches the files it changes.

## Compatibility

The deployment target is unaffected.
Every constant here is a compile-time enum value or `static const` alias,
so nothing is resolved at runtime; compiling both spellings to assembly and diffing
gives identical output.
Building with `-Werror=unguarded-availability` at a minimum of macOS 10.9
flags none of them, including the `NSMenuItemValidation` conformance.

For older toolchains, the new spellings were compile-verified against
the MacOSX 12.1, 13.3, 14.4 and 15.4 SDKs, all of which accept the full set.
That is already below the floor the project sets for itself, since
`MACOSX_DEPLOYMENT_TARGET = 13.0` rules out any SDK older than macOS 13
with or without this change.

## Test plan

- `xcodebuild build -workspace GitX.xcworkspace -scheme GitX -destination "platform=macOS,arch=arm64"`
   succeeds; 
   GitX's own warning count drops from 85 to 67
- `xcodebuild test -workspace GitX.xcworkspace -scheme GitX -only-testing:GitXTests`
   passes, 35 tests, unchanged from master
- Each replacement was checked against the SDK headers to confirm the old constant is
   declared as an alias of the new one, and compiled against the MacOSX 12.1 through 15.4 SDKs
   to confirm the new name exists there too
