### PR TITLE
Fix the context menu doing nothing for staged files

### DIFF
--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -297,7 +297,7 @@
 
 	if (![sender isKindOfClass:[NSMenuItem class]]) return nil;
 
-	NSTableView *table = (sender == stagedTable.menu ? stagedTable : unstagedTable);
+	NSTableView *table = (((NSMenuItem *)sender).menu == stagedTable.menu ? stagedTable : unstagedTable);
 	NSArrayController *controller = (table.tag == 0 ? unstagedFilesController : stagedFilesController);
 	return controller.selectedObjects;
 }

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		7C41A9E2B5D340E1A7F26C08 /* PBGitHistorySelectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E9D3B41C86F42A7B10D5E33 /* PBGitHistorySelectionTests.m */; };
 		1D8C4F70A93E42B6BE7C0D95 /* PBGitWindowWiringTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */; };
 		7A1C3E5D2B8F49A0C6D14E82 /* PBRepositoryFinderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E9B0D4A18C7452FB3A0D95E /* PBRepositoryFinderTests.m */; };
+		4C7F2A9E5D1B48A3E602F7C1 /* PBGitCommitFileSelectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B8E1D6C0A9F42B7D51C8E30 /* PBGitCommitFileSelectionTests.m */; };
 		643952771603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 643952761603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m */; };
 		6C25810B1C2720E60080A89A /* GitXCommitCopier.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C25810A1C2720E60080A89A /* GitXCommitCopier.m */; };
 		6C4855C81D57DCFC0027A7B4 /* PBTerminalUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C4855C71D57DCFC0027A7B4 /* PBTerminalUtil.m */; };
@@ -696,6 +697,7 @@
 		5E9D3B41C86F42A7B10D5E33 /* PBGitHistorySelectionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitHistorySelectionTests.m; path = GitXTests/PBGitHistorySelectionTests.m; sourceTree = "<group>"; };
 		4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitWindowWiringTests.m; path = GitXTests/PBGitWindowWiringTests.m; sourceTree = "<group>"; };
 		6E9B0D4A18C7452FB3A0D95E /* PBRepositoryFinderTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBRepositoryFinderTests.m; path = GitXTests/PBRepositoryFinderTests.m; sourceTree = "<group>"; };
+		3B8E1D6C0A9F42B7D51C8E30 /* PBGitCommitFileSelectionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitCommitFileSelectionTests.m; path = GitXTests/PBGitCommitFileSelectionTests.m; sourceTree = "<group>"; };
 		6C2581091C2720E60080A89A /* GitXCommitCopier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitXCommitCopier.h; sourceTree = "<group>"; };
 		6C25810A1C2720E60080A89A /* GitXCommitCopier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXCommitCopier.m; sourceTree = "<group>"; };
 		6C4855C61D57DCFC0027A7B4 /* PBTerminalUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBTerminalUtil.h; sourceTree = "<group>"; };
@@ -819,6 +821,7 @@
 				5E9D3B41C86F42A7B10D5E33 /* PBGitHistorySelectionTests.m */,
 				4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */,
 				6E9B0D4A18C7452FB3A0D95E /* PBRepositoryFinderTests.m */,
+				3B8E1D6C0A9F42B7D51C8E30 /* PBGitCommitFileSelectionTests.m */,
 			);
 			name = GitXTests;
 			sourceTree = "<group>";
@@ -1757,6 +1760,7 @@
 				7C41A9E2B5D340E1A7F26C08 /* PBGitHistorySelectionTests.m in Sources */,
 				1D8C4F70A93E42B6BE7C0D95 /* PBGitWindowWiringTests.m in Sources */,
 				7A1C3E5D2B8F49A0C6D14E82 /* PBRepositoryFinderTests.m in Sources */,
+				4C7F2A9E5D1B48A3E602F7C1 /* PBGitCommitFileSelectionTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GitXTests/PBGitCommitFileSelectionTests.m
+++ b/GitXTests/PBGitCommitFileSelectionTests.m
@@ -1,0 +1,90 @@
+//
+//  PBGitCommitFileSelectionTests.m
+//  GitXTests
+//
+
+#import <XCTest/XCTest.h>
+#import "PBGitCommitController.h"
+#import "PBChangedFile.h"
+
+// The file actions ask the commit controller which of its two tables a menu
+// item came from before reading a selection, and that seam is private to the
+// class, so the test names it the way the other suites here do.
+@interface PBGitCommitController (PBFileSelectionTests)
+- (NSArray<PBChangedFile *> *)selectedFilesForSender:(id)sender;
+@end
+
+@interface PBGitCommitFileSelectionTests : XCTestCase
+@property (nonatomic, strong) PBGitCommitController *controller;
+@property (nonatomic, strong) NSTableView *unstagedTable;
+@property (nonatomic, strong) NSTableView *stagedTable;
+@property (nonatomic, strong) PBChangedFile *unstagedFile;
+@property (nonatomic, strong) PBChangedFile *stagedFile;
+@end
+
+@implementation PBGitCommitFileSelectionTests
+
+- (void)setUp
+{
+	[super setUp];
+
+	// The controller holds its tables weakly, so the test owns them instead.
+	self.unstagedTable = [[NSTableView alloc] initWithFrame:NSZeroRect];
+	self.unstagedTable.tag = 0;
+	self.unstagedTable.menu = [[NSMenu alloc] initWithTitle:@"Unstaged"];
+
+	self.stagedTable = [[NSTableView alloc] initWithFrame:NSZeroRect];
+	self.stagedTable.tag = 1;
+	self.stagedTable.menu = [[NSMenu alloc] initWithTitle:@"Staged"];
+
+	self.unstagedFile = [[PBChangedFile alloc] initWithPath:@"unstaged.txt"];
+	self.stagedFile = [[PBChangedFile alloc] initWithPath:@"staged.txt"];
+
+	NSArrayController *unstagedFiles = [[NSArrayController alloc] initWithContent:@[ self.unstagedFile ]];
+	[unstagedFiles setSelectedObjects:@[ self.unstagedFile ]];
+
+	NSArrayController *stagedFiles = [[NSArrayController alloc] initWithContent:@[ self.stagedFile ]];
+	[stagedFiles setSelectedObjects:@[ self.stagedFile ]];
+
+	self.controller = [[PBGitCommitController alloc] init];
+	[self.controller setValue:self.unstagedTable forKey:@"unstagedTable"];
+	[self.controller setValue:self.stagedTable forKey:@"stagedTable"];
+	[self.controller setValue:unstagedFiles forKey:@"unstagedFilesController"];
+	[self.controller setValue:stagedFiles forKey:@"stagedFilesController"];
+}
+
+- (void)tearDown
+{
+	self.controller = nil;
+	self.stagedTable = nil;
+	self.unstagedTable = nil;
+	self.stagedFile = nil;
+	self.unstagedFile = nil;
+
+	[super tearDown];
+}
+
+- (NSMenuItem *)itemInMenu:(NSMenu *)menu
+{
+	NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:@"Open"
+												  action:@selector(openFiles:)
+										   keyEquivalent:@""];
+	[menu addItem:item];
+	return item;
+}
+
+- (void)testTakesTheStagedSelectionForTheStagedTablesMenu
+{
+	NSArray<PBChangedFile *> *files = [self.controller selectedFilesForSender:[self itemInMenu:self.stagedTable.menu]];
+
+	XCTAssertEqualObjects(files, @[ self.stagedFile ]);
+}
+
+- (void)testTakesTheUnstagedSelectionForTheUnstagedTablesMenu
+{
+	NSArray<PBChangedFile *> *files = [self.controller selectedFilesForSender:[self itemInMenu:self.unstagedTable.menu]];
+
+	XCTAssertEqualObjects(files, @[ self.unstagedFile ]);
+}
+
+@end


### PR DESCRIPTION
Read the selection from the table whose contextual menu was used, so
the file actions act on the files the menu was opened on.

- Compare the menu item's menu against the staged table's menu, which
  is the comparison the menu validation already makes
- Cover the mapping from either table's menu with tests

The controller copies the unstaged table's menu when the view loads so
the two tables can be told apart by identity, and the menu validation
relies on exactly that.
The sender lookup never did, comparing the menu-item itself against a menu,
which is never equal, so every lookup resolved to the unstaged table.

Opening a staged selection from its contextual menu therefore did nothing at all,
while the menu went on offering the item and naming the files correctly, since
the title is built by the validation that gets the comparison right.
Revealing a staged selection in Finder was silently broken the same way.
The two remaining actions that share the lookup, moving to trash and ignoring,
are already hidden or disabled for the staged table, so neither was reachable.

## Supporting Images

### Context-menu

The option is available for staged files, but does not work

<img width="664" height="302" alt="image" src="https://github.com/user-attachments/assets/95feffc8-f940-4719-911d-4925fc894ed4" />


### Top-menu

The option is grayed-out when staged files are selected

<img width="242" height="310" alt="image" src="https://github.com/user-attachments/assets/be5ee6e6-fff4-46ba-a179-00eb318a5e2f" />


## Test plan

- New `PBGitCommitFileSelectionTests` covers both tables; the staged
  case fails before this change and passes after, and the unstaged
  case passes either way
- `xcodebuild test -only-testing:GitXTests` passes 41/41
