### PR TITLE
Fix the gitx stdin check leaking the stream it opens

### DIFF
--- a/Classes/gitx.m
+++ b/Classes/gitx.m
@@ -366,7 +366,9 @@ int main(int argc, const char **argv)
 		}
 
 		// gitx can be used to pipe diff output to be displayed in GitX
-		if (!isatty(STDIN_FILENO) && fdopen(STDIN_FILENO, "r"))
+		int stdinFlags = fcntl(STDIN_FILENO, F_GETFL);
+		BOOL stdinIsReadable = (stdinFlags != -1) && ((stdinFlags & O_ACCMODE) != O_WRONLY);
+		if (!isatty(STDIN_FILENO) && stdinIsReadable)
 			handleSTDINDiff();
 
 


### PR DESCRIPTION
The command line tool decides whether to read a piped diff by opening a stream 
on **_`stdin`_** and throwing the result away, so every run that is not attached to a terminal 
leaks a `FILE` for the life of the process. 
This is the `unix.Stream` analyzer finding in `gitx.m`.

- Test that **_`stdin`_** is open and readable through its descriptor flags
  instead, which answers the same question without allocating anything
- Keep the guard in place, since `handleSTDINDiff` reads **_`stdin`_** through
  `NSFileHandle` and raises when the descriptor is closed

The stream cannot simply be closed: `fclose` would take **_`stdin`_** with it,
and `handleSTDINDiff` needs that same descriptor. The guard cannot be
dropped either, because `isatty` returns 0 for a closed **_`stdin`_**, so it is
the guard that keeps `readDataToEndOfFile` off a bad descriptor. 
The new check matches `fdopen(fd, "r")` exactly, which fails both on an invalid
descriptor and on a write-only one.

## Test plan

- `xcodebuild analyze` no longer reports the `unix.Stream` warning at `gitx.m:370`,
  with `gitx.m` confirmed re-analyzed in that run
- Run from a non-repository directory, `gitx` gets past the guard and
  prints its usual message under an empty pipe, a closed **_`stdin`_**,
  a `/dev/null` **_`stdin`_** and a write-only descriptor
- A pipe held open for three seconds still blocks in `handleSTDINDiff`
  for the full three, while a closed **_`stdin`_** returns at once, so the
  readable path is still entered rather than skipped