### PR TITLE
Fix the git dir lookup reading past the discovered path

### DIFF
--- a/Classes/git/PBRepositoryFinder.m
+++ b/Classes/git/PBRepositoryFinder.m
@@ -44,14 +44,15 @@
 											GIT_REPOSITORY_OPEN_CROSS_FS,
 											nil);
 
-	NSData *repoPathBuffer = nil;
+	NSString *repoPath = nil;
 	if (path_buffer.ptr) {
-		repoPathBuffer = [NSData dataWithBytes:path_buffer.ptr length:path_buffer.asize];
+		repoPath = [[NSString alloc] initWithBytes:path_buffer.ptr
+											length:path_buffer.size
+										  encoding:NSUTF8StringEncoding];
 		git_buf_free(&path_buffer);
 	}
 
-	if (gitResult == GIT_OK && repoPathBuffer.length) {
-		NSString *repoPath = [NSString stringWithUTF8String:repoPathBuffer.bytes];
+	if (gitResult == GIT_OK && repoPath.length) {
 		BOOL isDirectory;
 		if ([[NSFileManager defaultManager] fileExistsAtPath:repoPath
 												 isDirectory:&isDirectory] &&

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		63E155858B2CC783EE10F1D9 /* PBGitIndexRefreshTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */; };
 		7C41A9E2B5D340E1A7F26C08 /* PBGitHistorySelectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E9D3B41C86F42A7B10D5E33 /* PBGitHistorySelectionTests.m */; };
 		1D8C4F70A93E42B6BE7C0D95 /* PBGitWindowWiringTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */; };
+		7A1C3E5D2B8F49A0C6D14E82 /* PBRepositoryFinderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E9B0D4A18C7452FB3A0D95E /* PBRepositoryFinderTests.m */; };
 		643952771603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 643952761603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m */; };
 		6C25810B1C2720E60080A89A /* GitXCommitCopier.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C25810A1C2720E60080A89A /* GitXCommitCopier.m */; };
 		6C4855C81D57DCFC0027A7B4 /* PBTerminalUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C4855C71D57DCFC0027A7B4 /* PBTerminalUtil.m */; };
@@ -694,6 +695,7 @@
 		689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitIndexRefreshTests.m; path = GitXTests/PBGitIndexRefreshTests.m; sourceTree = "<group>"; };
 		5E9D3B41C86F42A7B10D5E33 /* PBGitHistorySelectionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitHistorySelectionTests.m; path = GitXTests/PBGitHistorySelectionTests.m; sourceTree = "<group>"; };
 		4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitWindowWiringTests.m; path = GitXTests/PBGitWindowWiringTests.m; sourceTree = "<group>"; };
+		6E9B0D4A18C7452FB3A0D95E /* PBRepositoryFinderTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBRepositoryFinderTests.m; path = GitXTests/PBRepositoryFinderTests.m; sourceTree = "<group>"; };
 		6C2581091C2720E60080A89A /* GitXCommitCopier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitXCommitCopier.h; sourceTree = "<group>"; };
 		6C25810A1C2720E60080A89A /* GitXCommitCopier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXCommitCopier.m; sourceTree = "<group>"; };
 		6C4855C61D57DCFC0027A7B4 /* PBTerminalUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBTerminalUtil.h; sourceTree = "<group>"; };
@@ -816,6 +818,7 @@
 				689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */,
 				5E9D3B41C86F42A7B10D5E33 /* PBGitHistorySelectionTests.m */,
 				4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */,
+				6E9B0D4A18C7452FB3A0D95E /* PBRepositoryFinderTests.m */,
 			);
 			name = GitXTests;
 			sourceTree = "<group>";
@@ -1753,6 +1756,7 @@
 				63E155858B2CC783EE10F1D9 /* PBGitIndexRefreshTests.m in Sources */,
 				7C41A9E2B5D340E1A7F26C08 /* PBGitHistorySelectionTests.m in Sources */,
 				1D8C4F70A93E42B6BE7C0D95 /* PBGitWindowWiringTests.m in Sources */,
+				7A1C3E5D2B8F49A0C6D14E82 /* PBRepositoryFinderTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GitXTests/PBRepositoryFinderTests.m
+++ b/GitXTests/PBRepositoryFinderTests.m
@@ -1,0 +1,96 @@
+//
+//  PBRepositoryFinderTests.m
+//  GitXTests
+//
+
+#import <XCTest/XCTest.h>
+#import "PBRepositoryFinder.h"
+
+// The finder hands libgit2 a git_buf and turns the bytes it writes back into a
+// path, so these need a repository that actually exists on disk rather than the
+// stubs the other suites here use.
+@interface PBRepositoryFinderTests : XCTestCase
+@property (nonatomic, strong) NSURL *workDir;
+@end
+
+@implementation PBRepositoryFinderTests
+
+- (void)setUp
+{
+	[super setUp];
+
+	self.workDir = [[NSURL fileURLWithPath:NSTemporaryDirectory() isDirectory:YES]
+		URLByAppendingPathComponent:[NSString stringWithFormat:@"GitXFinder-%@", NSUUID.UUID.UUIDString]
+						isDirectory:YES];
+	[NSFileManager.defaultManager createDirectoryAtURL:self.workDir
+						   withIntermediateDirectories:YES
+											attributes:nil
+												 error:NULL];
+
+	NSTask *task = [[NSTask alloc] init];
+	task.executableURL = [NSURL fileURLWithPath:@"/usr/bin/git"];
+	task.arguments = @[@"init", @"--quiet", self.workDir.path];
+	task.standardOutput = NSFileHandle.fileHandleWithNullDevice;
+	task.standardError = NSFileHandle.fileHandleWithNullDevice;
+	[task launchAndReturnError:NULL];
+	[task waitUntilExit];
+}
+
+- (void)tearDown
+{
+	[NSFileManager.defaultManager removeItemAtURL:self.workDir error:NULL];
+	self.workDir = nil;
+
+	[super tearDown];
+}
+
+- (NSString *)resolvedGitDirPath
+{
+	// The temporary directory is itself a symlink on macOS, so compare what both
+	// sides resolve to rather than the paths as spelled.
+	return [self.workDir URLByAppendingPathComponent:@".git" isDirectory:YES].URLByResolvingSymlinksInPath.path;
+}
+
+- (void)testFindsTheGitDirectoryOfARepositoryRoot
+{
+	NSURL *found = [PBRepositoryFinder gitDirForURL:self.workDir];
+
+	XCTAssertNotNil(found);
+	XCTAssertEqualObjects(found.URLByResolvingSymlinksInPath.path, self.resolvedGitDirPath);
+}
+
+- (void)testFindsTheGitDirectoryFromANestedSubdirectory
+{
+	NSURL *nested = [self.workDir URLByAppendingPathComponent:@"one/two/three" isDirectory:YES];
+	[NSFileManager.defaultManager createDirectoryAtURL:nested
+						   withIntermediateDirectories:YES
+											attributes:nil
+												 error:NULL];
+
+	NSURL *found = [PBRepositoryFinder gitDirForURL:nested];
+
+	XCTAssertNotNil(found);
+	XCTAssertEqualObjects(found.URLByResolvingSymlinksInPath.path, self.resolvedGitDirPath);
+}
+
+- (void)testReturnsNilForADirectoryOutsideAnyRepository
+{
+	NSURL *outside = [[NSURL fileURLWithPath:NSTemporaryDirectory() isDirectory:YES]
+		URLByAppendingPathComponent:[NSString stringWithFormat:@"GitXPlain-%@", NSUUID.UUID.UUIDString]
+						isDirectory:YES];
+	[NSFileManager.defaultManager createDirectoryAtURL:outside
+						   withIntermediateDirectories:YES
+											attributes:nil
+												 error:NULL];
+
+	XCTAssertNil([PBRepositoryFinder gitDirForURL:outside]);
+
+	[NSFileManager.defaultManager removeItemAtURL:outside error:NULL];
+}
+
+- (void)testReturnsNilForANonFileURL
+{
+	XCTAssertNil([PBRepositoryFinder gitDirForURL:[NSURL URLWithString:@"https://example.com/repo.git"]]);
+}
+
+@end


### PR DESCRIPTION
`git_repository_discover` fills a `git_buf` whose `asize` is the
allocated capacity, not the length of the path it wrote. `gitDirForURL:`
copied `asize` bytes, so the `NSData` it built carried the path plus
whatever happened to follow it in that allocation.

- Build the path with `initWithBytes:length:encoding:` over the
  buffer's `size`, dropping the `NSData` round-trip that existed only
  to hand a C string to `stringWithUTF8String:`
- Guard on the resulting path rather than on the allocation size.
  libgit2 documents `asize` as zero when it does not own the buffer,
  so that test passed only because `git_repository_discover` happens to
  allocate its own
- Add the first tests for `PBRepositoryFinder`: repository root, nested
  subdirectory, a directory outside any repository, and a non-file URL

Note that swapping `asize` for `size` on its own would be wrong. `size`
excludes the NUL that libgit2 writes at `ptr[size]`, so an `NSData` of
exactly `size` bytes has no terminator and `stringWithUTF8String:`
would scan past the end of it. Hence building the string from the bytes
and a length instead, which does not depend on a terminator at all.

This also unblocks a libgit2 upgrade: `git_buf.asize` was renamed
`reserved` in libgit2 1.x, and this line is the only thing in GitX that
fails to compile against it. With `gitx/objective-git#98` checked out,
GitX builds and its tests pass against libgit2 1.9.4 once this lands.

## Test plan

- `xcodebuild test -workspace GitX.xcworkspace -scheme GitX
  -only-testing:GitXTests` passes, 39 tests, up from 35
- The four new tests `git init` a repository in a temporary directory
  and resolve symlinks on both sides before comparing, since
  `NSTemporaryDirectory()` is itself a symlink
- Mutation-checked that the new tests have teeth: changing the encoding
  to `NSUTF16StringEncoding` fails both lookup tests while the two
  negative tests still pass
