### PR TITLE
Run the CI build steps through the Makefile targets

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -73,7 +73,7 @@ jobs:
           brew install openssl@3
           openssl version
       - name: pre build
-        run: cd External/objective-git && script/bootstrap && script/update_libgit2 && cd ../..
+        run: make deps
       - name: Show openssl version
         run: |
           openssl version
@@ -85,14 +85,7 @@ jobs:
       # unlike the screenshot pipeline below they can run on every build
       - name: Run unit tests
         if: ${{ matrix.abi == 'arm64' }}
-        run: |
-          xcodebuild test \
-            -workspace GitX.xcworkspace \
-            -scheme GitX \
-            -only-testing:GitXTests \
-            -destination "platform=macOS,arch=${{ matrix.abi }}" \
-            ARCHS="${{ matrix.abi }}" \
-            CODE_SIGN_IDENTITY="-"
+        run: make unit-test ARCH=${{ matrix.abi }}
 
       # Test (only on arm64 to avoid tripling CI time)
       - name: Prepare screenshot comparison
@@ -103,17 +96,17 @@ jobs:
         run: |
           git clone --no-checkout "$GITHUB_WORKSPACE" /tmp/gitx-screenshot-repo
           git -C /tmp/gitx-screenshot-repo checkout 52ff1051d0c8e5cf3ee5
+      # TODO Consider running `make ui-test` here rather than `make
+      # all-tests`. The scheme tests every target, so this repeats the
+      # GitXTests run of the "Run unit tests" step above; `ui-test` narrows
+      # it to GitXUITests, which is all the screenshots need.
       - name: Run tests
         if: ${{ env.variableSet != '' && matrix.abi == 'arm64' && github.event_name == 'pull_request' }}
         run: |
-          xcodebuild test \
-            -workspace GitX.xcworkspace \
-            -scheme GitX \
-            -destination "platform=macOS,arch=${{ matrix.abi }}" \
-            ARCHS="${{ matrix.abi }}" \
-            CODE_SIGN_IDENTITY="-" \
+          make all-tests \
+            ARCH=${{ matrix.abi }} \
             GITX_SCREENSHOT_REPO=/tmp/gitx-screenshot-repo \
-            -resultBundlePath TestResults-${{ matrix.abi }}.xcresult
+            RESULT_BUNDLE=TestResults-${{ matrix.abi }}.xcresult
       - name: Extract screenshots from test results
         if: ${{ env.variableSet != '' && matrix.abi == 'arm64' && github.event_name == 'pull_request' }}
         run: |
@@ -160,7 +153,7 @@ jobs:
         # Updater.app, which then shares the app's bundle ID and breaks the
         # gitx CLI (Scripting Bridge resolves the wrong bundle). The GitX
         # target already sets its identifier in the project file.
-        run: xcodebuild -workspace GitX.xcworkspace -scheme GitX -archivePath ./GitX archive ARCHS="${{ matrix.abi }}"
+        run: make archive ARCH=${{ matrix.abi }} ARCHIVE=GitX.xcarchive
       - name: Prepare artifact
         if: ${{ env.variableSet != '' }}
         env:
@@ -169,12 +162,14 @@ jobs:
           EXPORT_OPTIONS_PATH=$RUNNER_TEMP/ExportOptions.plist
           echo -n "$EXPORT_OPTIONS" > "$EXPORT_OPTIONS_PATH"
           echo "EXPORT_OPTIONS_PATH=$EXPORT_OPTIONS_PATH"
-          xcodebuild -exportArchive -archivePath GitX.xcarchive -exportPath . -exportOptionsPlist "$EXPORT_OPTIONS_PATH"
           echo "Create GitX-${{ matrix.abi }}.dmg"
-          mkdir dist && cp -R GitX.app dist/ && ln -s /Applications dist/
-          hdiutil create -fs HFS+ -srcfolder dist/ -volname GitX GitX-${{ matrix.abi }}.dmg
-          rm -rf dist
-          zip -r GitX-${{ matrix.abi }}.zip GitX.app
+          make package-signed \
+            ARCH=${{ matrix.abi }} \
+            ARCHIVE=GitX.xcarchive \
+            EXPORT_DIR=. \
+            EXPORT_OPTIONS="$EXPORT_OPTIONS_PATH" \
+            DMG=GitX-${{ matrix.abi }}.dmg \
+            ZIP=GitX-${{ matrix.abi }}.zip
       - name: Notarize App
         if: ${{ env.variableSet != '' }}
         env:


### PR DESCRIPTION
Call the targets that already define these commands, so that the
workflow and a developer's machine run the same thing rather than two
copies of it that drift apart.

- Replace the dependency, test, archive and packaging commands with
  the targets that hold them
- Leave the certificate, notarization and upload steps alone, being
  the runner's business and not runnable locally

The targets these steps call came from #590, now merged, so this is a
single commit against master.

### Where CI attaches to the target graph

The same picture as #590, which explains the targets themselves. What
matters here is which nodes the workflow now enters at.

Before:

```mermaid
flowchart TD
  pb["pre-build<br>builds deps inline"] --> gss["git-submodule-sync"]
  ds["dmg-signed<br>packages inline"] --> ar["archive"]
  bp["build-project"] --> ar
  app["app"] --> ar
  dmg["dmg"] --> app
  run["run"] --> build["build"]
  ut["unit-test"]
  uit["ui-test"]
```

After, with the three targets #590 adds shaded:

```mermaid
flowchart TD
  pb["pre-build"] --> gss["git-submodule-sync"]
  pb --> deps["deps"]
  ds["dmg-signed"] --> ar["archive"]
  ds -. "via make" .-> ps["package-signed"]
  bp["build-project"] --> ar
  app["app"] --> ar
  dmg["dmg"] --> app
  run["run"] --> build["build"]
  ut["unit-test"]
  uit["ui-test"]
  at["all-tests"]
  classDef new fill:#E1F5EE,stroke:#0F6E56,color:#04342C
  class deps,ps,at new
```

This PR points five steps at `deps`, `unit-test`, `all-tests`,
`archive` and `package-signed`. None of them is an aggregate: CI enters
low in the graph every time, while a person keeps using the targets
above them, `pre-build`, `test` and `dmg-signed`. That is why `deps`
and `package-signed` had to be split out of their parents at all. CI
has checked the submodules out through its own step and builds the
archive in another, so a step calling `pre-build` would redo the
checkout and a step calling `dmg-signed` would archive a second time
per architecture.

### The duplicate test run is kept, deliberately

CI's "Run tests" step passes no `-only-testing`, and the scheme tests
every target, so it runs `GitXTests` a second time after the "Run unit
tests" step has already run them. This change keeps that exactly as it
is, calling `make all-tests`, which is the target written to match it.

`make ui-test` narrows the run to `GitXUITests`, which is all the
screenshots need, and would drop the repeat. That is a change to what
CI does rather than to how it says it, so it is left alone here and
marked with a TODO beside the step. Say the word and it is a one-word
edit.

Test plan:

- This PR's own CI run is green on both architectures, with `make
  deps`, `make unit-test ARCH=arm64` and `make archive` running on the
  runners
- `make all-tests ARCH=arm64 RESULT_BUNDLE=<path>` is green locally and
  writes the bundle, running the unit suites and `GitXScreenshotTests`
- `make -n` for every converted step reproduces the command that step
  runs today, with the same paths
- The screenshot and packaging steps need signing secrets, so they do
  not run on a fork PR and are verified by reading and by `make -n`
  only

