### PR TITLE
Fix dragging a file to the Finder taking it out of the repository

### DIFF
--- a/Classes/Views/PBFileChangesTableView.m
+++ b/Classes/Views/PBFileChangesTableView.m
@@ -25,8 +25,13 @@
 	return nil;
 }
 
+// Copying only once the drag leaves GitX: the files being dragged are the
+// working copy, and a move takes them out of the repository.
 - (NSDragOperation)draggingSession:(NSDraggingSession *)session sourceOperationMaskForDraggingContext:(NSDraggingContext)context
 {
+	if (context == NSDraggingContextOutsideApplication)
+		return NSDragOperationCopy;
+
 	return NSDragOperationEvery;
 }
 

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		5D3A8C1F7E2B49D0A83C6F41 /* GitXCommitCopierTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F6B9E0D4C8A47135BE2D90A /* GitXCommitCopierTests.m */; };
 		8A2D5F31C64B47E09D1A3B72 /* PBGitCommitFileDragTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E7C1B90D53A428FB60E9C15 /* PBGitCommitFileDragTests.m */; };
 		9C4E1A72F08B4D3EA5176BD3 /* PBGitPrefsAutocrlfTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F6B08D14C9A47128EBD5A60 /* PBGitPrefsAutocrlfTests.m */; };
+		6D1F4A83B27C4E5090A1C3F7 /* PBFileChangesTableViewDragTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B8E5C0947D14A6FB3E70D82 /* PBFileChangesTableViewDragTests.m */; };
 		643952771603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 643952761603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m */; };
 		6C25810B1C2720E60080A89A /* GitXCommitCopier.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C25810A1C2720E60080A89A /* GitXCommitCopier.m */; };
 		6C4855C81D57DCFC0027A7B4 /* PBTerminalUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C4855C71D57DCFC0027A7B4 /* PBTerminalUtil.m */; };
@@ -704,6 +705,7 @@
 		2F6B9E0D4C8A47135BE2D90A /* GitXCommitCopierTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = GitXCommitCopierTests.m; path = GitXTests/GitXCommitCopierTests.m; sourceTree = "<group>"; };
 		4E7C1B90D53A428FB60E9C15 /* PBGitCommitFileDragTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitCommitFileDragTests.m; path = GitXTests/PBGitCommitFileDragTests.m; sourceTree = "<group>"; };
 		3F6B08D14C9A47128EBD5A60 /* PBGitPrefsAutocrlfTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitPrefsAutocrlfTests.m; path = GitXTests/PBGitPrefsAutocrlfTests.m; sourceTree = "<group>"; };
+		2B8E5C0947D14A6FB3E70D82 /* PBFileChangesTableViewDragTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBFileChangesTableViewDragTests.m; path = GitXTests/PBFileChangesTableViewDragTests.m; sourceTree = "<group>"; };
 		6C2581091C2720E60080A89A /* GitXCommitCopier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitXCommitCopier.h; sourceTree = "<group>"; };
 		6C25810A1C2720E60080A89A /* GitXCommitCopier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXCommitCopier.m; sourceTree = "<group>"; };
 		6C4855C61D57DCFC0027A7B4 /* PBTerminalUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBTerminalUtil.h; sourceTree = "<group>"; };
@@ -831,6 +833,7 @@
 				2F6B9E0D4C8A47135BE2D90A /* GitXCommitCopierTests.m */,
 				4E7C1B90D53A428FB60E9C15 /* PBGitCommitFileDragTests.m */,
 				3F6B08D14C9A47128EBD5A60 /* PBGitPrefsAutocrlfTests.m */,
+				2B8E5C0947D14A6FB3E70D82 /* PBFileChangesTableViewDragTests.m */,
 			);
 			name = GitXTests;
 			sourceTree = "<group>";
@@ -1773,6 +1776,7 @@
 				5D3A8C1F7E2B49D0A83C6F41 /* GitXCommitCopierTests.m in Sources */,
 				8A2D5F31C64B47E09D1A3B72 /* PBGitCommitFileDragTests.m in Sources */,
 				9C4E1A72F08B4D3EA5176BD3 /* PBGitPrefsAutocrlfTests.m in Sources */,
+				6D1F4A83B27C4E5090A1C3F7 /* PBFileChangesTableViewDragTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GitXTests/PBFileChangesTableViewDragTests.m
+++ b/GitXTests/PBFileChangesTableViewDragTests.m
@@ -1,0 +1,48 @@
+//
+//  PBFileChangesTableViewDragTests.m
+//  GitXTests
+//
+
+#import <XCTest/XCTest.h>
+#import "PBFileChangesTableView.h"
+
+@interface PBFileChangesTableViewDragTests : XCTestCase
+@property (nonatomic, strong) PBFileChangesTableView *tableView;
+@end
+
+@implementation PBFileChangesTableViewDragTests
+
+- (void)setUp
+{
+	[super setUp];
+
+	self.tableView = [[PBFileChangesTableView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)];
+}
+
+- (void)tearDown
+{
+	self.tableView = nil;
+	[super tearDown];
+}
+
+// The table view answers this before a drag begins and never reads the
+// session, so the tests hand it one it can safely ignore.
+- (NSDragOperation)operationForContext:(NSDraggingContext)context
+{
+	NSDraggingSession *session = nil;
+	return [self.tableView draggingSession:session sourceOperationMaskForDraggingContext:context];
+}
+
+- (void)testOffersOnlyACopyOnceTheDragLeavesGitX
+{
+	XCTAssertEqual([self operationForContext:NSDraggingContextOutsideApplication], NSDragOperationCopy,
+				   @"dropping a changed file on another application must leave the working copy alone");
+}
+
+- (void)testStillOffersEveryOperationWithinGitX
+{
+	XCTAssertEqual([self operationForContext:NSDraggingContextWithinApplication], NSDragOperationEvery,
+				   @"staging and unstaging by drag rely on a move being offered inside GitX");
+}
+
+@end


### PR DESCRIPTION
Offer a copy, rather than any operation the destination likes, once
the drag has left GitX.

- Restrict the source operation mask outside the application to a copy

### This can lose files today

Dragging a changed file from the staged or unstaged list onto a Finder
window does not copy it. The Finder moves it, so the file leaves the
working copy and the list then reports it deleted.
Nothing warns, and nothing about the gesture suggests the file is being taken away, which
makes it easy to do by accident while meaning only to open or share a copy of it.

For a tracked file the damage is recoverable with `git checkout`. 
For an untracked one it is not: the file is gone from the repository with
nothing in git recording that it was ever there. 
Both lists show untracked files.

### Where it comes from

The mask has allowed every operation since e76d4831 (2008), the commit
that added the external drag in the first place, for a purpose that a
copy serves fully:

> This allows you to drag a changed file to for example XCode, so you
> can edit it.

The comment that commit left in the data source still reads 
`// External, to drag them to for example XCode or Textmate`. 
Opening a file elsewhere was the intent; relocating it was not. 
A later commit carried the mask over to the current API without revisiting the value.

`PBQLOutlineView` already restricts itself to a copy, commented
`/* Needed to drag outside application */`. 
This brings the two views into agreement.

Going to a file on disk is unaffected: 
Reveal in Finder is in the context menu of both lists and in the main menu.

Test plan:

- `xcodebuild test -only-testing:GitXTests` is green, 42/42, 
  and the build carries the same warnings as master
- To be checked by hand, a drag session being beyond a unit test:
  a file dragged from either list to a Finder window is copied and stays
  in the working copy; a file dragged into a text editor still opens;
  dragging between the two lists still stages and unstages
