### PR TITLE
Give the Makefile a target for every build step CI runs

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -167,9 +167,9 @@ jobs:
           EXPORT_OPTIONS: ${{ secrets.NOTARY_EXPORT_OPTIONS }}
         run: |
           EXPORT_OPTIONS_PATH=$RUNNER_TEMP/ExportOptions.plist
-          echo -n "$EXPORT_OPTIONS" > EXPORT_OPTIONS_PATH
+          echo -n "$EXPORT_OPTIONS" > "$EXPORT_OPTIONS_PATH"
           echo "EXPORT_OPTIONS_PATH=$EXPORT_OPTIONS_PATH"
-          xcodebuild -exportArchive -archivePath GitX.xcarchive -exportPath . -exportOptionsPlist EXPORT_OPTIONS_PATH
+          xcodebuild -exportArchive -archivePath GitX.xcarchive -exportPath . -exportOptionsPlist "$EXPORT_OPTIONS_PATH"
           echo "Create GitX-${{ matrix.abi }}.dmg"
           mkdir dist && cp -R GitX.app dist/ && ln -s /Applications dist/
           hdiutil create -fs HFS+ -srcfolder dist/ -volname GitX GitX-${{ matrix.abi }}.dmg

--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -190,7 +190,8 @@ jobs:
 
           ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
 
-          xcrun notarytool submit "$ZIP_PATH" --key-id $KEY_ID --apple-id $APPLE_ID --team-id $TEAM_ID --password $APPLE_PASSWORD --wait | tee "$NOTARY_LOG" echo "print log output"
+          xcrun notarytool submit "$ZIP_PATH" --key-id $KEY_ID --apple-id $APPLE_ID --team-id $TEAM_ID --password $APPLE_PASSWORD --wait | tee "$NOTARY_LOG"
+          echo "print log output"
           cat "$NOTARY_LOG"
 
           ID=$(cat "$NOTARY_LOG" | tail -3 | cut -d':' -f2 | head -n 1)

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,19 @@
 # two stay in sync; the CI step each one matches is named below.
 # Changing a command here means changing it there too, and the other way round.
 #
-#   pre-build      "pre build"          (alias: bootstrap)
+#   deps           "pre build"
 #   unit-test      "Run unit tests"     (alias: test)
-#   ui-test        "Run tests"
+#   all-tests      "Run tests"
 #   archive        "Build project"      (alias: build-project)
-#   dmg-signed     "Prepare artifact"
+#   package-signed "Prepare artifact"
+#
+# `pre-build` is `deps` plus the submodule checkout that CI gets from its own
+# checkout step, so a fresh local clone wants pre-build and CI wants deps.
+#
+# `ui-test` runs the UI tests on their own. CI's "Run tests" runs the whole
+# scheme, repeating the unit tests it has already run in its own step, so
+# `all-tests` is the one that matches CI today and `ui-test` is the narrower
+# target to reach for otherwise.
 #
 # Signing: without a Dev.xcconfig the build is signed ad-hoc, and the hardened
 # runtime rejects that, leaving the app unable to load its own frameworks. So
@@ -42,10 +50,21 @@ EXPORT_OPTIONS ?= ExportOptions.plist
 # Extra build settings for the archive, as `xcodebuild` NAME=VALUE arguments.
 ARCHIVE_SETTINGS ?=
 
+# Where `dmg-signed` exports the signed app, and the zip it packs alongside the
+# disk image. CI overrides both, since it notarizes the app where it lands.
+EXPORT_DIR ?= $(BUILD_DIR)/export
+ZIP ?= $(BUILD_DIR)/GitX-$(ARCH).zip
+
+# Set to a path to have xcodebuild write an .xcresult bundle, which is where CI
+# reads the screenshots back out of a test run.
+RESULT_BUNDLE ?=
+RESULT_BUNDLE_ARG := $(if $(RESULT_BUNDLE),-resultBundlePath $(RESULT_BUNDLE))
+
 XCODEBUILD := xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) ARCHS="$(ARCH)"
 
-.PHONY: help git-submodule-sync pre-build bootstrap build unit-test test \
-	ui-test archive build-project app run dmg dmg-signed clean git-clean-dry-run
+.PHONY: help git-submodule-sync deps pre-build bootstrap build unit-test test \
+	ui-test all-tests archive build-project app run dmg package-signed \
+	dmg-signed clean git-clean-dry-run
 
 help: ## Show this help
 	@grep -hE '^[A-Za-z][A-Za-z.-]*:.*## ' $(MAKEFILE_LIST) \
@@ -60,10 +79,12 @@ git-submodule-sync: ## Check out the submodules at the revisions this tree wants
 	git submodule sync
 	git submodule update --init --recursive
 
-# CI gets the submodules from actions/checkout, so its "pre build" step is
-# only the second half of this; a fresh local clone needs both.
-pre-build: git-submodule-sync ## Fetch and build the objective-git and libgit2 dependencies
+deps: ## Build the objective-git and libgit2 dependencies
 	cd External/objective-git && script/bootstrap && script/update_libgit2
+
+# CI gets the submodules from actions/checkout and so calls `deps` on its own;
+# a fresh local clone needs both halves.
+pre-build: git-submodule-sync deps ## Check out the submodules, then build the dependencies
 
 bootstrap: pre-build
 
@@ -79,7 +100,14 @@ test: unit-test
 ui-test: ## Run the UI tests that drive the app and take the screenshots
 	$(XCODEBUILD) -destination "$(DESTINATION)" \
 		-only-testing:GitXUITests CODE_SIGN_IDENTITY="-" \
-		GITX_SCREENSHOT_REPO="$(GITX_SCREENSHOT_REPO)" test
+		GITX_SCREENSHOT_REPO="$(GITX_SCREENSHOT_REPO)" $(RESULT_BUNDLE_ARG) test
+
+# Runs the unit tests a second time, since the scheme tests every target. That
+# is what CI's "Run tests" step does today, and this target exists to match it.
+all-tests: ## Run every test target in the scheme, screenshots included
+	$(XCODEBUILD) -destination "$(DESTINATION)" \
+		CODE_SIGN_IDENTITY="-" \
+		GITX_SCREENSHOT_REPO="$(GITX_SCREENSHOT_REPO)" $(RESULT_BUNDLE_ARG) test
 
 archive: ## Build a release GitX.xcarchive, which the dmg targets export from
 	$(XCODEBUILD) -archivePath $(ARCHIVE) $(ARCHIVE_SETTINGS) archive
@@ -109,17 +137,26 @@ dmg: app ## Package build/GitX.app into an unsigned disk image that runs locally
 	hdiutil create -fs HFS+ -srcfolder $(BUILD_DIR)/dist -volname GitX $(DMG)
 	rm -rf $(BUILD_DIR)/dist
 
-dmg-signed: archive ## Package a signed disk image (needs ExportOptions.plist)
+# Clears the exported app rather than the directory holding it, since CI
+# exports into the checkout itself and that is not ours to delete.
+package-signed: ## Package an archive that already exists (needs ExportOptions.plist)
 	@test -f $(EXPORT_OPTIONS) \
 		|| { echo "No $(EXPORT_OPTIONS); see EXPORT_OPTIONS in the Makefile"; exit 1; }
-	rm -rf $(BUILD_DIR)/export $(BUILD_DIR)/dist $(DMG)
+	rm -rf $(EXPORT_DIR)/GitX.app $(BUILD_DIR)/dist $(DMG) $(ZIP)
+	mkdir -p $(EXPORT_DIR)
 	xcodebuild -exportArchive -archivePath $(ARCHIVE) \
-		-exportPath $(BUILD_DIR)/export -exportOptionsPlist $(EXPORT_OPTIONS)
-	mkdir $(BUILD_DIR)/dist
-	cp -R $(BUILD_DIR)/export/GitX.app $(BUILD_DIR)/dist/
+		-exportPath $(EXPORT_DIR) -exportOptionsPlist $(EXPORT_OPTIONS)
+	mkdir -p $(BUILD_DIR)/dist
+	cp -R $(EXPORT_DIR)/GitX.app $(BUILD_DIR)/dist/
 	ln -s /Applications $(BUILD_DIR)/dist/
 	hdiutil create -fs HFS+ -srcfolder $(BUILD_DIR)/dist -volname GitX $(DMG)
 	rm -rf $(BUILD_DIR)/dist
+	cd $(EXPORT_DIR) && zip -r $(abspath $(ZIP)) GitX.app
+
+# Packaging runs as its own make so that it cannot start before the archive
+# has finished. CI archives in a step of its own and calls package-signed.
+dmg-signed: archive ## Build and package a signed disk image and zip
+	$(MAKE) package-signed
 
 clean: ## Remove the build directory and Xcode's build products
 	rm -rf $(BUILD_DIR)


### PR DESCRIPTION
Cover the commands the workflow runs itself, so that each one has a
single definition the Makefile and CI can share rather than two copies
that drift apart.

- Split the dependency build out as `deps`, the half of `pre-build`
  that CI needs, having checked out the submodules already
- Add `all-tests` for the wider test step CI runs today, and let both
  test targets write the result bundle it reads screenshots from
- Add `package-signed`, exporting where CI wants the app and packing
  the zip it uploads, without archiving a second time to do it

Nothing calls these yet; this only makes the targets able to stand in.
Switching the workflow over is #591, so it can be weighed on its own.

### What changes in the target graph

Before:

```mermaid
flowchart TD
  pb["pre-build<br>builds deps inline"] --> gss["git-submodule-sync"]
  ds["dmg-signed<br>packages inline"] --> ar["archive"]
  bp["build-project"] --> ar
  app["app"] --> ar
  dmg["dmg"] --> app
  run["run"] --> build["build"]
  ut["unit-test"]
  uit["ui-test"]
```

After, with the three new targets shaded:

```mermaid
flowchart TD
  pb["pre-build"] --> gss["git-submodule-sync"]
  pb --> deps["deps"]
  ds["dmg-signed"] --> ar["archive"]
  ds -. "via make" .-> ps["package-signed"]
  bp["build-project"] --> ar
  app["app"] --> ar
  dmg["dmg"] --> app
  run["run"] --> build["build"]
  ut["unit-test"]
  uit["ui-test"]
  at["all-tests"]
  classDef new fill:#E1F5EE,stroke:#0F6E56,color:#04342C
  class deps,ps,at new
```

Two of the three are extractions rather than new work: `deps` and `package-signed` 
were already there as inline recipe lines inside `pre-build` and `dmg-signed`. 
Naming them lets a caller attach below those parents, which is what CI needs, 
having checked out the submodules through its own step and built the archive in another. 
A CI step calling `dmg-signed` would archive a second time per architecture.

`package-signed` hangs off `dmg-signed` by a dotted edge because it is not a prerequisite: 
the recipe calls it through `$(MAKE)`, so it cannot start before the archive has finished 
even under `make -j`.

`all-tests` is the odd one out, a sibling of `ui-test` rather than an extraction, and 
exists only because CI's test step runs the whole scheme.

The header claimed the targets already mirrored the workflow, which had stopped being true: 
`ui-test` runs only the UI tests while CI's step runs the whole scheme. 
It now names which target matches which step, and which one to prefer otherwise.

Two unrelated mistakes in the workflow are fixed along the way, each in its own commit. 
Both worked by accident, so neither changes what CI does:

- The signing options were written to a file named after the variable
  holding their path, and read back under that same literal name
- The notarization progress message was handed to `tee` as two more
  files to write, so it created files named after itself and printed nothing

Test plan:

- `make unit-test ARCH=arm64` is green, 42/42
- `make all-tests ARCH=arm64 RESULT_BUNDLE=<path>` is green and writes the bundle,
  running the unit suites and `GitXScreenshotTests`
- `make -n` for `deps`, `archive`, `package-signed` and `dmg-signed`
  reproduces the commands the matching CI steps run today, with CI's own paths,
  and `package-signed` runs xcodebuild once rather than archiving again
- The workflow still parses as YAML. The notarization and export
  changes need signing secrets, so they are read rather than run
