### PR TITLE
Fix the tests under a Dev.xcconfig, and add smoke-test and map

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ RESULT_BUNDLE_ARG := $(if $(RESULT_BUNDLE),-resultBundlePath $(RESULT_BUNDLE))
 
 XCODEBUILD := xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) ARCHS="$(ARCH)"
 
+# The tests sign ad-hoc, so they drop the hardened runtime too: a Dev.xcconfig
+# turns it on, and it refuses to map an ad-hoc signed framework into the host.
+TEST_SETTINGS := CODE_SIGN_IDENTITY="-" ENABLE_HARDENED_RUNTIME=NO
+
 .PHONY: help git-submodule-sync deps pre-build bootstrap build unit-test test \
 	ui-test all-tests archive build-project app run dmg package-signed \
 	dmg-signed clean git-clean-dry-run
@@ -93,20 +97,20 @@ build: ## Build the app for local use
 
 unit-test: ## Run the unit tests, needing no signing, repo or network
 	$(XCODEBUILD) -destination "$(DESTINATION)" \
-		-only-testing:GitXTests CODE_SIGN_IDENTITY="-" test
+		-only-testing:GitXTests $(TEST_SETTINGS) test
 
 test: unit-test
 
 ui-test: ## Run the UI tests that drive the app and take the screenshots
 	$(XCODEBUILD) -destination "$(DESTINATION)" \
-		-only-testing:GitXUITests CODE_SIGN_IDENTITY="-" \
+		-only-testing:GitXUITests $(TEST_SETTINGS) \
 		GITX_SCREENSHOT_REPO="$(GITX_SCREENSHOT_REPO)" $(RESULT_BUNDLE_ARG) test
 
 # Runs the unit tests a second time, since the scheme tests every target. That
 # is what CI's "Run tests" step does today, and this target exists to match it.
 all-tests: ## Run every test target in the scheme, screenshots included
 	$(XCODEBUILD) -destination "$(DESTINATION)" \
-		CODE_SIGN_IDENTITY="-" \
+		$(TEST_SETTINGS) \
 		GITX_SCREENSHOT_REPO="$(GITX_SCREENSHOT_REPO)" $(RESULT_BUNDLE_ARG) test
 
 archive: ## Build a release GitX.xcarchive, which the dmg targets export from

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,8 @@ XCODEBUILD := xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) ARCHS="$(ARCH
 TEST_SETTINGS := CODE_SIGN_IDENTITY="-" ENABLE_HARDENED_RUNTIME=NO
 
 .PHONY: help git-submodule-sync deps pre-build bootstrap build unit-test test \
-	ui-test all-tests archive build-project app run dmg package-signed \
+	ui-test all-tests archive build-project app smoke-test run dmg \
+	package-signed \
 	dmg-signed clean git-clean-dry-run
 
 help: ## Show this help
@@ -121,6 +122,21 @@ build-project: archive
 app: archive ## Copy the app out of the archive to build/GitX.app
 	rm -rf $(APP)
 	cp -R $(ARCHIVE)/Products/Applications/GitX.app $(APP)
+
+# Covers what no test does: the Release build turns the hardened runtime on,
+# and library validation then refuses to map a framework whose team differs
+# from the tool loading it. Reads the output rather than the exit status,
+# since gitx exits 1 after printing its version, while a bundle it cannot
+# load dies in dyld before main and prints nothing. Wants the real identity
+# `archive` builds with, so an ad-hoc archive proves nothing here.
+#
+# The guard keeps that from passing silently: asking for `dmg` in the same
+# invocation turns the hardened runtime off for the archive they share, and
+# without it library validation never runs and the check proves nothing.
+smoke-test: app ## Check the packaged gitx tool can load the app frameworks
+	@codesign -dv --verbose=2 "$(APP)" 2>&1 | grep -q "flags=.*runtime" \
+		|| { echo "$(APP) carries no hardened runtime; run smoke-test on its own"; exit 1; }
+	"$(APP)/Contents/Resources/gitx" --version | grep -q "GitX version"
 
 # Runs the Debug build, not the archive: Release turns on the hardened runtime,
 # and an ad-hoc signature plus the hardened runtime leaves the app unable to

--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,19 @@ XCODEBUILD := xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) ARCHS="$(ARCH
 TEST_SETTINGS := CODE_SIGN_IDENTITY="-" ENABLE_HARDENED_RUNTIME=NO
 
 .PHONY: help git-submodule-sync deps pre-build bootstrap build unit-test test \
-	ui-test all-tests archive build-project app smoke-test run dmg \
+	ui-test all-tests archive build-project app smoke-test run dmg map \
 	package-signed \
 	dmg-signed clean git-clean-dry-run
 
 help: ## Show this help
 	@grep -hE '^[A-Za-z][A-Za-z.-]*:.*## ' $(MAKEFILE_LIST) \
 		| awk -F':.*## ' '{printf "  %-20s %s\n", $$1, $$2}'
+
+# Reads the edges out of make's own rule database, so a target that gains a
+# prerequisite appears here without anyone maintaining a second copy of the
+# graph. The descriptions it prints alongside are the help text above.
+map: ## Show which targets pull in which, from make's own rule database
+	@scripts/make-target-map.sh
 
 # A real file, not a phony target, so that make leaves an existing config
 # alone rather than writing over settings you may have edited by hand.

--- a/scripts/make-target-map.sh
+++ b/scripts/make-target-map.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# Prints the make target graph. The edges come from make's own rule database,
+# so a target that gains a prerequisite shows it here without anyone saying so.
+# The trailing descriptions are the `##` help text, and are only labels.
+
+set -eu
+
+cd "$(dirname "$0")/.."
+
+{
+	make -pnr 2>/dev/null \
+		| sed -n 's/^\([a-zA-Z][A-Za-z0-9_.-]*\):\([^=]*\)$/EDGE \1\2/p' \
+		| grep -v '^EDGE Makefile' \
+		| sort -u
+	sed -n 's/^\([a-zA-Z][A-Za-z0-9_.-]*\):.*## \(.*\)$/DESC \1 \2/p' Makefile
+} | awk '
+	function label(t) { return t (t in desc ? "  (" desc[t] ")" : "") }
+
+	function walk(t, indent,    i, n, arr) {
+		n = split(deps[t], arr, " ")
+		for (i = 1; i <= n; i++) {
+			print indent "\\_ " label(arr[i])
+			walk(arr[i], indent "   ")
+		}
+	}
+
+	$1 == "EDGE" {
+		target = $2; $1 = ""; $2 = ""; sub(/^ +/, "")
+		if (!(target in deps)) order[++count] = target
+		deps[target] = $0
+		next
+	}
+
+	$1 == "DESC" { target = $2; $1 = ""; $2 = ""; sub(/^ +/, ""); desc[target] = $0; next }
+
+	END {
+		print "Targets that pull something in"
+		print ""
+		for (i = 1; i <= count; i++) {
+			t = order[i]
+			if (deps[t] == "") continue
+			print "  " label(t)
+			walk(t, "  ")
+			print ""
+		}
+		print "Targets that stand alone"
+		print ""
+		for (i = 1; i <= count; i++)
+			if (deps[order[i]] == "") print "  " label(order[i])
+	}
+'


### PR DESCRIPTION
Three Makefile changes: the test targets could not run with a Dev.xcconfig present,
nothing covered the signing configuration that ships, and
the target list gave no hint which target to run.

- Pair the hardened runtime with the ad-hoc identity the test targets pin
- Add `smoke-test`, running the packaged gitx tool from a release archive
- Add `map`, graphing the target dependencies from make's own rule database

Test plan:

- `unit-test` passes its 49 tests and `ui-test` its 4; `all-tests` runs both
- `smoke-test` passes on a signed archive, and fails when the tool alone is
  re-signed ad-hoc, which reproduces #595
- `map` renders the graph, `help` is otherwise unchanged

