### PR TITLE
Clear the NSWorkspace and open panel deprecation warnings

### DIFF
--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -440,7 +440,7 @@
 		return;
 	PBGitTree *tree = [selectedFiles objectAtIndex:0];
 	NSString *name = [tree tmpFileNameForContents];
-	[[NSWorkspace sharedWorkspace] openFile:name];
+	[[NSWorkspace sharedWorkspace] openURL:[NSURL fileURLWithPath:name]];
 }
 
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem

--- a/Classes/Controllers/PBGitWindowController.m
+++ b/Classes/Controllers/PBGitWindowController.m
@@ -268,11 +268,9 @@
 		}
 	}
 
-	[[NSWorkspace sharedWorkspace] openURLs:nonSubmoduleURLs
-					withAppBundleIdentifier:nil
-									options:0
-			 additionalEventParamDescriptor:nil
-						  launchIdentifiers:NULL];
+	for (NSURL *fileURL in nonSubmoduleURLs) {
+		[[NSWorkspace sharedWorkspace] openURL:fileURL];
+	}
 }
 
 - (void)revealURLsInFinder:(NSArray<NSURL *> *)fileURLs

--- a/Classes/Controllers/PBRepositoryDocumentController.m
+++ b/Classes/Controllers/PBRepositoryDocumentController.m
@@ -12,6 +12,7 @@
 #import "PBGitBinary.h"
 
 #import <ObjectiveGit/GTRepository.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 @implementation PBRepositoryDocumentController
 // This method is overridden to configure the open panel to only allow
@@ -20,7 +21,7 @@
 {
 	[openPanel setCanChooseFiles:YES];
 	[openPanel setCanChooseDirectories:YES];
-	[openPanel setAllowedFileTypes:[NSArray arrayWithObject:@"git"]];
+	[openPanel setAllowedContentTypes:[NSArray arrayWithObject:[UTType typeWithFilenameExtension:@"git"]]];
 
 	NSModalResponse response = [openPanel runModal];
 


### PR DESCRIPTION
Replace the file-opening and open-panel calls that macOS deprecated in
11.0 and 12.0 with their documented successors.

- Open the selected file through `openURL:`
- Open the repository URLs one at a time, as the batch call has no
  successor that keeps each URL on its own default application
- Filter the open panel by content type instead of file extension

Warnings go from 64 to 61 in GitX's own sources.
The remainder come from the vendored **_ObjectiveGit_** and **_libgit2_** headers and
are not addressable from this repository.

The second point is the only real behavior change here, so it was
checked by hand rather than argued from the documentation.
Opening a multiple-file selection whose files belong to three different
applications opens all three, and does so indistinguishably from the
batch call it replaces.

## Test plan

- `xcodebuild test -only-testing:GitXTests` passes 39/39 - unchanged
- Clean build drops exactly the three intended warnings and adds none
- Opened a repository through **_File > Open_**, which exercises the content
  type filter, and confirmed the type built for the `git` extension is never `nil`,
  since a `nil` entry would throw as the panel opens
- Opened a three-file selection covering three different default
  applications, and compared the result against a build of master
