### PR TITLE
Fix external git diff-files being called repeatedly for the same file (Issue #530)

### DIFF
--- a/Classes/git/PBGitIndex.m
+++ b/Classes/git/PBGitIndex.m
@@ -13,6 +13,8 @@
 #import "PBTask.h"
 #import "PBChangedFile.h"
 
+#import <sys/stat.h>
+
 NSString *PBGitIndexIndexRefreshStatus = @"PBGitIndexIndexRefreshStatus";
 NSString *PBGitIndexIndexRefreshFailed = @"PBGitIndexIndexRefreshFailed";
 NSString *PBGitIndexFinishedIndexRefresh = @"PBGitIndexFinishedIndexRefresh";
@@ -54,6 +56,8 @@ NS_ENUM(NSUInteger, PBGitIndexOperation){
 	NSDictionary *_stagedChanges;
 	NSDictionary *_unstagedChanges;
 	NSDictionary *_untrackedChanges;
+	NSString *_diffCacheKey;
+	NSString *_diffCacheOutput;
 }
 
 @property (retain) NSDictionary *amendEnvironment;
@@ -670,7 +674,53 @@ NS_ENUM(NSUInteger, PBGitIndexOperation){
 }
 
 
+- (NSString *)fingerprintOfFileAtURL:(nullable NSURL *)url
+{
+	struct stat info;
+	if (!url.isFileURL || stat(url.path.fileSystemRepresentation, &info) != 0)
+		return @"absent";
+
+	return [NSString stringWithFormat:@"%lld.%ld.%ld",
+									  (long long)info.st_size,
+									  (long)info.st_mtimespec.tv_sec,
+									  (long)info.st_mtimespec.tv_nsec];
+}
+
+- (nullable NSString *)diffCacheKeyForFile:(PBChangedFile *)file staged:(BOOL)staged contextLines:(NSUInteger)context
+{
+	NSURL *indexURL = self.repository.indexURL;
+	if (!indexURL)
+		return nil;
+
+	NSURL *fileURL = [self.repository.workingDirectoryURL URLByAppendingPathComponent:file.path];
+
+	return [NSString stringWithFormat:@"%@ %d %lu %d %@ %@ %@",
+									  file.path,
+									  staged,
+									  (unsigned long)context,
+									  (int)file.status,
+									  [self parentTree],
+									  [self fingerprintOfFileAtURL:fileURL],
+									  [self fingerprintOfFileAtURL:indexURL]];
+}
+
 - (NSString *)diffForFile:(PBChangedFile *)file staged:(BOOL)staged contextLines:(NSUInteger)context
+{
+	NSString *cacheKey = [self diffCacheKeyForFile:file staged:staged contextLines:context];
+	if (cacheKey && [cacheKey isEqualToString:_diffCacheKey])
+		return _diffCacheOutput;
+
+	NSString *output = [self readDiffForFile:file staged:staged contextLines:context];
+
+	if (cacheKey && output) {
+		_diffCacheKey = cacheKey;
+		_diffCacheOutput = output;
+	}
+
+	return output;
+}
+
+- (NSString *)readDiffForFile:(PBChangedFile *)file staged:(BOOL)staged contextLines:(NSUInteger)context
 {
 	NSString *parameter = [NSString stringWithFormat:@"-U%lu", context];
 	if (staged) {

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		7A1C4E2B90D3F5A6C1B80011 /* PBGitRepositoryFetchArgumentsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */; };
 		63E155858B2CC783EE10F1D8 /* PBGitIndexReconcileTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */; };
 		63E155858B2CC783EE10F1D9 /* PBGitIndexRefreshTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */; };
+		9A3F7C21E48B450D9C2A1F60 /* PBGitIndexDiffCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A3F7C21E48B450D9C2A1F61 /* PBGitIndexDiffCacheTests.m */; };
 		7C41A9E2B5D340E1A7F26C08 /* PBGitHistorySelectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E9D3B41C86F42A7B10D5E33 /* PBGitHistorySelectionTests.m */; };
 		1D8C4F70A93E42B6BE7C0D95 /* PBGitWindowWiringTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */; };
 		7A1C3E5D2B8F49A0C6D14E82 /* PBRepositoryFinderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E9B0D4A18C7452FB3A0D95E /* PBRepositoryFinderTests.m */; };
@@ -698,6 +699,7 @@
 		7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitRepositoryFetchArgumentsTests.m; path = GitXTests/PBGitRepositoryFetchArgumentsTests.m; sourceTree = "<group>"; };
 		689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitIndexReconcileTests.m; path = GitXTests/PBGitIndexReconcileTests.m; sourceTree = "<group>"; };
 		689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitIndexRefreshTests.m; path = GitXTests/PBGitIndexRefreshTests.m; sourceTree = "<group>"; };
+		9A3F7C21E48B450D9C2A1F61 /* PBGitIndexDiffCacheTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitIndexDiffCacheTests.m; path = GitXTests/PBGitIndexDiffCacheTests.m; sourceTree = "<group>"; };
 		5E9D3B41C86F42A7B10D5E33 /* PBGitHistorySelectionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitHistorySelectionTests.m; path = GitXTests/PBGitHistorySelectionTests.m; sourceTree = "<group>"; };
 		4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitWindowWiringTests.m; path = GitXTests/PBGitWindowWiringTests.m; sourceTree = "<group>"; };
 		6E9B0D4A18C7452FB3A0D95E /* PBRepositoryFinderTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBRepositoryFinderTests.m; path = GitXTests/PBRepositoryFinderTests.m; sourceTree = "<group>"; };
@@ -826,6 +828,7 @@
 				7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */,
 				689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */,
 				689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */,
+				9A3F7C21E48B450D9C2A1F61 /* PBGitIndexDiffCacheTests.m */,
 				5E9D3B41C86F42A7B10D5E33 /* PBGitHistorySelectionTests.m */,
 				4F2E8A13C7D9406B85A31E27 /* PBGitWindowWiringTests.m */,
 				6E9B0D4A18C7452FB3A0D95E /* PBRepositoryFinderTests.m */,
@@ -1769,6 +1772,7 @@
 				7A1C4E2B90D3F5A6C1B80011 /* PBGitRepositoryFetchArgumentsTests.m in Sources */,
 				63E155858B2CC783EE10F1D8 /* PBGitIndexReconcileTests.m in Sources */,
 				63E155858B2CC783EE10F1D9 /* PBGitIndexRefreshTests.m in Sources */,
+				9A3F7C21E48B450D9C2A1F60 /* PBGitIndexDiffCacheTests.m in Sources */,
 				7C41A9E2B5D340E1A7F26C08 /* PBGitHistorySelectionTests.m in Sources */,
 				1D8C4F70A93E42B6BE7C0D95 /* PBGitWindowWiringTests.m in Sources */,
 				7A1C3E5D2B8F49A0C6D14E82 /* PBRepositoryFinderTests.m in Sources */,

--- a/GitXTests/PBGitIndexDiffCacheTests.m
+++ b/GitXTests/PBGitIndexDiffCacheTests.m
@@ -1,0 +1,174 @@
+//
+//  PBGitIndexDiffCacheTests.m
+//  GitXTests
+//
+
+#import <XCTest/XCTest.h>
+#import "PBChangedFile.h"
+#import "PBGitIndex.h"
+#import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
+
+// Records the diff git is asked for instead of running it, and points the two
+// paths the cache stats at a temporary directory the test owns.
+@interface PBDiffStubRepository : PBGitRepository
+@property (nonatomic, strong) NSURL *workingURL;
+@property (nonatomic, strong) NSURL *indexFileURL;
+@property (nonatomic, strong) NSMutableArray<NSArray<NSString *> *> *askedFor;
+@end
+
+@implementation PBDiffStubRepository
+
+- (instancetype)init
+{
+	if (!(self = [super init]))
+		return nil;
+
+	_askedFor = [NSMutableArray array];
+
+	return self;
+}
+
+- (NSURL *)workingDirectoryURL
+{
+	return self.workingURL;
+}
+
+- (NSURL *)getIndexURL
+{
+	return self.indexFileURL;
+}
+
+// So that -parentTree names HEAD and HEAD^ rather than falling back to the
+// empty tree for both, which is what an amend has to be told apart by.
+- (BOOL)revisionExists:(NSString *)spec
+{
+	return YES;
+}
+
+- (NSString *)outputOfTaskWithArguments:(NSArray *)arguments error:(NSError **)error
+{
+	[self.askedFor addObject:arguments ?: @[]];
+
+	return [NSString stringWithFormat:@"diff %lu", (unsigned long)self.askedFor.count];
+}
+
+@end
+
+@interface PBGitIndexDiffCacheTests : XCTestCase
+@property (nonatomic, strong) PBDiffStubRepository *repository;
+@property (nonatomic, strong) PBGitIndex *gitIndex;
+@property (nonatomic, strong) NSURL *directory;
+@end
+
+@implementation PBGitIndexDiffCacheTests
+
+- (void)setUp
+{
+	[super setUp];
+
+	self.directory = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]]];
+	[[NSFileManager defaultManager] createDirectoryAtURL:self.directory
+							withIntermediateDirectories:YES
+											 attributes:nil
+												  error:NULL];
+
+	[self write:@"one\n" to:@"a.txt"];
+	[self write:@"index contents" to:@"index"];
+
+	// The index holds its repository weakly, so the test case owns them both
+	self.repository = [[PBDiffStubRepository alloc] init];
+	self.repository.workingURL = self.directory;
+	self.repository.indexFileURL = [self.directory URLByAppendingPathComponent:@"index"];
+	self.gitIndex = [[PBGitIndex alloc] initWithRepository:self.repository];
+}
+
+- (void)tearDown
+{
+	[[NSFileManager defaultManager] removeItemAtURL:self.directory error:NULL];
+
+	[super tearDown];
+}
+
+- (void)write:(NSString *)contents to:(NSString *)name
+{
+	NSURL *url = [self.directory URLByAppendingPathComponent:name];
+	[contents writeToURL:url atomically:NO encoding:NSUTF8StringEncoding error:NULL];
+}
+
+- (PBChangedFile *)modifiedFile
+{
+	PBChangedFile *file = [[PBChangedFile alloc] initWithPath:@"a.txt"];
+	file.status = MODIFIED;
+	file.hasUnstagedChanges = YES;
+
+	return file;
+}
+
+- (NSString *)unstagedDiff
+{
+	return [self.gitIndex diffForFile:[self modifiedFile] staged:NO contextLines:3];
+}
+
+#pragma mark A diff nothing could have changed is not asked for twice
+
+- (void)testTheSameDiffIsAskedForOnlyOnce
+{
+	NSString *first = [self unstagedDiff];
+	NSString *second = [self unstagedDiff];
+
+	XCTAssertEqual(self.repository.askedFor.count, 1u,
+				   @"nothing about the file or the index changed between the two");
+	XCTAssertEqualObjects(second, first);
+}
+
+- (void)testADifferentContextSizeIsAskedFor
+{
+	[self.gitIndex diffForFile:[self modifiedFile] staged:NO contextLines:3];
+	[self.gitIndex diffForFile:[self modifiedFile] staged:NO contextLines:6];
+
+	XCTAssertEqual(self.repository.askedFor.count, 2u);
+	XCTAssertEqualObjects(self.repository.askedFor.lastObject,
+						  (@[ @"diff-files", @"-U6", @"--", @"a.txt" ]));
+}
+
+- (void)testTheStagedDiffIsAskedForSeparately
+{
+	[self.gitIndex diffForFile:[self modifiedFile] staged:NO contextLines:3];
+	[self.gitIndex diffForFile:[self modifiedFile] staged:YES contextLines:3];
+
+	XCTAssertEqual(self.repository.askedFor.count, 2u);
+	XCTAssertEqualObjects(self.repository.askedFor.lastObject.firstObject, @"diff-index");
+}
+
+#pragma mark A diff that could have changed is asked for again
+
+- (void)testEditingTheWorkingFileIsAskedForAgain
+{
+	NSString *first = [self unstagedDiff];
+	[self write:@"one\ntwo\n" to:@"a.txt"];
+	NSString *second = [self unstagedDiff];
+
+	XCTAssertEqual(self.repository.askedFor.count, 2u);
+	XCTAssertNotEqualObjects(second, first);
+}
+
+- (void)testWritingTheIndexIsAskedForAgain
+{
+	[self unstagedDiff];
+	[self write:@"index contents, changed" to:@"index"];
+	[self unstagedDiff];
+
+	XCTAssertEqual(self.repository.askedFor.count, 2u);
+}
+
+- (void)testAmendingIsAskedForAgain
+{
+	[self.gitIndex diffForFile:[self modifiedFile] staged:YES contextLines:3];
+	self.gitIndex.amend = YES;
+	[self.gitIndex diffForFile:[self modifiedFile] staged:YES contextLines:3];
+
+	XCTAssertEqual(self.repository.askedFor.count, 2u);
+}
+
+@end


### PR DESCRIPTION
The commit view re-renders on every index update, and each render asks git for
the diff of the file on screen.
Staging one file does that three times over an untouched file, which is 
what #530 reports seeing in the log.

- Answer from the last diff while the path, context, parent tree, working file
  and index are all unchanged
- Stat the two files rather than trust the refresh output, which reports how a
  file is staged but not whether its content changed

Test plan:

- Staging one file, same repo and steps, with a logging git wrapper:
  `diff-files -U3 -- <path>` ran 3 times before and runs 1 time after
- An external edit to the selected file still re-reads its diff, checked in the
  running app
- 6 new tests in `PBGitIndexDiffCacheTests`, `make unit-test` is 55 green
