### PR TITLE
Clear the file name pasteboard deprecation warnings

### DIFF
--- a/Classes/Controllers/PBGitCommitController.m
+++ b/Classes/Controllers/PBGitCommitController.m
@@ -23,7 +23,7 @@
 #define kNotificationDictionaryDescriptionKey @"description"
 #define kNotificationDictionaryMessageKey @"message"
 
-#define FileChangesTableViewType @"GitFileChangedType"
+#define FileChangesTableViewType @"net.phere.GitX.changed-file"
 
 @interface PBGitCommitController () <NSTextViewDelegate, NSMenuDelegate, NSMenuItemValidation> {
 	IBOutlet PBCommitMessageView *commitMessageView;
@@ -686,32 +686,25 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray<PBChangedFile *> *files)
 	}
 }
 
-- (BOOL)tableView:(NSTableView *)tv writeRowsWithIndexes:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard
+- (id<NSPasteboardWriting>)tableView:(NSTableView *)tv pasteboardWriterForRow:(NSInteger)row
 {
-	// Copy the row numbers to the pasteboard.
-	[pboard declareTypes:[NSArray arrayWithObjects:FileChangesTableViewType, NSFilenamesPboardType, nil] owner:self];
+	NSArrayController *controller = [tv tag] == 0 ? unstagedFilesController : stagedFilesController;
+	NSArray *files = [controller arrangedObjects];
+	if (row < 0 || row >= (NSInteger)files.count)
+		return nil;
+
+	NSPasteboardItem *item = [[NSPasteboardItem alloc] init];
 
 	// Internal, for dragging from one tableview to the other
-	NSError *error = nil;
-	NSData *data = [NSKeyedArchiver archivedDataWithRootObject:rowIndexes requiringSecureCoding:YES error:&error];
-	if (!data) {
-		PBLogError(error);
-		return NO;
-	}
-	[pboard setData:data forType:FileChangesTableViewType];
+	[item setString:[@(row) stringValue] forType:FileChangesTableViewType];
 
 	// External, to drag them to for example XCode or Textmate
-	NSArrayController *controller = [tv tag] == 0 ? unstagedFilesController : stagedFilesController;
-	NSArray *files = [controller.arrangedObjects objectsAtIndexes:rowIndexes];
-	NSURL *workingDirectoryURL = self.repository.workingDirectoryURL;
+	PBChangedFile *file = [files objectAtIndex:row];
+	NSURL *fileURL = [self.repository.workingDirectoryURL URLByAppendingPathComponent:file.path];
+	if (fileURL)
+		[item setString:fileURL.absoluteString forType:NSPasteboardTypeFileURL];
 
-	NSMutableArray<NSString *> *paths = [NSMutableArray arrayWithCapacity:rowIndexes.count];
-	for (PBChangedFile *file in files) {
-		[paths addObject:[[workingDirectoryURL URLByAppendingPathComponent:file.path] path]];
-	}
-	[pboard setPropertyList:paths forType:NSFilenamesPboardType];
-
-	return YES;
+	return item;
 }
 
 - (NSDragOperation)tableView:(NSTableView *)tableView
@@ -732,13 +725,16 @@ BOOL shouldTrashInsteadOfDiscardAnyFileIn(NSArray<PBChangedFile *> *files)
 	dropOperation:(NSTableViewDropOperation)operation
 {
 	NSPasteboard *pboard = [info draggingPasteboard];
-	NSData *rowData = [pboard dataForType:FileChangesTableViewType];
-	NSError *error = nil;
-	NSIndexSet *rowIndexes = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSIndexSet class] fromData:rowData error:&error];
-	if (!rowIndexes) {
-		PBLogError(error);
-		return NO;
+
+	NSMutableIndexSet *rowIndexes = [NSMutableIndexSet indexSet];
+	for (NSPasteboardItem *item in pboard.pasteboardItems) {
+		NSString *draggedRow = [item stringForType:FileChangesTableViewType];
+		if (draggedRow)
+			[rowIndexes addIndex:draggedRow.integerValue];
 	}
+
+	if (!rowIndexes.count)
+		return NO;
 
 	NSArrayController *controller = [aTableView tag] == 0 ? stagedFilesController : unstagedFilesController;
 	NSArray *files = [[controller arrangedObjects] objectsAtIndexes:rowIndexes];

--- a/Classes/Views/PBCommitMessageView.m
+++ b/Classes/Views/PBCommitMessageView.m
@@ -66,12 +66,18 @@
 {
 	NSPasteboard *pboard = [sender draggingPasteboard];
 
-	if ([[pboard types] containsObject:NSFilenamesPboardType]) {
-		NSArray *filenames = [pboard propertyListForType:NSFilenamesPboardType];
+	NSDictionary *options = @{NSPasteboardURLReadingFileURLsOnlyKey : @YES};
+	NSArray<NSURL *> *fileURLs = [pboard readObjectsForClasses:@[ [NSURL class] ] options:options];
+
+	if (fileURLs.count) {
 		NSString *baseDir = [self.repository.workingDirectory stringByAppendingString:@"/"];
 		if (baseDir) {
 			NSMutableArray *relativeNames = [NSMutableArray new];
-			for (NSString *filename in filenames) {
+			for (NSURL *fileURL in fileURLs) {
+				NSString *filename = fileURL.path;
+				if (!filename)
+					continue;
+
 				if ([filename hasPrefix:baseDir]) {
 					NSString *relativeName = [filename substringFromIndex:(baseDir.length)];
 					if (relativeName.length) {

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		7A1C3E5D2B8F49A0C6D14E82 /* PBRepositoryFinderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E9B0D4A18C7452FB3A0D95E /* PBRepositoryFinderTests.m */; };
 		4C7F2A9E5D1B48A3E602F7C1 /* PBGitCommitFileSelectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B8E1D6C0A9F42B7D51C8E30 /* PBGitCommitFileSelectionTests.m */; };
 		5D3A8C1F7E2B49D0A83C6F41 /* GitXCommitCopierTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F6B9E0D4C8A47135BE2D90A /* GitXCommitCopierTests.m */; };
+		8A2D5F31C64B47E09D1A3B72 /* PBGitCommitFileDragTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E7C1B90D53A428FB60E9C15 /* PBGitCommitFileDragTests.m */; };
 		643952771603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 643952761603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m */; };
 		6C25810B1C2720E60080A89A /* GitXCommitCopier.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C25810A1C2720E60080A89A /* GitXCommitCopier.m */; };
 		6C4855C81D57DCFC0027A7B4 /* PBTerminalUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C4855C71D57DCFC0027A7B4 /* PBTerminalUtil.m */; };
@@ -700,6 +701,7 @@
 		6E9B0D4A18C7452FB3A0D95E /* PBRepositoryFinderTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBRepositoryFinderTests.m; path = GitXTests/PBRepositoryFinderTests.m; sourceTree = "<group>"; };
 		3B8E1D6C0A9F42B7D51C8E30 /* PBGitCommitFileSelectionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitCommitFileSelectionTests.m; path = GitXTests/PBGitCommitFileSelectionTests.m; sourceTree = "<group>"; };
 		2F6B9E0D4C8A47135BE2D90A /* GitXCommitCopierTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = GitXCommitCopierTests.m; path = GitXTests/GitXCommitCopierTests.m; sourceTree = "<group>"; };
+		4E7C1B90D53A428FB60E9C15 /* PBGitCommitFileDragTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitCommitFileDragTests.m; path = GitXTests/PBGitCommitFileDragTests.m; sourceTree = "<group>"; };
 		6C2581091C2720E60080A89A /* GitXCommitCopier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitXCommitCopier.h; sourceTree = "<group>"; };
 		6C25810A1C2720E60080A89A /* GitXCommitCopier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXCommitCopier.m; sourceTree = "<group>"; };
 		6C4855C61D57DCFC0027A7B4 /* PBTerminalUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBTerminalUtil.h; sourceTree = "<group>"; };
@@ -825,6 +827,7 @@
 				6E9B0D4A18C7452FB3A0D95E /* PBRepositoryFinderTests.m */,
 				3B8E1D6C0A9F42B7D51C8E30 /* PBGitCommitFileSelectionTests.m */,
 				2F6B9E0D4C8A47135BE2D90A /* GitXCommitCopierTests.m */,
+				4E7C1B90D53A428FB60E9C15 /* PBGitCommitFileDragTests.m */,
 			);
 			name = GitXTests;
 			sourceTree = "<group>";
@@ -1765,6 +1768,7 @@
 				7A1C3E5D2B8F49A0C6D14E82 /* PBRepositoryFinderTests.m in Sources */,
 				4C7F2A9E5D1B48A3E602F7C1 /* PBGitCommitFileSelectionTests.m in Sources */,
 				5D3A8C1F7E2B49D0A83C6F41 /* GitXCommitCopierTests.m in Sources */,
+				8A2D5F31C64B47E09D1A3B72 /* PBGitCommitFileDragTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GitXTests/PBGitCommitFileDragTests.m
+++ b/GitXTests/PBGitCommitFileDragTests.m
@@ -1,0 +1,138 @@
+//
+//  PBGitCommitFileDragTests.m
+//  GitXTests
+//
+
+#import <XCTest/XCTest.h>
+#import "PBGitCommitController.h"
+#import "PBGitRepository.h"
+#import "PBChangedFile.h"
+
+// The drag payload the two tables exchange between themselves, named in
+// PBGitCommitController.m and not exported from it.
+static NSString *const PBFileChangesTableViewType = @"net.phere.GitX.changed-file";
+
+// -[PBGitRepository workingDirectoryURL] asks libgit2 for the checkout, so
+// the test hands the controller a repository that answers on its own.
+@interface PBFixedDirectoryRepository : PBGitRepository
+@end
+
+@implementation PBFixedDirectoryRepository
+- (NSURL *)workingDirectoryURL
+{
+	return [NSURL fileURLWithPath:@"/gitx-drag-tests" isDirectory:YES];
+}
+@end
+
+// The table asks the commit controller for one pasteboard writer per dragged
+// row through a data source method the class does not publish, so the test
+// names it the way the other suites here do.
+@interface PBGitCommitController (PBFileDragTests)
+- (id<NSPasteboardWriting>)tableView:(NSTableView *)tv pasteboardWriterForRow:(NSInteger)row;
+@end
+
+@interface PBGitCommitFileDragTests : XCTestCase
+@property (nonatomic, strong) PBGitCommitController *controller;
+@property (nonatomic, strong) PBGitRepository *repository;
+@property (nonatomic, strong) NSTableView *unstagedTable;
+@property (nonatomic, strong) NSPasteboard *pasteboard;
+@end
+
+@implementation PBGitCommitFileDragTests
+
+- (void)setUp
+{
+	[super setUp];
+
+	// The controller holds its table and its repository weakly, so the test
+	// owns them instead.
+	self.unstagedTable = [[NSTableView alloc] initWithFrame:NSZeroRect];
+	self.unstagedTable.tag = 0;
+
+	self.repository = [[PBFixedDirectoryRepository alloc] init];
+
+	NSArrayController *unstagedFiles = [[NSArrayController alloc] initWithContent:@[
+		[[PBChangedFile alloc] initWithPath:@"first.txt"],
+		[[PBChangedFile alloc] initWithPath:@"second.txt"]
+	]];
+
+	self.controller = [[PBGitCommitController alloc] init];
+	[self.controller setValue:self.repository forKey:@"repository"];
+	[self.controller setValue:self.unstagedTable forKey:@"unstagedTable"];
+	[self.controller setValue:unstagedFiles forKey:@"unstagedFilesController"];
+
+	self.pasteboard = [NSPasteboard pasteboardWithUniqueName];
+}
+
+- (void)tearDown
+{
+	[self.pasteboard releaseGlobally];
+	self.pasteboard = nil;
+	self.controller = nil;
+	self.repository = nil;
+	self.unstagedTable = nil;
+
+	[super tearDown];
+}
+
+// A drag writes one item per row, which is what the table does with the
+// writers it is handed.
+- (NSUInteger)dragRows:(NSIndexSet *)rowIndexes
+{
+	NSMutableArray *items = [NSMutableArray array];
+	[rowIndexes enumerateIndexesUsingBlock:^(NSUInteger row, BOOL *stop) {
+		id<NSPasteboardWriting> item = [self.controller tableView:self.unstagedTable pasteboardWriterForRow:row];
+		if (item)
+			[items addObject:item];
+	}];
+
+	[self.pasteboard clearContents];
+	[self.pasteboard writeObjects:items];
+
+	return items.count;
+}
+
+- (NSArray<NSString *> *)pathsOnThePasteboard
+{
+	NSDictionary *options = @{NSPasteboardURLReadingFileURLsOnlyKey : @YES};
+	NSArray<NSURL *> *fileURLs = [self.pasteboard readObjectsForClasses:@[ [NSURL class] ] options:options];
+
+	NSMutableArray<NSString *> *paths = [NSMutableArray arrayWithCapacity:fileURLs.count];
+	for (NSURL *fileURL in fileURLs)
+		[paths addObject:fileURL.path];
+
+	return paths;
+}
+
+- (void)testOffersEveryDraggedFileToTheReceivingApplication
+{
+	XCTAssertEqual([self dragRows:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, 2)]], 2u);
+
+	XCTAssertEqualObjects([self pathsOnThePasteboard],
+						  (@[ @"/gitx-drag-tests/first.txt", @"/gitx-drag-tests/second.txt" ]));
+}
+
+// A drag of several rows has to put each on its own item. Written as one item
+// carrying them all, the table never starts the drag at all.
+- (void)testWritesOneItemForEachDraggedRow
+{
+	[self dragRows:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, 2)]];
+
+	XCTAssertEqual(self.pasteboard.pasteboardItems.count, 2u);
+}
+
+- (void)testKeepsTheRowsReadableForADragBetweenTheTables
+{
+	[self dragRows:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, 2)]];
+
+	NSMutableArray<NSString *> *rows = [NSMutableArray array];
+	for (NSPasteboardItem *item in self.pasteboard.pasteboardItems) {
+		NSString *row = [item stringForType:PBFileChangesTableViewType];
+		if (row)
+			[rows addObject:row];
+	}
+
+	XCTAssertEqualObjects(rows, (@[ @"0", @"1" ]));
+}
+
+@end


### PR DESCRIPTION
Hand the dragged and dropped files over as file URLs, the shape that
replaced the file name property list on the pasteboard.

- Hand the table one pasteboard writer per row, which is where a drag
  of several files gets its several items
- Read the files dropped on the commit message as file URLs
- Name the internal row payload after the bundle, since an item drops
  a type that is not a uniform type identifier
- Carry that row on the same item, so a drag between the two tables
  reads the rows back off the items it was handed

The tables exchange rows through a private type, which the older
pasteboard API accepted under any name. Carried on an item it needs a
real identifier, and is dropped without one, silently and without
failing the drag.

This clears four of the seven pasteboard warnings. The three left are
`NSFilesPromisePboardType` in `PBQLOutlineView`, which need
`NSFilePromiseProvider` and a reworked write path, so they are better
off on their own.

Dragging a file out to the Finder moves it rather than copying it.
That is long-standing behaviour rather than anything new here, and
#592 addresses it separately.

Test plan:

- `PBGitCommitFileDragTests` covers the drag from both ends: every
  dragged file reaches the receiver, each dragged row gets its own
  pasteboard item, and the rows stay readable for a drag between the
  tables
- `xcodebuild test -only-testing:GitXTests` is green, 45/45
- Checked by hand, a drag session being beyond a unit test: dragging
  one file and several files between the staged and unstaged lists,
  in both directions; dragging several files out to another editor,
  which opens all of them; dropping files on the commit message from
  inside the repository, which writes relative paths, and from
  outside it, which writes absolute ones
