### PR TITLE
Clear the localizability warning in the autocrlf pop up

### DIFF
--- a/Classes/Controllers/PBGitPrefsWindowController.m
+++ b/Classes/Controllers/PBGitPrefsWindowController.m
@@ -145,6 +145,11 @@ static const NSUInteger kMaxProjectNameLength = 25;
 	}
 }
 
+// The pop up rows other than this one are titled with the values git itself
+// accepts, and are read back as the setting. This one stands for no value at
+// all, so it is found by its tag and its title stays free to be translated.
+static const NSInteger PBGitPrefsAutocrlfUnsetTag = -1;
+
 - (void)setControl:(NSControl *)control toValue:(NSString *)value type:(PBGitPrefsRowType)type
 {
 	switch (type) {
@@ -164,9 +169,11 @@ static const NSUInteger kMaxProjectNameLength = 25;
 		}
 		case PBGitPrefsRowTypeAutocrlf: {
 			NSPopUpButton *popUp = (NSPopUpButton *)control;
-			NSString *title = value.length ? value : @"(not set)";
-			if (![popUp itemWithTitle:title]) title = @"(not set)";
-			[popUp selectItemWithTitle:title];
+			NSMenuItem *item = value.length ? [popUp itemWithTitle:value] : nil;
+			if (item)
+				[popUp selectItem:item];
+			else
+				[popUp selectItemWithTag:PBGitPrefsAutocrlfUnsetTag];
 			break;
 		}
 	}
@@ -241,8 +248,8 @@ static const NSUInteger kMaxProjectNameLength = 25;
 		}
 		case PBGitPrefsRowTypeAutocrlf: {
 			NSPopUpButton *popUp = (NSPopUpButton *)control;
-			NSString *title = popUp.selectedItem.title;
-			return [title isEqualToString:@"(not set)"] ? nil : title;
+			if (popUp.selectedTag == PBGitPrefsAutocrlfUnsetTag) return nil;
+			return popUp.selectedItem.title;
 		}
 	}
 	return nil;

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		4C7F2A9E5D1B48A3E602F7C1 /* PBGitCommitFileSelectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B8E1D6C0A9F42B7D51C8E30 /* PBGitCommitFileSelectionTests.m */; };
 		5D3A8C1F7E2B49D0A83C6F41 /* GitXCommitCopierTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F6B9E0D4C8A47135BE2D90A /* GitXCommitCopierTests.m */; };
 		8A2D5F31C64B47E09D1A3B72 /* PBGitCommitFileDragTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E7C1B90D53A428FB60E9C15 /* PBGitCommitFileDragTests.m */; };
+		9C4E1A72F08B4D3EA5176BD3 /* PBGitPrefsAutocrlfTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F6B08D14C9A47128EBD5A60 /* PBGitPrefsAutocrlfTests.m */; };
 		643952771603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 643952761603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m */; };
 		6C25810B1C2720E60080A89A /* GitXCommitCopier.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C25810A1C2720E60080A89A /* GitXCommitCopier.m */; };
 		6C4855C81D57DCFC0027A7B4 /* PBTerminalUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C4855C71D57DCFC0027A7B4 /* PBTerminalUtil.m */; };
@@ -702,6 +703,7 @@
 		3B8E1D6C0A9F42B7D51C8E30 /* PBGitCommitFileSelectionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitCommitFileSelectionTests.m; path = GitXTests/PBGitCommitFileSelectionTests.m; sourceTree = "<group>"; };
 		2F6B9E0D4C8A47135BE2D90A /* GitXCommitCopierTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = GitXCommitCopierTests.m; path = GitXTests/GitXCommitCopierTests.m; sourceTree = "<group>"; };
 		4E7C1B90D53A428FB60E9C15 /* PBGitCommitFileDragTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitCommitFileDragTests.m; path = GitXTests/PBGitCommitFileDragTests.m; sourceTree = "<group>"; };
+		3F6B08D14C9A47128EBD5A60 /* PBGitPrefsAutocrlfTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitPrefsAutocrlfTests.m; path = GitXTests/PBGitPrefsAutocrlfTests.m; sourceTree = "<group>"; };
 		6C2581091C2720E60080A89A /* GitXCommitCopier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitXCommitCopier.h; sourceTree = "<group>"; };
 		6C25810A1C2720E60080A89A /* GitXCommitCopier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXCommitCopier.m; sourceTree = "<group>"; };
 		6C4855C61D57DCFC0027A7B4 /* PBTerminalUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBTerminalUtil.h; sourceTree = "<group>"; };
@@ -828,6 +830,7 @@
 				3B8E1D6C0A9F42B7D51C8E30 /* PBGitCommitFileSelectionTests.m */,
 				2F6B9E0D4C8A47135BE2D90A /* GitXCommitCopierTests.m */,
 				4E7C1B90D53A428FB60E9C15 /* PBGitCommitFileDragTests.m */,
+				3F6B08D14C9A47128EBD5A60 /* PBGitPrefsAutocrlfTests.m */,
 			);
 			name = GitXTests;
 			sourceTree = "<group>";
@@ -1769,6 +1772,7 @@
 				4C7F2A9E5D1B48A3E602F7C1 /* PBGitCommitFileSelectionTests.m in Sources */,
 				5D3A8C1F7E2B49D0A83C6F41 /* GitXCommitCopierTests.m in Sources */,
 				8A2D5F31C64B47E09D1A3B72 /* PBGitCommitFileDragTests.m in Sources */,
+				9C4E1A72F08B4D3EA5176BD3 /* PBGitPrefsAutocrlfTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GitXTests/PBGitPrefsAutocrlfTests.m
+++ b/GitXTests/PBGitPrefsAutocrlfTests.m
@@ -1,0 +1,62 @@
+//
+//  PBGitPrefsAutocrlfTests.m
+//  GitXTests
+//
+
+#import <XCTest/XCTest.h>
+#import "PBGitPrefsWindowController.h"
+
+// The controller finds the "no value" row of a core.autocrlf pop up by this
+// tag. The suite names it the same way the drag suite names the pasteboard
+// type it drives, so that the nib and the controller cannot drift apart
+// without a test saying so.
+static const NSInteger PBGitPrefsAutocrlfUnsetTag = -1;
+
+@interface PBGitPrefsAutocrlfTests : XCTestCase
+@property (nonatomic, strong) PBGitPrefsWindowController *controller;
+@end
+
+@implementation PBGitPrefsAutocrlfTests
+
+- (void)setUp
+{
+	[super setUp];
+
+	self.controller = [[PBGitPrefsWindowController alloc] initWithWindowNibName:@"PBGitPrefsWindowController"];
+	(void)[self.controller window]; // force the nib, and with it our outlets, to load
+}
+
+- (void)tearDown
+{
+	self.controller = nil;
+	[super tearDown];
+}
+
+- (void)assertPopUp:(NSPopUpButton *)popUp named:(NSString *)name
+{
+	XCTAssertNotNil(popUp, @"the %@ pop up should be wired to the nib", name);
+
+	NSMutableArray *taggedTitles = [NSMutableArray array];
+	NSMutableArray *untaggedTitles = [NSMutableArray array];
+	for (NSMenuItem *item in popUp.itemArray) {
+		if (item.tag == PBGitPrefsAutocrlfUnsetTag)
+			[taggedTitles addObject:item.title];
+		else
+			[untaggedTitles addObject:item.title];
+	}
+
+	XCTAssertEqual(taggedTitles.count, (NSUInteger)1, @"the %@ pop up should mark exactly one row as the unset row", name);
+	XCTAssertEqualObjects(untaggedTitles, (@[ @"false", @"true", @"input" ]), @"every other row of the %@ pop up should read as a value git accepts", name);
+}
+
+- (void)testTheRepositoryPopUpMarksTheRowThatStandsForNoValue
+{
+	[self assertPopUp:self.controller.localAutocrlfPopUp named:@"repository"];
+}
+
+- (void)testTheGlobalPopUpMarksTheRowThatStandsForNoValue
+{
+	[self assertPopUp:self.controller.globalAutocrlfPopUp named:@"global"];
+}
+
+@end

--- a/Resources/en.lproj/PBGitPrefsWindowController.xib
+++ b/Resources/en.lproj/PBGitPrefsWindowController.xib
@@ -120,7 +120,7 @@
             <font key="font" metaFont="system"/>
             <menu key="menu" title="OtherViews" id="27">
                 <items>
-                    <menuItem title="(not set)" state="on" id="28"/>
+                    <menuItem title="(not set)" state="on" tag="-1" id="28"/>
                     <menuItem title="false" id="29"/>
                     <menuItem title="true" id="30"/>
                     <menuItem title="input" id="31"/>
@@ -435,7 +435,7 @@ Gw
             <font key="font" metaFont="system"/>
             <menu key="menu" title="OtherViews" id="97">
                 <items>
-                    <menuItem title="(not set)" state="on" id="98"/>
+                    <menuItem title="(not set)" state="on" tag="-1" id="98"/>
                     <menuItem title="false" id="99"/>
                     <menuItem title="true" id="100"/>
                     <menuItem title="input" id="101"/>


### PR DESCRIPTION
The `core.autocrlf` pop ups carry one row that means "no value", and the
controller recognised it by comparing against its `(not set)` title.
That made a piece of user-facing text load bearing, which is what the
`NonLocalizedStringChecker` analyzer warning was pointing at.

- Mark that row in the nib with a tag and find it by that tag, so the
  words on it no longer decide what gets saved
- Read the setting from the selected title only once the tag has ruled
  out the unset row, which is safe because every other row is titled
  with a value git accepts
- Cover both pop ups with a test, so the nib and the controller cannot
  drift apart quietly

Wrapping the literal in `NSLocalizedString` would have cleared the
warning and left a trap behind. GitX ships only `en.lproj`, so the macro
returns its key unchanged and everything keeps working; the day a second
locale arrives, the controller's string and the nib's title diverge,
`itemWithTitle:` stops matching, and GitX writes the translated words
into `core.autocrlf`. Keying on a tag instead frees the label to be
translated whenever that day comes.

The one thing the change moves into the nib is the tag itself, which is
why the tests assert on the nib rather than trusting it.

## Test plan

- Two new tests fail before the nib change and pass after it, covering
  the repository and the global pop up
- `GitXTests` is green at 47 of 47
- `xcodebuild analyze` no longer reports the warning at
  `PBGitPrefsWindowController.m:169`, with the file confirmed
  re-analyzed in that run