### PR TITLE
Remove empty lines in dialog

### DIFF
--- a/Classes/Views/PBGitXMessageSheet.m
+++ b/Classes/Views/PBGitXMessageSheet.m
@@ -79,20 +79,22 @@
 
 	NSError *taskError = error.userInfo[NSUnderlyingErrorKey];
 	if (taskError && taskError.domain == PBTaskErrorDomain) {
-		[messageParts addObject:NSLocalizedString(@"The underlying task failed:", @"PBGitXMessageSheet - task failed header")];
-		[messageParts addObject:taskError.localizedDescription];
-		[messageParts addObject:taskError.localizedFailureReason];
+		NSMutableArray *taskFailureLines = [NSMutableArray array];
+		[taskFailureLines addObject:NSLocalizedString(@"The underlying task failed:", @"PBGitXMessageSheet - task failed header")];
+		[taskFailureLines addObject:taskError.localizedDescription];
+		[taskFailureLines addObject:taskError.localizedFailureReason];
 		if (taskError.code == PBTaskNonZeroExitCodeError) {
 			NSString *message = NSLocalizedString(@"Return code: %@", @"PBGitXMessageSheet - task return code header");
 			message = [NSString stringWithFormat:message, taskError.userInfo[PBTaskTerminationStatusKey]];
-			[messageParts addObject:message];
-			message = NSLocalizedString(@"Output:", @"PBGitXMessageSheet - task output header");
+			[taskFailureLines addObject:message];
+		}
+		[messageParts addObject:[taskFailureLines componentsJoinedByString:@"\n"]];
+
+		if (taskError.code == PBTaskNonZeroExitCodeError) {
+			NSString *message = NSLocalizedString(@"Output:", @"PBGitXMessageSheet - task output header");
 			message = [message stringByAppendingString:@"\n"];
 			message = [message stringByAppendingString:taskError.userInfo[PBTaskTerminationOutputKey]];
 			[messageParts addObject:message];
-		} else {
-			[messageParts addObject:taskError.localizedDescription];
-			[messageParts addObject:taskError.localizedFailureReason];
 		}
 	}
 


### PR DESCRIPTION
This makes the text in dialog immediate complete readable, without scrolling.

Consolidated "The underlying task failed:", the task description, failure reason, and return code into one compact block (single newlines) instead of separate blank-line-separated paragraphs, while keeping one blank line before/after the block for readability.

Before:
<img width="542" height="314" alt="image" src="https://github.com/user-attachments/assets/a0751b72-df4b-40c4-8f1e-f36f1a25ffad" />

after:
<img width="540" height="309" alt="image" src="https://github.com/user-attachments/assets/bee39889-9779-41a9-9bb0-58a05358a8e5" />
