### PR TITLE
Fix a branch checkout leaving its tip off screen

### DIFF
--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -242,6 +242,16 @@
 		return;
 
 	[commitController setSelectedObjects:commits];
+	[self scrollToSelection];
+}
+
+- (void)scrollToSelection
+{
+	NSUInteger row = commitController.selectionIndexes.firstIndex;
+	if (row == NSNotFound)
+		return;
+
+	[commitList scrollRowToVisible:row];
 }
 
 // Picking a branch in the sidebar is a request to look at that branch, so the

--- a/GitXTests/PBGitHistorySelectionTests.m
+++ b/GitXTests/PBGitHistorySelectionTests.m
@@ -16,6 +16,7 @@
 @property (nonatomic, strong) GTOID *lastSelectedOID;
 - (GTOID *)OIDToReselect;
 - (void)restoreSelectionAfterUpdate;
+- (void)scrollToSelection;
 @end
 
 // The restore only reads OIDs off the commits, so it needs nothing of the real
@@ -35,8 +36,10 @@
 @end
 
 // The history list reaches for its table view once it actually moves the
-// selection, which a test has no nib for, so stop at the decision.
+// selection, which a test has no nib for, so stop at the decision and count
+// the scrolls it asks for.
 @interface PBStubHistoryController : PBGitHistoryController
+@property (nonatomic, assign) NSUInteger scrollCount;
 @end
 
 @implementation PBStubHistoryController
@@ -44,13 +47,18 @@
 {
 	return NO;
 }
+
+- (void)scrollToSelection
+{
+	self.scrollCount++;
+}
 @end
 
 static NSString *const kBranchTipSHA = @"8031ee6a0000000000000000000000000000beef";
 
 @interface PBGitHistorySelectionTests : XCTestCase
 @property (nonatomic, strong) PBGitRepository *repository;
-@property (nonatomic, strong) PBGitHistoryController *historyController;
+@property (nonatomic, strong) PBStubHistoryController *historyController;
 @end
 
 @implementation PBGitHistorySelectionTests
@@ -140,6 +148,36 @@ static NSString *const kBranchTipSHA = @"8031ee6a0000000000000000000000000000bee
 	[self.historyController restoreSelectionAfterUpdate];
 
 	XCTAssertEqualObjects([commits.selectedObjects.firstObject OID], [GTOID oidWithSHA:pickedSHA]);
+}
+
+- (void)testARestoredSelectionIsBroughtBackIntoView
+{
+	NSString *pickedSHA = @"c12df1e80000000000000000000000000000cafe";
+	NSArrayController *commits = [[NSArrayController alloc] init];
+	commits.avoidsEmptySelection = NO;
+	commits.content = @[ [PBStubCommit commitWithSHA:kBranchTipSHA], [PBStubCommit commitWithSHA:pickedSHA] ];
+	[commits setSelectedObjects:@[]];
+	[self.historyController setValue:commits forKey:@"commitController"];
+
+	self.historyController.lastSelectedOID = [GTOID oidWithSHA:pickedSHA];
+
+	[self.historyController restoreSelectionAfterUpdate];
+
+	XCTAssertEqual(self.historyController.scrollCount, 1u, @"a selection nobody can see is not a selection");
+}
+
+- (void)testASelectionThatWasNeverDroppedIsLeftWhereItIs
+{
+	NSArrayController *commits = [[NSArrayController alloc] init];
+	commits.content = @[ [PBStubCommit commitWithSHA:kBranchTipSHA] ];
+	[commits setSelectedObjects:commits.content];
+	[self.historyController setValue:commits forKey:@"commitController"];
+
+	self.historyController.lastSelectedOID = [GTOID oidWithSHA:kBranchTipSHA];
+
+	[self.historyController restoreSelectionAfterUpdate];
+
+	XCTAssertEqual(self.historyController.scrollCount, 0u, @"an update on its own is no reason to move the list under the user");
 }
 
 // A branch change outranks it: there the list is meant to move.


### PR DESCRIPTION
Fixes #606.

Changing branch does move the history list to the new branch's tip, but
the rebuild that follows the checkout puts the scroll back at the top and
drops the selection along with it. Restoring that selection put it back
where it stood without bringing it into view, so on any repository whose
branch tips are more than a screen apart the list looked untouched.

Traced on a 60-commit repository, switching to a branch whose tip is row
56 of the list:

```
scroll oldIndex=55 newIndex=55   visible={{0, -28}, ...}  ->  {{0, 791}, ...}   moved to the tip
restore  currentlySelected=1     visible={{0, 791}, ...}
restore  currentlySelected=0     visible={{0, -28}, ...}   rebuild: selection and scroll both lost
restore  PUTTING BACK selection  visible={{0, -28}, ...}   selection back, scroll left at the top
```

This comes from #579, not from #582: before it, the
rebuild's dropped selection was re-made by `-selectCommit:`, which
scrolled as it went. `-gitDirForURL:` is only read when a document is
opened, and the string it builds is the same one as before - the old code
ran `stringWithUTF8String:` over the buffer, which stops at the same NUL
that `size` counts up to.

### Test plan

* `PBGitHistorySelectionTests` gains 2 tests, of which
  `testARestoredSelectionIsBroughtBackIntoView` fails on master
* `make unit-test`: 51 tests, 0 failures
* On that 60-commit repository, double-clicking the far branch used to
  leave row 1 at the top of the view; it now scrolls so the selected row
  56 sits inside the viewport
