### PR TITLE
Fix the first lines of a file hiding behind its tab bar

### DIFF
--- a/Classes/Controllers/PBWebController.h
+++ b/Classes/Controllers/PBWebController.h
@@ -26,4 +26,6 @@
 
 - (WebScriptObject *)script;
 - (void)closeView;
+
+- (NSRect)frameForWebView;
 @end

--- a/Classes/Controllers/PBWebController.m
+++ b/Classes/Controllers/PBWebController.m
@@ -244,7 +244,12 @@
 - (void)windowDidEndLiveResizeWithNotification:(NSNotification *)theNotification
 {
 	self.view.autoresizingMask = NSViewMinXMargin | NSViewMaxXMargin | NSViewMinYMargin | NSViewMaxYMargin | NSViewWidthSizable | NSViewHeightSizable;
-	self.view.frame = self.view.superview.bounds;
+	self.view.frame = [self frameForWebView];
+}
+
+- (NSRect)frameForWebView
+{
+	return self.view.superview.bounds;
 }
 
 @end

--- a/Classes/Views/GLFileView.m
+++ b/Classes/Views/GLFileView.m
@@ -73,6 +73,14 @@
 	[self performSelector:@selector(restoreSplitViewPositiion) withObject:nil afterDelay:0];
 }
 
+- (NSRect)frameForWebView
+{
+	NSRect frame = typeBar.superview.bounds;
+	frame.size.height = NSMinY(typeBar.frame);
+
+	return frame;
+}
+
 - (void)showFile
 {
 	NSArray *files = [historyController.treeController selectedObjects];

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		63E155858B2CC783EE10F1D7 /* PBGitRevListRaceConditionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0044 /* PBGitRevListRaceConditionTests.m */; };
 		7A1C4E2B90D3F5A6C1B80011 /* PBGitRepositoryFetchArgumentsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */; };
 		3D8A5F14C7E9420B96741C80 /* PBGitRepositoryIgnoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D8A5F14C7E9420B96741C81 /* PBGitRepositoryIgnoreTests.m */; };
+		6B2E70F3A19C4D5E8A730C90 /* GLFileViewLayoutTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B2E70F3A19C4D5E8A730C91 /* GLFileViewLayoutTests.m */; };
 		63E155858B2CC783EE10F1D8 /* PBGitIndexReconcileTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */; };
 		63E155858B2CC783EE10F1D9 /* PBGitIndexRefreshTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */; };
 		9A3F7C21E48B450D9C2A1F60 /* PBGitIndexDiffCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A3F7C21E48B450D9C2A1F61 /* PBGitIndexDiffCacheTests.m */; };
@@ -699,6 +700,7 @@
 		689D57B4A78CEF3B32EB0044 /* PBGitRevListRaceConditionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitRevListRaceConditionTests.m; path = GitXTests/PBGitRevListRaceConditionTests.m; sourceTree = "<group>"; };
 		7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitRepositoryFetchArgumentsTests.m; path = GitXTests/PBGitRepositoryFetchArgumentsTests.m; sourceTree = "<group>"; };
 		3D8A5F14C7E9420B96741C81 /* PBGitRepositoryIgnoreTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitRepositoryIgnoreTests.m; path = GitXTests/PBGitRepositoryIgnoreTests.m; sourceTree = "<group>"; };
+		6B2E70F3A19C4D5E8A730C91 /* GLFileViewLayoutTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = GLFileViewLayoutTests.m; path = GitXTests/GLFileViewLayoutTests.m; sourceTree = "<group>"; };
 		689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitIndexReconcileTests.m; path = GitXTests/PBGitIndexReconcileTests.m; sourceTree = "<group>"; };
 		689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitIndexRefreshTests.m; path = GitXTests/PBGitIndexRefreshTests.m; sourceTree = "<group>"; };
 		9A3F7C21E48B450D9C2A1F61 /* PBGitIndexDiffCacheTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PBGitIndexDiffCacheTests.m; path = GitXTests/PBGitIndexDiffCacheTests.m; sourceTree = "<group>"; };
@@ -829,6 +831,7 @@
 				689D57B4A78CEF3B32EB0044 /* PBGitRevListRaceConditionTests.m */,
 				7A1C4E2B90D3F5A6C1B80012 /* PBGitRepositoryFetchArgumentsTests.m */,
 				3D8A5F14C7E9420B96741C81 /* PBGitRepositoryIgnoreTests.m */,
+				6B2E70F3A19C4D5E8A730C91 /* GLFileViewLayoutTests.m */,
 				689D57B4A78CEF3B32EB0045 /* PBGitIndexReconcileTests.m */,
 				689D57B4A78CEF3B32EB0046 /* PBGitIndexRefreshTests.m */,
 				9A3F7C21E48B450D9C2A1F61 /* PBGitIndexDiffCacheTests.m */,
@@ -1774,6 +1777,7 @@
 				63E155858B2CC783EE10F1D7 /* PBGitRevListRaceConditionTests.m in Sources */,
 				7A1C4E2B90D3F5A6C1B80011 /* PBGitRepositoryFetchArgumentsTests.m in Sources */,
 				3D8A5F14C7E9420B96741C80 /* PBGitRepositoryIgnoreTests.m in Sources */,
+				6B2E70F3A19C4D5E8A730C90 /* GLFileViewLayoutTests.m in Sources */,
 				63E155858B2CC783EE10F1D8 /* PBGitIndexReconcileTests.m in Sources */,
 				63E155858B2CC783EE10F1D9 /* PBGitIndexRefreshTests.m in Sources */,
 				9A3F7C21E48B450D9C2A1F60 /* PBGitIndexDiffCacheTests.m in Sources */,

--- a/GitXTests/GLFileViewLayoutTests.m
+++ b/GitXTests/GLFileViewLayoutTests.m
@@ -1,0 +1,67 @@
+//
+//  GLFileViewLayoutTests.m
+//  GitXTests
+//
+
+#import <XCTest/XCTest.h>
+#import "GLFileView.h"
+
+// The type bar is an outlet, so a test has to hand it over itself. Only the
+// room it takes up matters here, which any view can stand in for.
+@interface PBLayoutStubFileView : GLFileView
+- (void)useTypeBar:(id)bar;
+@end
+
+@implementation PBLayoutStubFileView
+
+- (void)useTypeBar:(id)bar
+{
+	typeBar = bar;
+}
+
+@end
+
+@interface GLFileViewLayoutTests : XCTestCase
+@property (nonatomic, strong) NSView *container;
+@property (nonatomic, strong) NSView *typeBar;
+@property (nonatomic, strong) PBLayoutStubFileView *fileView;
+@end
+
+@implementation GLFileViewLayoutTests
+
+- (void)buildViewerOfHeight:(CGFloat)height barHeight:(CGFloat)barHeight
+{
+	self.container = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 400, height)];
+	self.typeBar = [[NSView alloc] initWithFrame:NSMakeRect(0, height - barHeight, 400, barHeight)];
+	[self.container addSubview:self.typeBar];
+
+	self.fileView = [[PBLayoutStubFileView alloc] init];
+	[self.fileView useTypeBar:self.typeBar];
+}
+
+- (void)testTheViewerStopsWhereTheTypeBarStarts
+{
+	[self buildViewerOfHeight:214 barHeight:25];
+
+	NSRect frame = [self.fileView frameForWebView];
+
+	XCTAssertEqual(NSMaxY(frame), 189.0, @"the file has to end below the bar, not behind it");
+	XCTAssertEqual(NSMinY(frame), 0.0);
+	XCTAssertEqual(NSWidth(frame), 400.0, @"the whole width is still the viewer's to use");
+}
+
+- (void)testTheViewerFollowsTheContainerItSitsIn
+{
+	[self buildViewerOfHeight:900 barHeight:25];
+
+	XCTAssertEqual(NSMaxY([self.fileView frameForWebView]), 875.0, @"a resized window leaves the bar where it is");
+}
+
+- (void)testATallerTypeBarTakesItsOwnRoom
+{
+	[self buildViewerOfHeight:214 barHeight:46];
+
+	XCTAssertEqual(NSMaxY([self.fileView frameForWebView]), 168.0);
+}
+
+@end


### PR DESCRIPTION
Fixes #598.

The Source, Blame and History bar shares its pane with the file viewer:
the bar sits in the top 25 points, the viewer fills the rest. Ending a
live window resize threw that away:

```objc
- (void)windowDidEndLiveResizeWithNotification:(NSNotification *)theNotification
{
    self.view.autoresizingMask = ...;
    self.view.frame = self.view.superview.bounds;   // the whole pane
}
```

The viewer then covered the bar's 25 points too, and since the bar is the
later sibling it is drawn on top, hiding the first line and a half of
every file from then on. That is why it looks like a per-repository
problem: it is per-window, and it starts the first time that window is
resized.

`PBWebController` now asks itself which frame its web view is to occupy,
which for every other web view in GitX is still the whole superview, and
`GLFileView` answers with the room below the bar.

### Test plan

* New `GLFileViewLayoutTests`: 3 tests, all failing on master, covering
  the viewer's frame at two pane heights and with a bar laid out taller
  than the nib reserved for it
* `make unit-test`: 52 tests, 0 failures
* Traced the real thing: with a file open in the tree view, the viewer
  sits at y=546, below the bar at 521..546. Dragging the window edge on
  master moves it to y=521, under the bar; with this change it stays at
  546 across repeated resizes
* Checked the commit view's diff, which shares the base class, still
  fills its own pane after a resize
