### PR TITLE
Clear the deprecation warnings that change no behavior

### DIFF
--- a/Classes/Controllers/PBHistorySearchController.m
+++ b/Classes/Controllers/PBHistorySearchController.m
@@ -507,7 +507,6 @@
 
 	NSBox *box = [[NSBox alloc] initWithFrame:[[panel contentView] frame]];
 	[box setBoxType:NSBoxCustom];
-	[box setBorderType:NSLineBorder];
 	[box setFillColor:[NSColor colorWithCalibratedWhite:0.0f alpha:0.5f]];
 	[box setBorderColor:[NSColor colorWithCalibratedWhite:0.5f alpha:0.5f]];
 	[box setCornerRadius:12.0f];

--- a/Classes/PBCommitList.swift
+++ b/Classes/PBCommitList.swift
@@ -165,16 +165,16 @@ import WebKit
 
         let column = self.column(withIdentifier: NSUserInterfaceItemIdentifier("SubjectColumn"))
         guard column != -1,
-              let cell = view(atColumn: column, row: index, makeIfNecessary: false) as? PBGitRevisionCell,
-              let commit = cell.objectValue as? PBGitCommit else {
+              let cell = view(atColumn: column, row: index, makeIfNecessary: false) as? PBGitRevisionCell else {
             return nil
         }
+        let commit = cell.objectValue
 
         let point = window?.contentView?.convert(event.locationInWindow, to: cell) ?? .zero
         let i = Int(cell.indexAt(x: point.x))
         let clickedRef: PBGitRef? = (i >= 0 && i < commit.refs.count) ? commit.refs[i] as? PBGitRef : nil
 
-        let selectedCommits = controller.selectedCommits as? [PBGitCommit] ?? []
+        let selectedCommits = controller.selectedCommits
         let items: [NSMenuItem]
 
         if let clickedRef = clickedRef {

--- a/Classes/Views/PBGitRevisionRow.m
+++ b/Classes/Views/PBGitRevisionRow.m
@@ -22,11 +22,11 @@ NS_ASSUME_NONNULL_BEGIN
 	if ([self isSelected]) {
 		if ([[self window] isKeyWindow]) {
 			if ([[self window] firstResponder] == (NSTableView *)self.controller.commitList) {
-				return [NSColor alternateSelectedControlColor];
+				return [NSColor selectedContentBackgroundColor];
 			}
 			return [NSColor selectedControlColor];
 		}
-		return [NSColor secondarySelectedControlColor];
+		return [NSColor unemphasizedSelectedContentBackgroundColor];
 	}
 
 	// light blue color highlighting search results


### PR DESCRIPTION
Clear five deprecation warnings whose replacements were confirmed to
produce identical results, so nothing here can change what the app does.

- Take `selectedContentBackgroundColor` and
  `unemphasizedSelectedContentBackgroundColor` for the search result
  highlight; both measure byte-identical to the colors they replace in
  the Aqua, Dark Aqua, and high-contrast appearances
- Drop `setBorderType:` from the rewind panel's box, which is
  `NSBoxCustom` and renders pixel-identical with or without it
- Bind the clicked commit and the selected commits at their declared
  types, which the compiler already reports as always succeeding

Warnings go from 69 to 64 in GitX's own sources. The rest of the build's
warnings come from the vendored ObjectiveGit and libgit2 headers and are
not addressable from this repository.

## Test plan

- `xcodebuild test -only-testing:GitXTests` passes 39/39, unchanged
- Clean build drops exactly the five intended warnings and introduces
  none, confirmed by diffing the deduplicated warning sets
- Color equality and box rendering were checked out of band rather than
  assumed, since both would otherwise be silent visual changes
