### PR TITLE
Clear the keyed-archiver deprecation warnings

### DIFF
--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -692,7 +692,12 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray<PBChangedFile *> *files)
 	[pboard declareTypes:[NSArray arrayWithObjects:FileChangesTableViewType, NSFilenamesPboardType, nil] owner:self];
 
 	// Internal, for dragging from one tableview to the other
-	NSData *data = [NSKeyedArchiver archivedDataWithRootObject:rowIndexes];
+	NSError *error = nil;
+	NSData *data = [NSKeyedArchiver archivedDataWithRootObject:rowIndexes requiringSecureCoding:YES error:&error];
+	if (!data) {
+		PBLogError(error);
+		return NO;
+	}
 	[pboard setData:data forType:FileChangesTableViewType];
 
 	// External, to drag them to for example XCode or Textmate
@@ -728,7 +733,12 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray<PBChangedFile *> *files)
 {
 	NSPasteboard *pboard = [info draggingPasteboard];
 	NSData *rowData = [pboard dataForType:FileChangesTableViewType];
-	NSIndexSet *rowIndexes = [NSKeyedUnarchiver unarchiveObjectWithData:rowData];
+	NSError *error = nil;
+	NSIndexSet *rowIndexes = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSIndexSet class] fromData:rowData error:&error];
+	if (!rowIndexes) {
+		PBLogError(error);
+		return NO;
+	}
 
 	NSArrayController *controller = [aTableView tag] == 0 ? stagedFilesController : unstagedFilesController;
 	NSArray *files = [[controller arrangedObjects] objectsAtIndexes:rowIndexes];

--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -738,7 +738,12 @@
 		if ([[[self.repository headRef] ref] isEqualToRef:ref])
 			return NO;
 
-		NSData *data = [NSKeyedArchiver archivedDataWithRootObject:[NSArray arrayWithObjects:[NSNumber numberWithInteger:row], [NSNumber numberWithInt:index], NULL]];
+		NSError *error = nil;
+		NSData *data = [NSKeyedArchiver archivedDataWithRootObject:[NSArray arrayWithObjects:[NSNumber numberWithInteger:row], [NSNumber numberWithInt:index], NULL] requiringSecureCoding:YES error:&error];
+		if (!data) {
+			PBLogError(error);
+			return NO;
+		}
 		[pboard declareTypes:[NSArray arrayWithObject:@"PBGitRef"] owner:self];
 		[pboard setData:data forType:@"PBGitRef"];
 	} else {
@@ -785,7 +790,12 @@
 	if (!data)
 		return NO;
 
-	NSArray *numbers = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+	NSError *error = nil;
+	NSArray *numbers = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithObjects:[NSArray class], [NSNumber class], nil] fromData:data error:&error];
+	if (numbers.count < 2) {
+		PBLogError(error);
+		return NO;
+	}
 	int oldRow = [[numbers objectAtIndex:0] intValue];
 	if (oldRow == row)
 		return NO;


### PR DESCRIPTION
Move the drag-and-drop pasteboard payloads onto the secure-coding keyed
archiver API that replaced the entry points deprecated in 10.14, and
handle the failure the replacement reports rather than letting it fall-through.

- Archive the file-change and ref drags requiring secure coding
- Decode them through `unarchivedObjectOfClass(es):fromData:error:`
- Name `NSNumber` alongside `NSArray` so the ref payload decodes fully
- Refuse the drag when encoding or decoding fails

The last point matters beyond the warnings.
The previous API raised on malformed data, while the replacement returns `nil`, and
neither drop handler was written for a `nil` payload.
On the file-change side that would have reached `objectsAtIndexes:` with `nil` - and crashed;
on the ref side it was quieter and worse, since messaging `nil` yields an index of 0 and
the drop would have moved the wrong ref.
Both paths now log and return `NO`.

Warnings go from 69 to 65 in GitX's own sources.
The remainder come from the vendored **_ObjectiveGit_** and **_libgit2_** headers and
are not addressable from this repository.

## Test plan

- `xcodebuild test -only-testing:GitXTests` passes 39/39 - unchanged
- Clean build drops exactly the four intended warnings and adds none,
  (confirmed by diffing the deduplicated warning sets)
- Exercised in a running build against a scratch repository:
  dragging a file from _unstaged_ to _staged_ and back,
  dragging a multiple-file selection, and
  dragging a branch label onto another commit,
  (which the `reflog` records as the expected ref update)
- The round trip was also checked directly for both payload shapes,
  including the index set class a real table-view supplies, and a
  wrong allowed class was confirmed to return `nil` with an error
  rather than a partly-decoded object
