### PR TITLE
Simplify building GitX outside of Xcode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@
 # runtime rejects that, leaving the app unable to load its own frameworks. So
 # `dmg` builds with the hardened runtime off and stays runnable either way,
 # while `archive` and `dmg-signed` keep it and want a real identity, which the
-# README explains how to set up. The tests need no identity at all.
+# README explains how to set up; `make Dev.xcconfig` writes one for you. The
+# tests need no identity at all.
 #
 # Override the architecture on an Intel Mac or for a cross build:
 #   make build ARCH=x86_64
@@ -47,8 +48,13 @@ XCODEBUILD := xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) ARCHS="$(ARCH
 	ui-test archive build-project app run dmg dmg-signed clean git-clean-dry-run
 
 help: ## Show this help
-	@grep -hE '^[a-z-]+:.*## ' $(MAKEFILE_LIST) \
+	@grep -hE '^[A-Za-z][A-Za-z.-]*:.*## ' $(MAKEFILE_LIST) \
 		| awk -F':.*## ' '{printf "  %-20s %s\n", $$1, $$2}'
+
+# A real file, not a phony target, so that make leaves an existing config
+# alone rather than writing over settings you may have edited by hand.
+Dev.xcconfig: ## Write the local signing settings from the keychain certificate
+	scripts/make-dev-xcconfig.sh $@
 
 git-submodule-sync: ## Check out the submodules at the revisions this tree wants
 	git submodule sync

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,126 @@
+# Common GitX developer commands. Run `make help` for the list.
+#
+# Targets deliberately mirror the steps in .github/workflows/BuildPR.yml so the
+# two stay in sync; the CI step each one matches is named below.
+# Changing a command here means changing it there too, and the other way round.
+#
+#   pre-build      "pre build"          (alias: bootstrap)
+#   unit-test      "Run unit tests"     (alias: test)
+#   ui-test        "Run tests"
+#   archive        "Build project"      (alias: build-project)
+#   dmg-signed     "Prepare artifact"
+#
+# Signing: without a Dev.xcconfig the build is signed ad-hoc, and the hardened
+# runtime rejects that, leaving the app unable to load its own frameworks. So
+# `dmg` builds with the hardened runtime off and stays runnable either way,
+# while `archive` and `dmg-signed` keep it and want a real identity, which the
+# README explains how to set up. The tests need no identity at all.
+#
+# Override the architecture on an Intel Mac or for a cross build:
+#   make build ARCH=x86_64
+
+ARCH ?= $(shell uname -m)
+
+WORKSPACE := GitX.xcworkspace
+SCHEME := GitX
+DESTINATION := platform=macOS,arch=$(ARCH)
+
+BUILD_DIR := build
+ARCHIVE := $(BUILD_DIR)/GitX.xcarchive
+APP := $(BUILD_DIR)/GitX.app
+DMG := $(BUILD_DIR)/GitX-$(ARCH).dmg
+
+# Repo the UI screenshot tests open. CI points this at a fixed snapshot so the
+# screenshots stay comparable; locally this checkout is good enough.
+GITX_SCREENSHOT_REPO ?= $(CURDIR)
+
+# Signing options for `dmg-signed`, in the format `xcodebuild -exportArchive`
+# expects. Not in the repo: create your own, or export one from Xcode.
+EXPORT_OPTIONS ?= ExportOptions.plist
+
+# Extra build settings for the archive, as `xcodebuild` NAME=VALUE arguments.
+ARCHIVE_SETTINGS ?=
+
+XCODEBUILD := xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) ARCHS="$(ARCH)"
+
+.PHONY: help git-submodule-sync pre-build bootstrap build unit-test test \
+	ui-test archive build-project app run dmg dmg-signed clean git-clean-dry-run
+
+help: ## Show this help
+	@grep -hE '^[a-z-]+:.*## ' $(MAKEFILE_LIST) \
+		| awk -F':.*## ' '{printf "  %-20s %s\n", $$1, $$2}'
+
+git-submodule-sync: ## Check out the submodules at the revisions this tree wants
+	git submodule sync
+	git submodule update --init --recursive
+
+# CI gets the submodules from actions/checkout, so its "pre build" step is
+# only the second half of this; a fresh local clone needs both.
+pre-build: git-submodule-sync ## Fetch and build the objective-git and libgit2 dependencies
+	cd External/objective-git && script/bootstrap && script/update_libgit2
+
+bootstrap: pre-build
+
+build: ## Build the app for local use
+	$(XCODEBUILD) -destination "$(DESTINATION)" build
+
+unit-test: ## Run the unit tests, needing no signing, repo or network
+	$(XCODEBUILD) -destination "$(DESTINATION)" \
+		-only-testing:GitXTests CODE_SIGN_IDENTITY="-" test
+
+test: unit-test
+
+ui-test: ## Run the UI tests that drive the app and take the screenshots
+	$(XCODEBUILD) -destination "$(DESTINATION)" \
+		-only-testing:GitXUITests CODE_SIGN_IDENTITY="-" \
+		GITX_SCREENSHOT_REPO="$(GITX_SCREENSHOT_REPO)" test
+
+archive: ## Build a release GitX.xcarchive, which the dmg targets export from
+	$(XCODEBUILD) -archivePath $(ARCHIVE) $(ARCHIVE_SETTINGS) archive
+
+build-project: archive
+
+app: archive ## Copy the app out of the archive to build/GitX.app
+	rm -rf $(APP)
+	cp -R $(ARCHIVE)/Products/Applications/GitX.app $(APP)
+
+# Runs the Debug build, not the archive: Release turns on the hardened runtime,
+# and an ad-hoc signature plus the hardened runtime leaves the app unable to
+# load its own frameworks. -n forces a new instance, since an installed GitX
+# claims the same bundle id and `open` would just bring that one to the front.
+run: build ## Open the app that was just built
+	open -n "$$($(XCODEBUILD) -showBuildSettings \
+		| awk -F' = ' '/ BUILT_PRODUCTS_DIR /{print $$2}')/GitX.app"
+
+# Drops the hardened runtime so that an ad-hoc signed image still runs; with a
+# real identity to hand, `make dmg ARCHIVE_SETTINGS=` keeps it instead.
+dmg: ARCHIVE_SETTINGS = ENABLE_HARDENED_RUNTIME=NO
+dmg: app ## Package build/GitX.app into an unsigned disk image that runs locally
+	rm -rf $(BUILD_DIR)/dist $(DMG)
+	mkdir $(BUILD_DIR)/dist
+	cp -R $(APP) $(BUILD_DIR)/dist/
+	ln -s /Applications $(BUILD_DIR)/dist/
+	hdiutil create -fs HFS+ -srcfolder $(BUILD_DIR)/dist -volname GitX $(DMG)
+	rm -rf $(BUILD_DIR)/dist
+
+dmg-signed: archive ## Package a signed disk image (needs ExportOptions.plist)
+	@test -f $(EXPORT_OPTIONS) \
+		|| { echo "No $(EXPORT_OPTIONS); see EXPORT_OPTIONS in the Makefile"; exit 1; }
+	rm -rf $(BUILD_DIR)/export $(BUILD_DIR)/dist $(DMG)
+	xcodebuild -exportArchive -archivePath $(ARCHIVE) \
+		-exportPath $(BUILD_DIR)/export -exportOptionsPlist $(EXPORT_OPTIONS)
+	mkdir $(BUILD_DIR)/dist
+	cp -R $(BUILD_DIR)/export/GitX.app $(BUILD_DIR)/dist/
+	ln -s /Applications $(BUILD_DIR)/dist/
+	hdiutil create -fs HFS+ -srcfolder $(BUILD_DIR)/dist -volname GitX $(DMG)
+	rm -rf $(BUILD_DIR)/dist
+
+clean: ## Remove the build directory and Xcode's build products
+	rm -rf $(BUILD_DIR)
+	$(XCODEBUILD) clean
+
+# Lists only, and nothing depends on it: the real `git clean -Xdf` throws away
+# every ignored file in the tree, not just the ones a build made, so deciding
+# to run it is left to you.
+git-clean-dry-run: ## List the ignored files a `git clean -Xdf` would remove
+	git clean -Xdn --exclude='!/Dev.xcconfig'

--- a/README.markdown
+++ b/README.markdown
@@ -53,8 +53,12 @@ In the steps below, we assume the certificate name to be _"Apple Development"_ b
 10. Double-click on this certificate to view its details.
 11. Copy the **Organizational Unit** value. This is your development team ID.
 
-You can also build and run on the command line. Once you've created the config file,
-you may use [the script shared here](https://github.com/gitx/gitx/discussions/366#discussion-4897466).
+You can also build and run on the command line. The `Makefile` wraps the
+commands CI uses: `make build`, `make unit-test` and `make dmg` are the common
+ones, `make help` lists them all, and `ARCH=x86_64` selects an x86 build.
+
+Once you've created the config file, you may also use
+[the script shared here](https://github.com/gitx/gitx/discussions/366#discussion-4897466).
 For x86 builds, please replace `arm64` with `x86_64`.
 
 ### Apple Silicon

--- a/README.markdown
+++ b/README.markdown
@@ -38,6 +38,9 @@ ENABLE_HARDENED_RUNTIME = YES
 Replace `YOUR_TEAM_ID` with your development team ID and `YOUR_CERT_NAME` with the name of your certificate.
 If you don't know your ID or don't have a certificate yet, follow the steps below.
 
+Once a certificate is in your keychain, `make Dev.xcconfig` writes this file
+for you, reading both values off the certificate itself.
+
 The certificate name is usually something like _Apple Development, Mac Developer, iPhone Developer, Apple Developer,_ etc.
 In the steps below, we assume the certificate name to be _"Apple Development"_ but you should use the name you see in your keychain.
 

--- a/scripts/make-dev-xcconfig.sh
+++ b/scripts/make-dev-xcconfig.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+#
+# Write a Dev.xcconfig holding the signing settings the local build needs,
+# reading them off the Apple development certificate in the keychain.
+#
+#   scripts/make-dev-xcconfig.sh [output-file]
+#
+# Set TEAM to pick between teams when the keychain holds several, and FORCE=1
+# to overwrite a config that is already there.
+#
+# Note that `security find-identity` is not used to find the certificate: it
+# pairs certificates with private keys through the old keychain API, and it
+# reports nothing for a key that Xcode filed in the data protection keychain,
+# even while xcodebuild signs with it happily.
+
+set -eu
+
+OUTPUT=${1:-Dev.xcconfig}
+TEAM=${TEAM:-}
+FORCE=${FORCE:-}
+
+if [ -e "$OUTPUT" ] && [ -z "$FORCE" ]; then
+	echo "$OUTPUT is already there; re-run with FORCE=1 to replace it." >&2
+	exit 1
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+for kind in "Apple Development" "Mac Development"; do
+	security find-certificate -a -c "$kind" -p >>"$WORK/all.pem" 2>/dev/null || true
+done
+
+if ! grep -q "BEGIN CERTIFICATE" "$WORK/all.pem" 2>/dev/null; then
+	cat >&2 <<'MESSAGE'
+No Apple Development certificate found in the keychain.
+
+You may well not need one. The tests, `make build`, `make run` and `make dmg`
+all work unsigned; a certificate only buys a build with the hardened runtime
+turned on, and `make dmg-signed`.
+
+If you do want one, the reason it is missing is one of these:
+
+  Nothing set up on this Mac yet. In Xcode: Settings > Accounts, add your
+  Apple ID if it is not listed, select your team, then Manage Certificates
+  > + > Apple Development. A certificate issued on another Mac does not
+  follow you to this one, as its private key stays in that keychain unless
+  you export it.
+
+  No developer account. A free Apple ID is enough for a development
+  certificate; a paid membership only matters for distributing the app.
+
+  An agreement waiting on you, which Xcode reports as "PLA Update
+  available". Accept it at https://developer.apple.com/account and ask for
+  the certificate again. Should Xcode keep reporting the old error, quit
+  and reopen it.
+MESSAGE
+	exit 1
+fi
+
+awk '/BEGIN CERTIFICATE/ { n++ } { print > (dir "/cert" n ".pem") }' \
+	dir="$WORK" "$WORK/all.pem"
+
+for cert in "$WORK"/cert*.pem; do
+	field() {
+		openssl x509 -in "$cert" -noout -subject -nameopt multiline 2>/dev/null \
+			| sed -n "s/^ *$1 *= *//p"
+	}
+	name=$(field commonName)
+	team=$(field organizationalUnitName)
+	[ -n "$name" ] && [ -n "$team" ] || continue
+
+	if openssl x509 -in "$cert" -noout -checkend 0 >/dev/null 2>&1; then
+		printf '%s\t%s\n' "$team" "$name" >>"$WORK/usable"
+	else
+		expiry=$(openssl x509 -in "$cert" -noout -enddate | sed 's/notAfter=//')
+		printf '%s (expired %s)\n' "$name" "$expiry" >>"$WORK/expired"
+	fi
+done
+
+# The same certificate can answer to more than one of the names looked up
+# above, and can sit in more than one keychain.
+if [ -s "$WORK/usable" ]; then sort -u "$WORK/usable" -o "$WORK/usable"; fi
+if [ -s "$WORK/expired" ]; then sort -u "$WORK/expired" -o "$WORK/expired"; fi
+
+if [ ! -s "$WORK/usable" ]; then
+	echo "Every development certificate in the keychain has expired:" >&2
+	sed 's/^/  /' "$WORK/expired" >&2
+	echo "Renew one in Xcode: Settings > Accounts > Manage Certificates." >&2
+	exit 1
+fi
+
+if [ -n "$TEAM" ]; then
+	grep "^$TEAM	" "$WORK/usable" >"$WORK/chosen" || {
+		echo "No usable certificate for team $TEAM. The keychain holds:" >&2
+		sed 's/^/  /' "$WORK/usable" >&2
+		exit 1
+	}
+else
+	cp "$WORK/usable" "$WORK/chosen"
+fi
+
+if [ "$(cut -f1 "$WORK/chosen" | sort -u | wc -l)" -gt 1 ]; then
+	echo "Certificates for more than one team are in the keychain:" >&2
+	sed 's/^/  /' "$WORK/chosen" >&2
+	echo "Name the one you want, as in: TEAM=XXXXXXXXXX $0" >&2
+	exit 1
+fi
+
+team=$(head -1 "$WORK/chosen" | cut -f1)
+name=$(head -1 "$WORK/chosen" | cut -f2)
+kind=${name%%:*}
+
+cat >"$OUTPUT" <<CONFIG
+// Written by scripts/make-dev-xcconfig.sh from $name
+//
+// Local settings, kept out of git by .gitignore. Regenerate after renewing
+// the certificate with: FORCE=1 scripts/make-dev-xcconfig.sh
+DEVELOPMENT_TEAM = $team
+CODE_SIGN_IDENTITY = $kind
+ENABLE_HARDENED_RUNTIME = YES
+CONFIG
+
+echo "Wrote $OUTPUT for team $team using $name"


### PR DESCRIPTION
Give the project one place to run what CI runs, so that a build, a test
run or a local disk image is a single command rather than a remembered
xcodebuild invocation.

- Name the targets after the BuildPR.yml steps they mirror, so that a
  change on one side is visible from the other
- Keep `dmg` runnable without a signing identity, and put the signed,
  hardened-runtime image behind `dmg-signed`
- Write Dev.xcconfig from the certificate in the keychain, naming the
  cause when there is none to read
- Leave the destructive commands out: `git-clean-dry-run` lists what a
  `git clean -Xdf` would take, and nothing runs it for you

Test plan:

- `make unit-test` passes, 35 tests on arm64
- `make dmg` builds an image whose app mounts and launches; with a
  certificate in place `make archive` produces a hardened-runtime build
  that launches too
- `make Dev.xcconfig` reproduces a hand-written config, and its failure
  paths were exercised against generated certificates: none, expired,
  and several teams