### PR TITLE
Fix copying a patch crashing when a commit has none

### DIFF
--- a/Classes/Util/GitXCommitCopier.m
+++ b/Classes/Util/GitXCommitCopier.m
@@ -58,12 +58,14 @@
 
 #pragma mark Helpers
 
-+ (NSArray<NSString *> *)transformCommits:(NSArray<PBGitCommit *> *)commits with:(NSString * (^)(PBGitCommit *commit))transformer
++ (NSArray<NSString *> *)transformCommits:(NSArray<PBGitCommit *> *)commits with:(NSString *_Nullable (^)(PBGitCommit *commit))transformer
 {
 	NSMutableArray *strings = [NSMutableArray arrayWithCapacity:commits.count];
 	[commits enumerateObjectsWithOptions:NSEnumerationReverse
 							  usingBlock:^(PBGitCommit *_Nonnull commit, NSUInteger idx, BOOL *_Nonnull stop) {
-								  [strings addObject:transformer(commit)];
+								  NSString *string = transformer(commit);
+								  if (string)
+									  [strings addObject:string];
 							  }];
 
 	return strings;

--- a/Classes/git/PBGitCommit.h
+++ b/Classes/git/PBGitCommit.h
@@ -35,7 +35,7 @@ extern NSString *const kGitXCommitType;
 @property (nonatomic, strong, readonly) NSString *committerEmail;
 @property (nonatomic, strong, readonly) NSString *committerDate;
 @property (nonatomic, strong, readonly) NSString *details;
-@property (nonatomic, strong, readonly) NSString *patch;
+@property (nonatomic, strong, readonly, nullable) NSString *patch;
 @property (nonatomic, strong, readonly) NSString *SHA;
 @property (nonatomic, strong, readonly, nullable) NSString *SVNRevision;
 

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		1D8C4F70A93E42B6BE7C0D95 /* PBGitWindowWiringTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */; };
 		7A1C3E5D2B8F49A0C6D14E82 /* PBRepositoryFinderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E9B0D4A18C7452FB3A0D95E /* PBRepositoryFinderTests.m */; };
 		4C7F2A9E5D1B48A3E602F7C1 /* PBGitCommitFileSelectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B8E1D6C0A9F42B7D51C8E30 /* PBGitCommitFileSelectionTests.m */; };
+		5D3A8C1F7E2B49D0A83C6F41 /* GitXCommitCopierTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F6B9E0D4C8A47135BE2D90A /* GitXCommitCopierTests.m */; };
 		643952771603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 643952761603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m */; };
 		6C25810B1C2720E60080A89A /* GitXCommitCopier.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C25810A1C2720E60080A89A /* GitXCommitCopier.m */; };
 		6C4855C81D57DCFC0027A7B4 /* PBTerminalUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C4855C71D57DCFC0027A7B4 /* PBTerminalUtil.m */; };
@@ -698,6 +699,7 @@
 		4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitWindowWiringTests.m; path = GitXTests/PBGitWindowWiringTests.m; sourceTree = "<group>"; };
 		6E9B0D4A18C7452FB3A0D95E /* PBRepositoryFinderTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBRepositoryFinderTests.m; path = GitXTests/PBRepositoryFinderTests.m; sourceTree = "<group>"; };
 		3B8E1D6C0A9F42B7D51C8E30 /* PBGitCommitFileSelectionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitCommitFileSelectionTests.m; path = GitXTests/PBGitCommitFileSelectionTests.m; sourceTree = "<group>"; };
+		2F6B9E0D4C8A47135BE2D90A /* GitXCommitCopierTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = GitXCommitCopierTests.m; path = GitXTests/GitXCommitCopierTests.m; sourceTree = "<group>"; };
 		6C2581091C2720E60080A89A /* GitXCommitCopier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitXCommitCopier.h; sourceTree = "<group>"; };
 		6C25810A1C2720E60080A89A /* GitXCommitCopier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXCommitCopier.m; sourceTree = "<group>"; };
 		6C4855C61D57DCFC0027A7B4 /* PBTerminalUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBTerminalUtil.h; sourceTree = "<group>"; };
@@ -822,6 +824,7 @@
 				4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */,
 				6E9B0D4A18C7452FB3A0D95E /* PBRepositoryFinderTests.m */,
 				3B8E1D6C0A9F42B7D51C8E30 /* PBGitCommitFileSelectionTests.m */,
+				2F6B9E0D4C8A47135BE2D90A /* GitXCommitCopierTests.m */,
 			);
 			name = GitXTests;
 			sourceTree = "<group>";
@@ -1761,6 +1764,7 @@
 				1D8C4F70A93E42B6BE7C0D95 /* PBGitWindowWiringTests.m in Sources */,
 				7A1C3E5D2B8F49A0C6D14E82 /* PBRepositoryFinderTests.m in Sources */,
 				4C7F2A9E5D1B48A3E602F7C1 /* PBGitCommitFileSelectionTests.m in Sources */,
+				5D3A8C1F7E2B49D0A83C6F41 /* GitXCommitCopierTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GitXTests/GitXCommitCopierTests.m
+++ b/GitXTests/GitXCommitCopierTests.m
@@ -1,0 +1,36 @@
+//
+//  GitXCommitCopierTests.m
+//  GitXTests
+//
+
+#import <XCTest/XCTest.h>
+#import "GitXCommitCopier.h"
+#import "PBGitCommit.h"
+
+// A commit that cannot produce a patch, which is what the copier is handed
+// whenever the format-patch task fails for the selected commit.
+@interface PBPatchlessCommit : PBGitCommit
+@end
+
+@implementation PBPatchlessCommit
+
+- (NSString *)patch
+{
+	return nil;
+}
+
+@end
+
+@interface GitXCommitCopierTests : XCTestCase
+@end
+
+@implementation GitXCommitCopierTests
+
+- (void)testCopiesTheCommitsWhosePatchIsMissingWithoutRaising
+{
+	PBPatchlessCommit *commit = [[PBPatchlessCommit alloc] init];
+
+	XCTAssertNoThrow([GitXCommitCopier toPatch:@[ commit ]]);
+}
+
+@end


### PR DESCRIPTION
Leave out the commits that cannot produce a patch instead of inserting
their missing patch into the array being joined.

- Declare the patch as absent, which is what it is once the
  format-patch task fails
- Skip the commits the transformer has nothing to say about

Copy Patch asks each selected commit for its patch and collects the
results. The property was declared as always present, so the failure
the getter already handled and logged reached the array as nil and
raised, taking down the application rather than copying the commits
that did produce a patch.

Test plan:

- `GitXCommitCopierTests` reproduces the crash with a commit whose
  patch is absent; it raises `NSInvalidArgumentException` before the
  fix and passes after
- `xcodebuild test -only-testing:GitXTests` is green, 42/42
- The build stays clean and drops one analyzer finding

