### PR TITLE
Fix the gitx tool being unable to load the app frameworks

### DIFF
--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -2221,7 +2221,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = gitx_askpasswd.entitlements;
-				CODE_SIGN_IDENTITY = "-";
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = gitx_askpasswd;
 				SKIP_INSTALL = YES;
@@ -2232,7 +2231,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = gitx_askpasswd.entitlements;
-				CODE_SIGN_IDENTITY = "-";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_PREFIX_HEADER = $PROJECT_TEMP_DIR/revision;
 				INFOPLIST_PREPROCESS = YES;
@@ -2269,7 +2267,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "cli tool.entitlements";
-				CODE_SIGN_IDENTITY = "-";
 				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = Resources/GitX_Prefix.pch;
@@ -2285,7 +2282,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "cli tool.entitlements";
-				CODE_SIGN_IDENTITY = "-";
 				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;


### PR DESCRIPTION
Let the two helper tools take the code signing identity from the xcconfig
like every other target, so that a build made with a development
certificate signs them with the team the app is signed with.

Both targets pinned an ad-hoc identity in their own build settings, which
beats the project xcconfig, so the app and its frameworks were signed with
the developer team while the tools were not. The hardened runtime refuses
to map a team-signed library into a process carrying no team, so `gitx .`
died before it started:

```
dyld: Library not loaded: @rpath/ObjectiveGit.framework/ObjectiveGit
  Reason: ... code signature ... not valid for use in process: mapping
  process and mapped file (non-platform) have different Team IDs
```

- Drop CODE_SIGN_IDENTITY from the cli tool target, Debug and Release
- Drop it from gitx_askpasswd, which pins the same value
- Leave GitX.xcconfig to supply the ad-hoc identity when no development
  certificate is configured

## Test plan

- `xcodebuild -target "cli tool" -showBuildSettings` reports the identity
  from the xcconfig rather than `-`
- `make build` with a Dev.xcconfig in place signs `gitx` and
  `gitx_askpasswd` with the same team as the app
- Running the rebuilt `gitx --version` from outside the checkout prints
  the version instead of aborting in dyld