### PR TITLE
Fix Ignore doing nothing once a .gitignore is already there

### DIFF
--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -606,6 +606,18 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 
 - (BOOL)ignoreFilePaths:(NSArray *)filePaths error:(NSError **)error
 {
+	@try {
+		return [self appendFilePathsToGitIgnore:filePaths error:error];
+	}
+	@catch (NSException *exception) {
+		NSString *failure = [NSString stringWithFormat:NSLocalizedString(@"The .gitignore file could not be written: %@", @""), exception.reason];
+
+		return PBReturnErrorWithUserInfo(error, NSLocalizedString(@"Ignoring the selected files failed", @""), failure, nil);
+	}
+}
+
+- (BOOL)appendFilePathsToGitIgnore:(NSArray *)filePaths error:(NSError **)error
+{
 	NSString *filesAsString = [filePaths componentsJoinedByString:@"\n"];
 
 	// Write to the file

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -621,7 +621,7 @@ NSString *const PBHookNameErrorKey = @"PBHookNameErrorKey";
 		if (!currentFile) return NO;
 
 		// Add a newline if not yet present
-		if ([currentFile characterAtIndex:([ignoreFile length] - 1)] != '\n')
+		if (currentFile.length > 0 && ![currentFile hasSuffix:@"\n"])
 			[currentFile appendString:@"\n"];
 		[currentFile appendString:filesAsString];
 

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		551BF176112F3F4B00265053 /* gitx_askpasswd in Resources */ = {isa = PBXBuildFile; fileRef = 551BF111112F371800265053 /* gitx_askpasswd */; };
 		63E155858B2CC783EE10F1D7 /* PBGitRevListRaceConditionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0044 /* PBGitRevListRaceConditionTests.m */; };
 		7A1C4E2B90D3F5A6C1B80011 /* PBGitRepositoryFetchArgumentsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */; };
+		3D8A5F14C7E9420B96741C80 /* PBGitRepositoryIgnoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D8A5F14C7E9420B96741C81 /* PBGitRepositoryIgnoreTests.m */; };
 		63E155858B2CC783EE10F1D8 /* PBGitIndexReconcileTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */; };
 		63E155858B2CC783EE10F1D9 /* PBGitIndexRefreshTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */; };
 		7C41A9E2B5D340E1A7F26C08 /* PBGitHistorySelectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E9D3B41C86F42A7B10D5E33 /* PBGitHistorySelectionTests.m */; };
@@ -696,6 +697,7 @@
 		643952761603EF9B00BB7AFF /* PBSourceViewGitSubmoduleItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBSourceViewGitSubmoduleItem.m; sourceTree = "<group>"; };
 		689D57B4A78CEF3B32EB0044 /* PBGitRevListRaceConditionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitRevListRaceConditionTests.m; path = GitXTests/PBGitRevListRaceConditionTests.m; sourceTree = "<group>"; };
 		7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitRepositoryFetchArgumentsTests.m; path = GitXTests/PBGitRepositoryFetchArgumentsTests.m; sourceTree = "<group>"; };
+		3D8A5F14C7E9420B96741C81 /* PBGitRepositoryIgnoreTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitRepositoryIgnoreTests.m; path = GitXTests/PBGitRepositoryIgnoreTests.m; sourceTree = "<group>"; };
 		689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitIndexReconcileTests.m; path = GitXTests/PBGitIndexReconcileTests.m; sourceTree = "<group>"; };
 		689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitIndexRefreshTests.m; path = GitXTests/PBGitIndexRefreshTests.m; sourceTree = "<group>"; };
 		5E9D3B41C86F42A7B10D5E33 /* PBGitHistorySelectionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitHistorySelectionTests.m; path = GitXTests/PBGitHistorySelectionTests.m; sourceTree = "<group>"; };
@@ -824,6 +826,7 @@
 			children = (
 				689D57B4A78CEF3B32EB0044 /* PBGitRevListRaceConditionTests.m */,
 				7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */,
+				3D8A5F14C7E9420B96741C81 /* PBGitRepositoryIgnoreTests.m */,
 				689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */,
 				689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */,
 				5E9D3B41C86F42A7B10D5E33 /* PBGitHistorySelectionTests.m */,
@@ -1767,6 +1770,7 @@
 			files = (
 				63E155858B2CC783EE10F1D7 /* PBGitRevListRaceConditionTests.m in Sources */,
 				7A1C4E2B90D3F5A6C1B80011 /* PBGitRepositoryFetchArgumentsTests.m in Sources */,
+				3D8A5F14C7E9420B96741C80 /* PBGitRepositoryIgnoreTests.m in Sources */,
 				63E155858B2CC783EE10F1D8 /* PBGitIndexReconcileTests.m in Sources */,
 				63E155858B2CC783EE10F1D9 /* PBGitIndexRefreshTests.m in Sources */,
 				7C41A9E2B5D340E1A7F26C08 /* PBGitHistorySelectionTests.m in Sources */,

--- a/GitXTests/PBGitRepositoryIgnoreTests.m
+++ b/GitXTests/PBGitRepositoryIgnoreTests.m
@@ -21,6 +21,21 @@
 
 @end
 
+// Stands in for anything that can raise while the .gitignore is written.
+@interface PBThrowingIgnoreRepository : PBIgnoreStubRepository
+@end
+
+@implementation PBThrowingIgnoreRepository
+
+- (NSString *)gitIgnoreFilename
+{
+	[NSException raise:NSInternalInconsistencyException format:@"no working directory to write into"];
+
+	return nil;
+}
+
+@end
+
 @interface PBGitRepositoryIgnoreTests : XCTestCase
 @property (nonatomic, strong) PBIgnoreStubRepository *repository;
 @property (nonatomic, strong) NSURL *directory;
@@ -97,6 +112,15 @@
 	XCTAssertTrue([self ignore:@[ @"f1" ]]);
 
 	XCTAssertEqualObjects([self ignoreFileContents], @"f1");
+}
+
+- (void)testAFailureIsReportedRatherThanRaised
+{
+	PBThrowingIgnoreRepository *repository = [[PBThrowingIgnoreRepository alloc] init];
+	NSError *error = nil;
+
+	XCTAssertFalse([repository ignoreFilePaths:@[ @"f1" ] error:&error]);
+	XCTAssertNotNil(error, @"the caller has an error sheet to show, if it is handed an error");
 }
 
 - (void)testEverySelectedFileGetsItsOwnLine

--- a/GitXTests/PBGitRepositoryIgnoreTests.m
+++ b/GitXTests/PBGitRepositoryIgnoreTests.m
@@ -1,0 +1,111 @@
+//
+//  PBGitRepositoryIgnoreTests.m
+//  GitXTests
+//
+
+#import <XCTest/XCTest.h>
+#import "PBGitRepository.h"
+
+// Names a .gitignore the test owns, so that ignoring a file needs no working
+// directory and no libgit2 behind it.
+@interface PBIgnoreStubRepository : PBGitRepository
+@property (nonatomic, strong) NSString *ignoreFilename;
+@end
+
+@implementation PBIgnoreStubRepository
+
+- (NSString *)gitIgnoreFilename
+{
+	return self.ignoreFilename;
+}
+
+@end
+
+@interface PBGitRepositoryIgnoreTests : XCTestCase
+@property (nonatomic, strong) PBIgnoreStubRepository *repository;
+@property (nonatomic, strong) NSURL *directory;
+@end
+
+@implementation PBGitRepositoryIgnoreTests
+
+- (void)setUp
+{
+	[super setUp];
+
+	self.directory = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]]];
+	[[NSFileManager defaultManager] createDirectoryAtURL:self.directory
+							withIntermediateDirectories:YES
+											 attributes:nil
+												  error:NULL];
+
+	self.repository = [[PBIgnoreStubRepository alloc] init];
+	self.repository.ignoreFilename = [self.directory URLByAppendingPathComponent:@".gitignore"].path;
+}
+
+- (void)tearDown
+{
+	[[NSFileManager defaultManager] removeItemAtURL:self.directory error:NULL];
+
+	[super tearDown];
+}
+
+- (void)writeIgnoreFile:(NSString *)contents
+{
+	[contents writeToFile:self.repository.ignoreFilename atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+}
+
+- (NSString *)ignoreFileContents
+{
+	return [NSString stringWithContentsOfFile:self.repository.ignoreFilename encoding:NSUTF8StringEncoding error:NULL];
+}
+
+- (BOOL)ignore:(NSArray<NSString *> *)paths
+{
+	NSError *error = nil;
+
+	return [self.repository ignoreFilePaths:paths error:&error];
+}
+
+- (void)testTheFirstFileIgnoredWritesTheFile
+{
+	XCTAssertTrue([self ignore:@[ @"f1" ]]);
+
+	XCTAssertEqualObjects([self ignoreFileContents], @"f1");
+}
+
+- (void)testASecondFileIsAddedToTheFileTheFirstOneLeftBehind
+{
+	XCTAssertTrue([self ignore:@[ @"f1" ]]);
+
+	XCTAssertTrue([self ignore:@[ @"f2" ]], @"the second file has to be ignored just like the first");
+	XCTAssertEqualObjects([self ignoreFileContents], @"f1\nf2");
+}
+
+- (void)testAFileAlreadyEndingInANewlineDoesNotGetASecondOne
+{
+	[self writeIgnoreFile:@"build/\n"];
+
+	XCTAssertTrue([self ignore:@[ @"f1" ]]);
+
+	XCTAssertEqualObjects([self ignoreFileContents], @"build/\nf1");
+}
+
+- (void)testAnEmptyFileIsWrittenWithoutALeadingNewline
+{
+	[self writeIgnoreFile:@""];
+
+	XCTAssertTrue([self ignore:@[ @"f1" ]]);
+
+	XCTAssertEqualObjects([self ignoreFileContents], @"f1");
+}
+
+- (void)testEverySelectedFileGetsItsOwnLine
+{
+	[self writeIgnoreFile:@"build/"];
+
+	XCTAssertTrue([self ignore:(@[ @"f1", @"f2" ])]);
+
+	XCTAssertEqualObjects([self ignoreFileContents], @"build/\nf1\nf2");
+}
+
+@end


### PR DESCRIPTION
Fixes #597.

Ignoring a file worked the first time and never again.
Appending to the `.gitignore` that the first one left behind measured the length of the
string being built rather than the one read off disk:

```objc
NSString *ignoreFile;                                    // still nil here
...
if ([currentFile characterAtIndex:([ignoreFile length] - 1)] != '\n')
```

`[nil length]` is 0, and `0 - 1` on an `NSUInteger` wraps around, so the call raised `NSRangeException`.
That branch runs only when a `.gitignore` already exists, which is why 
the first file always worked and every one after it did nothing.
The exception reached AppKit, which logs it and carries on, so no error sheet was ever shown either.

The second commit catches anything raised there and hands the caller an error, which
it already knows how to show.

### Test plan

* New `PBGitRepositoryIgnoreTests`: 6 tests, of which 4 fail on master
  with the exception above and one covers the empty .gitignore that
  would have overflowed the same way
* `make unit-test`: 55 tests, 0 failures
* Ran the steps from the issue against a build: a fresh repository with
  f1 and f2, ignore f1, then ignore f2, and the .gitignore holds both
